### PR TITLE
docs: 스펙 모순 11건 해소 — requirements.md/prototype.html 업데이트

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -3,6 +3,21 @@
 ## NEXT ACTION
 디자인 고도화 (다음 세션)
 
+## 완료된 작업 (2026-04-22 — 스펙 모순 해소 + 요구사항 문서 업데이트, PR #9 머지)
+- PR #9 머지: 프로토타입 격차 7건 보강 + 스펙 모순 리뷰 문서 신규 (docs/explanation/prototype-requirements-review.md)
+- 스펙 결정 사항 11건 requirements.md 반영:
+  - C1: 첨부파일 10MB 통일 (prototype 공지/FAQ 샘플 수정)
+  - C2: 역할 enum 3종 유지 (user/manager/admin) — prototype dev/viewer 제거
+  - C3: Sub-task 폼 제목+유형(선택, 미선택 시 부모 기본값) — §9.2 보완
+  - C4: 공지 팝업 정렬 "긴급→중요→일반" 으로 명확화 — §10.3.2
+  - C5: 공지 Soft Delete + Admin 복원 가능 명시 — §10.3.4
+  - C6: 필터 스코프 User는 본인 VOC 내로 자동 제한 — §8.11 추가
+  - C7: Sub-task 상태 유지 (부모 완료 강제 시 자식 상태 불변) — §8.2
+  - C8: 시스템명 최대 20자, 한글/영문/숫자/공백/특수문자 허용 — §8.10
+  - C9: issue_code 슬러그 ASCII 영문 대문자 (ANALYSIS-2025-0001) — §8.1/§4/§8.7
+  - C10: page size §9.8 동적 계산으로 일원화 (§8.11 "기본 25개" 제거)
+  - C11: Admin/Manager 오탐 태그 수동 정정 가능, 이력 기록 — §8.8
+
 ## 완료된 작업 (2026-04-21 추가 — UI 인터랙션 개선, PR #4 머지)
 - 헤더 컬럼 클릭 정렬: sort 드롭다운 제거 → hcell 클릭 토글 (기본: 등록일 내림차순)
 - VOC 상세 큰 화면 전환 버튼 추가 (maximize/minimize 토글, fullscreen CSS)

--- a/prototype.html
+++ b/prototype.html
@@ -831,8 +831,7 @@ mark { background: oklch(75% 0.16 72 / .35); color: inherit; border-radius: 2px;
 .role-pill { font-size: 11.5px; padding: 2px 9px; border-radius: 4px; font-weight: 600; }
 .role-admin   { background: oklch(20% 0.06 262); color: var(--accent); border: 1px solid var(--brand-border); }
 .role-manager { background: oklch(20% 0.07 72); color: oklch(75% 0.14 72); border: 1px solid oklch(30% 0.09 72); }
-.role-dev     { background: oklch(18% 0.07 150); color: var(--status-emerald); border: 1px solid oklch(28% 0.10 150); }
-.role-viewer  { background: var(--bg-elevated); color: var(--text-tertiary); border: 1px solid var(--border-subtle); }
+.role-user    { background: var(--bg-elevated); color: var(--text-tertiary); border: 1px solid var(--border-subtle); }
 .user-avatar-sm {
   width: 28px; height: 28px; border-radius: 50%;
   background: var(--brand-bg); border: 1px solid var(--brand-border);
@@ -1206,8 +1205,7 @@ mark { background: oklch(75% 0.16 72 / .35); color: inherit; border-radius: 2px;
           <select id="newUserRole">
             <option value="admin">Admin</option>
             <option value="manager" selected>Manager</option>
-            <option value="dev">Developer</option>
-            <option value="viewer">Viewer</option>
+            <option value="user">User</option>
           </select>
         </div>
         <div style="display:flex;gap:6px;align-self:flex-end">
@@ -1514,7 +1512,7 @@ const SUBDATA = {
 // ── 공지사항 데이터
 const NOTICES = [
   { id: 1, title: '시스템 정기 점검 안내 (04/25 02:00~06:00)', content: '<p>안녕하세요. 시스템 안정성 강화를 위한 <strong>정기 점검</strong>을 아래와 같이 진행합니다.</p><ul><li>일시: 2026-04-25 02:00 ~ 06:00</li><li>영향: 전체 서비스 일시 중단</li></ul><p>불편을 드려 죄송합니다.</p>', level: 'urgent', popup: true, from: '2026-04-20', to: '2026-04-25', visible: true },
-  { id: 2, title: '첨부파일 용량 제한 변경 안내 (10MB → 20MB)', content: '<p>사용자 요청에 따라 첨부파일 최대 용량을 <strong>20MB</strong>로 확대합니다. (기존 10MB)</p><p>적용일: 2026-04-22부터</p>', level: 'important', popup: true, from: '2026-04-21', to: '2026-05-10', visible: true },
+  { id: 2, title: '첨부파일 용량 제한 안내', content: '<p>첨부파일 최대 용량은 파일당 <strong>10MB</strong>, VOC당 최대 5개입니다.</p><p>허용 형식: PNG, JPG, GIF, WebP</p>', level: 'important', popup: true, from: '2026-04-21', to: '2026-05-10', visible: true },
   { id: 3, title: 'VOC 시스템 사용 가이드 배포', content: '<p>신규 입사자를 위한 VOC 시스템 사용 가이드를 배포합니다. 우측 상단 <strong>도움말</strong> 메뉴에서 확인하세요.</p>', level: 'normal', popup: false, from: '2026-04-01', to: '2026-06-30', visible: true },
 ];
 
@@ -1522,7 +1520,7 @@ const NOTICES = [
 const FAQS = [
   { id: 1, category: '사용법', q: 'VOC는 어떻게 등록하나요?', a: '<p>상단 <strong>+ VOC 등록</strong> 버튼을 클릭하면 등록 모달이 열립니다. 시스템 → 메뉴 → 유형을 선택한 후 제목과 내용을 입력하고 저장하세요.</p>', visible: true },
   { id: 2, category: '사용법', q: '담당자를 지정하려면 어떻게 하나요?', a: '<p>VOC 상세 드로어에서 <strong>담당자</strong> 필드를 클릭하면 사용자 목록이 나타납니다. Manager 이상 권한이 있어야 지정 가능합니다.</p>', visible: true },
-  { id: 3, category: '오류', q: '파일 첨부가 안 됩니다.', a: '<p>지원 형식: PNG, JPG, GIF, WebP (최대 20MB / 개, 5개 / VOC). 다른 형식의 파일은 업로드가 제한됩니다. 문제가 지속되면 관리자에게 문의하세요.</p>', visible: true },
+  { id: 3, category: '오류', q: '파일 첨부가 안 됩니다.', a: '<p>지원 형식: PNG, JPG, GIF, WebP (최대 10MB / 개, 5개 / VOC). 다른 형식의 파일은 업로드가 제한됩니다. 문제가 지속되면 관리자에게 문의하세요.</p>', visible: true },
   { id: 4, category: '정책', q: 'VOC 상태는 누가 변경할 수 있나요?', a: '<p>상태 변경(진행 중 / 완료 등)은 <strong>Manager 이상</strong> 권한을 가진 사용자만 가능합니다. 일반 사용자는 본인이 등록한 VOC를 조회만 할 수 있습니다.</p>', visible: true },
   { id: 5, category: '정책', q: 'VOC를 삭제할 수 있나요?', a: '<p>삭제는 <strong>Admin</strong>만 가능합니다. 삭제된 VOC는 복구되지 않으며, Soft Delete 방식으로 처리됩니다.</p>', visible: true },
   { id: 6, category: '기타', q: '내 계정 역할(권한)은 어디서 확인하나요?', a: '<p>사이드바 좌측 하단 프로필 영역에서 현재 역할을 확인할 수 있습니다. 역할 변경이 필요하면 Admin에게 문의하세요.</p>', visible: true },
@@ -2511,9 +2509,9 @@ let ADMIN_CATS = [
 let ADMIN_USERS = [
   {id:1, name:'홍길동', init:'홍', email:'hong@vocpage.io', role:'admin',   active:true,  lastSeen:'방금 전'},
   {id:2, name:'김관리', init:'김', email:'kim@vocpage.io',  role:'manager', active:true,  lastSeen:'1시간 전'},
-  {id:3, name:'박개발', init:'박', email:'park@vocpage.io', role:'dev',     active:true,  lastSeen:'어제'},
-  {id:4, name:'이분석', init:'이', email:'lee@vocpage.io',  role:'viewer',  active:true,  lastSeen:'3일 전'},
-  {id:5, name:'최영업', init:'최', email:'choi@vocpage.io', role:'viewer',  active:false, lastSeen:'14일 전'},
+  {id:3, name:'박개발', init:'박', email:'park@vocpage.io', role:'user',    active:true,  lastSeen:'어제'},
+  {id:4, name:'이분석', init:'이', email:'lee@vocpage.io',  role:'user',    active:true,  lastSeen:'3일 전'},
+  {id:5, name:'최영업', init:'최', email:'choi@vocpage.io', role:'user',    active:false, lastSeen:'14일 전'},
 ];
 let ruleNextId=12, catNextId=6, userNextId=6;
 
@@ -2909,8 +2907,8 @@ function toggleArchiveType(slug) {
   if (t) { t.archived = !t.archived; renderVocTypes(); }
 }
 
-const ROLE_MAP = {admin:'Admin', manager:'Manager', dev:'Developer', viewer:'Viewer'};
-const ROLE_CLS = {admin:'role-admin', manager:'role-manager', dev:'role-dev', viewer:'role-viewer'};
+const ROLE_MAP = {admin:'Admin', manager:'Manager', user:'User'};
+const ROLE_CLS = {admin:'role-admin', manager:'role-manager', user:'role-user'};
 function renderUsers() {
   const tbody = document.getElementById('usersBody');
   tbody.innerHTML = ADMIN_USERS.map(u => `

--- a/requirements.md
+++ b/requirements.md
@@ -47,10 +47,10 @@
 ## 4. 데이터베이스 설계 (Data Schema)
 
 - **`users`**: 사내 유저 정보. 컬럼: `id(uuid)`, `ad_username`, `display_name`, `email`, `role(enum: user/manager/admin)`, `is_active`, `created_at`.
-- **`systems`**: 시스템 목록. 컬럼: `id`, `name`, `slug(URL-safe)`, `is_archived`. Admin이 관리 (추가/수정/아카이브).
+- **`systems`**: 시스템 목록. 컬럼: `id`, `name`, `slug(ASCII URL-safe)`, `is_archived`. Admin이 관리 (추가/수정/아카이브).
 - **`menus`**: 메뉴 목록. 컬럼: `id`, `system_id(FK→systems)`, `name`, `slug`, `is_archived`. Admin이 관리. 시스템 생성 시 "기타" 메뉴 자동 생성.
 - **`voc_types`**: VOC 유형 목록. 컬럼: `id`, `name`, `slug`, `color(hex, e.g. #e5534b)`, `sort_order`, `is_archived`. Admin이 관리. 초기값: 버그/기능 요청/개선 제안/문의.
-- **`vocs`**: VOC 메인 데이터. 컬럼: `id(uuid)`, `issue_code(unique, e.g. 인증-2025-0001)`, `sequence_no(시스템·연도 단위 유니크)`, `title`, `body(HTML)`, `status(enum: 접수됨/검토중/처리중/완료/보류)`, `priority(enum: urgent/high/medium/low, default medium)`, `type_id(FK→voc_types, NOT NULL)`, `system_id(FK→systems, NOT NULL)`, `menu_id(FK→menus, NOT NULL)`, `assignee_id`, `author_id`, `parent_id(self-join, 최대 1단계)`, `deleted_at`, `created_at`, `updated_at`.
+- **`vocs`**: VOC 메인 데이터. 컬럼: `id(uuid)`, `issue_code(unique, e.g. ANALYSIS-2025-0001)`, `sequence_no(시스템·연도 단위 유니크)`, `title`, `body(HTML)`, `status(enum: 접수됨/검토중/처리중/완료/보류)`, `priority(enum: urgent/high/medium/low, default medium)`, `type_id(FK→voc_types, NOT NULL)`, `system_id(FK→systems, NOT NULL)`, `menu_id(FK→menus, NOT NULL)`, `assignee_id`, `author_id`, `parent_id(self-join, 최대 1단계)`, `deleted_at`, `created_at`, `updated_at`.
 - **`voc_history`**: 감사 로그. 상태·담당자·Priority 변경 이력 보존.
 - **`tags` & `voc_tags`**: 태그 정보 및 VOC와의 다대다 매핑.
 - **`tag_rules`**: 자동 태깅을 위한 키워드/규칙 저장소.
@@ -94,7 +94,8 @@
 ## 8. 상세 기능 명세
 
 ### 8.1 VOC 식별자 (Issue Code)
-- 형식: `{시스템슬러그}-{yyyy}-{순번4자리}` (예: `인증-2025-0001`)
+- 형식: `{시스템슬러그}-{yyyy}-{순번4자리}` (예: `ANALYSIS-2025-0001`)
+- 시스템 슬러그는 ASCII URL-safe 문자열로 저장 (예: `analysis`, `pipeline`). `issue_code`에는 슬러그 값을 대문자로 사용.
 - 시스템별·연도별 독립 순번. 삭제된 VOC의 순번은 재사용하지 않음 (증가 전용).
 - 시스템명 변경 후에도 기존 VOC의 `issue_code`는 불변.
 - 동시 생성 경합은 DB sequence로 원자성 보장.
@@ -112,7 +113,7 @@
 
 - 상태 변경 시 `voc_history`에 이력 기록 (변경 전·후 상태, 변경자, 타임스탬프).
 - 상태 변경 시 VOC 작성자 및 담당자에게 인앱 알림 발송.
-- 미완료 Sub-task가 있는 부모 VOC를 '완료'로 전환 시 경고 메시지 후 강제 진행 가능.
+- 미완료 Sub-task가 있는 부모 VOC를 '완료'로 전환 시 경고 메시지 후 강제 진행 가능. Sub-task 상태는 변경되지 않으며 담당자가 개별 처리.
 
 ### 8.3 권한 모델
 
@@ -158,7 +159,7 @@
 ### 8.7 Sub-task
 
 - 최대 2단계: `vocs` → Sub-task. Sub-task의 Sub-task 생성 불가 (DB 제약으로 강제).
-- Sub-task ID: `{parent-issue-code}-{N}` (예: `인증-2025-0001-1`)
+- Sub-task ID: `{parent-issue-code}-{N}` (예: `ANALYSIS-2025-0001-1`)
 - Sub-task는 독립적인 상태·담당자·Priority·유형 보유.
 - Sub-task의 시스템/메뉴는 부모 VOC에서 상속 (변경 불가).
 - 부모 VOC Soft Delete 시 Sub-task도 cascade soft delete.
@@ -191,8 +192,9 @@
 - Sub-task의 유형은 부모와 독립적으로 선택 가능.
 
 #### 태그 (Tag)
-- 자동 태깅 전용 — 작성자가 수동으로 태그 추가/삭제 불가.
+- 자동 태깅 전용 — 작성자(User)가 수동으로 태그 추가/삭제 불가.
 - 키워드/정규식 규칙 기반으로 VOC 생성 시 자동 부여.
+- Admin/Manager는 오탐 정정을 위해 개별 VOC의 태그를 수동으로 추가/삭제 가능 (이력은 `voc_history`에 기록).
 - 유형과 역할 구분: 유형은 성격 분류(1개), 태그는 토픽 클러스터링(N개).
 
 ### 8.9 삭제 정책
@@ -207,13 +209,14 @@
 - VOC 본문: 최대 64KB (HTML)
 - 댓글: 최대 16KB (HTML), Toast UI Editor 사용
 - 댓글 이미지: 파일당 5MB 이하
-- 시스템명/메뉴명: 한글 2~16자, URL-safe slug 병행 저장
+- 시스템명/메뉴명: 최소 2자·최대 20자 (공백 포함, 한글/영문/숫자/주요특수문자 허용). URL-safe slug(ASCII) 병행 저장.
 
 ### 8.11 VOC 목록 필터/검색/페이지네이션
 
 - **필터 항목:** 상태(다중 선택), 시스템(단일), 메뉴(단일, 시스템 선택 시 활성화), 유형(다중 선택), 담당자(단일)
 - **텍스트 검색:** 제목 + 본문 대상 SQL `ILIKE '%keyword%'`. MVP에서는 FTS 미사용.
-- **페이지네이션:** 오프셋 기반, 기본 25개/페이지. `GET /api/vocs?page=1&limit=25&status=접수됨&systemId=...&menuId=...&type=bug&assigneeId=...&q=keyword`
+- **필터·검색 스코프:** 해당 사용자가 조회 가능한 VOC 범위로 자동 제한 (User는 본인 VOC 내에서만 동작).
+- **페이지네이션:** 오프셋 기반. 페이지당 항목 수는 §9.8 동적 계산 공식 적용. `GET /api/vocs?page=1&limit={N}&status=접수됨&systemId=...&menuId=...&type=bug&assigneeId=...&q=keyword`
 - **정렬:** 기본 `created_at DESC`. `?sort=priority|updated_at` 지원.
 
 ### 8.12 파일 저장소
@@ -251,7 +254,7 @@
 
 ### 9.2 서브태스크 생성 진입점
 - Sub-task 추가 UI는 **드로어 하단 인라인 폼 한 곳만** 유지. 헤더 아이콘 버튼(중복 진입점) 제거.
-- 드로어 하단 폼: 제목 입력 → 저장/취소 버튼.
+- 드로어 하단 폼: 제목 입력 + (선택) 유형 선택 → 저장/취소 버튼. 유형 미선택 시 부모 VOC 유형과 동일하게 기본 적용.
 - 저장 시 `{parent-code}-{N}` 형식 코드 자동 부여, 목록에 즉시 반영.
 - 부모 VOC가 이미 Sub-task인 경우 하단 폼 비활성화 (최대 2단계 제한, 안내 문구 표시).
 
@@ -386,7 +389,7 @@
 - Admin/Manager가 `팝업 여부 = ON`으로 설정한 공지는 로그인 시 팝업 표시
 - 팝업 하단에 **"오늘 하루 보지 않기"** 체크박스 제공
   - 체크 시 당일 재접속에서 해당 공지 팝업 미표시 (localStorage 기반)
-- 복수의 팝업 공지가 있을 경우 중요도 내림차순으로 순서 표시
+- 복수의 팝업 공지가 있을 경우 중요도 상위(긴급 → 중요 → 일반) 순으로 표시
 
 #### 10.3.3 공지사항 목록 (사용자 뷰)
 - 노출 기간 내이고 노출 여부 = ON인 공지만 표시
@@ -395,7 +398,7 @@
 
 #### 10.3.4 Admin/Manager 관리 기능
 - 공지 목록에서 **노출 여부 토글** (즉시 반영)
-- **삭제**: 완전 삭제 가능 (Soft Delete — DB에는 남기고 목록에서 제거)
+- **삭제**: Soft Delete (목록에서 제거, DB에는 유지). Admin은 관리 목록에서 복원 가능.
 - 노출 기간 종료 시 자동 비노출 (삭제 아님, 관리 목록에는 계속 표시)
 
 ### 10.4 FAQ 요구사항


### PR DESCRIPTION
## Summary
- 스펙 모순 11건(C1~C11) requirements.md 반영
- prototype.html 공지/FAQ 샘플 수정 (첨부파일 10MB 통일, 역할 enum 정리)
- 주요 결정: 첨부파일 10MB 통일, 역할 3종 유지, Sub-task 폼 스펙, 공지 정렬/소프트삭제, 필터 스코프, issue_code 슬러그, page size 일원화, 오탐 태그 수동 정정

## Test plan
- [ ] requirements.md C1~C11 항목 내용 확인
- [ ] prototype.html 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)