### PR TITLE
fix: enforce git workflow with hookify rules

### DIFF
--- a/.claude/hookify.block-force-push.local.md
+++ b/.claude/hookify.block-force-push.local.md
@@ -1,0 +1,15 @@
+---
+name: block-force-push
+enabled: true
+event: bash
+pattern: git\s+push\s+.*(--force|-f)(\s|$)
+action: block
+---
+
+🚫 **Force push is forbidden.**
+
+Per CLAUDE.md git workflow rules:
+
+- Force push to main is strictly prohibited
+- If you need to update a PR branch: `gh pr merge <n> --merge --delete-branch`, then create a new branch
+- Never rewrite published history

--- a/.claude/hookify.block-push-to-main.local.md
+++ b/.claude/hookify.block-push-to-main.local.md
@@ -1,0 +1,15 @@
+---
+name: block-push-to-main
+enabled: true
+event: bash
+pattern: git\s+push\s+.*origin\s+main|git\s+push\s+--set-upstream\s+origin\s+main
+action: block
+---
+
+🚫 **Direct push to main is forbidden.**
+
+Per CLAUDE.md git workflow rules:
+
+- Never push directly to main
+- Always create a feature branch: `feat/<topic>`, `fix/<topic>`, `docs/<topic>`
+- Push to feature branch, open a PR, merge via `gh pr merge <n> --merge --delete-branch`

--- a/.claude/hookify.block-squash-rebase-merge.local.md
+++ b/.claude/hookify.block-squash-rebase-merge.local.md
@@ -1,0 +1,16 @@
+---
+name: block-squash-rebase-merge
+enabled: true
+event: bash
+pattern: gh\s+pr\s+merge\s+.*--(squash|rebase)
+action: block
+---
+
+🚫 **Squash and rebase merges are forbidden.**
+
+Per CLAUDE.md git workflow rules:
+
+- `--squash`: destroys individual commit history
+- `--rebase`: replays commits directly onto main, erasing PR boundaries
+
+Always merge with: `gh pr merge <n> --merge --delete-branch`

--- a/.claude/hookify.warn-delete-local-branch.local.md
+++ b/.claude/hookify.warn-delete-local-branch.local.md
@@ -1,0 +1,17 @@
+---
+name: warn-delete-local-branch
+enabled: true
+event: bash
+pattern: gh\s+pr\s+merge\s+
+action: warn
+---
+
+⚠️ **PR merged — delete the local branch too.**
+
+Remote branch is deleted by `--delete-branch`. Now clean up locally:
+
+```bash
+git branch -D <branch-name>
+```
+
+Per CLAUDE.md git workflow: always delete local branches after merging.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,10 @@ Full spec: `docs/specs/requires/design.md`. Full token reference: §10 CSS Refer
     - `--squash`: destroys commit history
     - `--rebase`: replays commits directly onto main, erasing PR boundaries
     - `--merge`: preserves both the merge commit (PR boundary) and individual commits ✓
+  - After merging, delete the local branch: `git branch -D <branch>`
   - Review fixes follow the same rule: new `fix/<topic>` branch → PR → `--merge`
   - main changes only via PR — direct push and force push are forbidden
+  - These rules are enforced by hookify rules in `.claude/hookify.block-*.local.md`
 - Run tests before committing; follow existing code style (read 2-3 nearby files first)
 - No features beyond what the task requires (YAGNI)
 - CLAUDE.md stays under 200 lines


### PR DESCRIPTION
## Summary

- Add 4 hookify rules to enforce git workflow at runtime
  - Block direct push to protected branch
  - Block squash and rebase PR merges
  - Block force push
  - Warn to delete local branch after PR merge
- Update CLAUDE.md: add local branch deletion step and hookify enforcement note

## Test plan
- [ ] Verify direct push to protected branch is blocked
- [ ] Verify squash/rebase PR merges are blocked
- [ ] Verify force push is blocked
- [ ] Verify PR merge triggers local branch deletion warning

Generated with Claude Code