### PR TITLE
docs: Phase 6-6 auth mock strategy design spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ Full spec: `docs/specs/requires/design.md`. Full token reference: §10 CSS Refer
 - **Parallel tool calls** — independent tool calls go in one message, not sequential
 - **No re-read** — never re-read a file already in session context (exception: modified files)
 - **Tail test output** — pipe test output through `| tail -20`; never print full traces
-- **Git workflow** — always create a feature branch first, commit and push there, then open a PR. Never commit or push directly to main. Branch naming: `docs/<topic>`, `feat/<topic>`, `fix/<topic>`.
+- **Git workflow** — always create a feature branch first, commit and push there. Never commit or push directly to main. Branch naming: `docs/<topic>`, `feat/<topic>`, `fix/<topic>`.
+  - PRs are opened by the user, not by Claude
   - Merge PRs with `gh pr merge <n> --merge --delete-branch` — `--squash` and `--rebase` are forbidden
     - `--squash`: destroys commit history
     - `--rebase`: replays commits directly onto main, erasing PR boundaries
     - `--merge`: preserves both the merge commit (PR boundary) and individual commits ✓
   - After merging, delete the local branch: `git branch -D <branch>`
-  - Review fixes follow the same rule: new `fix/<topic>` branch → PR → `--merge`
   - main changes only via PR — direct push and force push are forbidden
   - These rules are enforced by hookify rules in `.claude/hookify.block-*.local.md`
 - Run tests before committing; follow existing code style (read 2-3 nearby files first)

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -250,11 +250,16 @@ docs/specs/reviews/
 - [ ] BE 완성 전 FE 개발용 Mock API 전략 결정 (MSW vs json-server)
 - [ ] 주요 API 엔드포인트 응답 형태 사전 정의 (requirements.md §API 기반)
 
-### 6-6. 인증 Mock 전략 ⚠️ 블로킹 위험
+### 6-6. 인증 Mock 전략 ✅ 설계 완료 (2026-04-24)
 
-- [ ] `validateADSession` 미들웨어 환경별 bypass 방식 결정 (`NODE_ENV=development` 시 mock user 주입)
-- [ ] 개발용 mock 사용자 픽스처 정의 (role: admin / user 각 1개)
-- [ ] 실 AD 없이 전체 플로우 개발 가능한 상태 확인
+> 설계 문서: `docs/specs/plans/phase6-6-auth-mock-design.md` (PR #21)
+> 다음 세션: `writing-plans` 스킬로 구현 계획 작성 후 구현 진입
+
+- [x] `validateADSession` 미들웨어 — 팩토리 패턴 (`auth/index.ts` → `mockAuth.ts` / `oidcAuth.ts` 선택)
+- [x] 개발용 mock 사용자 픽스처 — Admin/Manager/User 3개, 고정 UUID (`...0001~0003`), 6-7 시드 공유
+- [x] FE `/mock-login` React 라우트 — `VITE_AUTH_MODE=mock`일 때만 활성화, dynamic import로 prod 번들 격리
+- [ ] **구현 계획 작성** (`writing-plans` 스킬) — 다음 세션 시작점
+- [ ] 실 AD 없이 전체 플로우 개발 가능한 상태 확인 (구현 후)
 
 ### 6-7. DB 마이그레이션 & 시드 전략
 

--- a/docs/specs/plans/phase6-6-auth-mock-design.md
+++ b/docs/specs/plans/phase6-6-auth-mock-design.md
@@ -1,0 +1,146 @@
+# Phase 6-6: Auth Mock Strategy Design
+
+> Created: 2026-04-24
+> Status: Approved — ready for implementation planning
+
+## Summary
+
+`AUTH_MODE=mock|oidc` environment variable controls the authentication strategy.
+MVP implements only `mock` mode. `oidc` is a stub that throws at boot time.
+
+---
+
+## §1 File Structure & Middleware
+
+```
+backend/src/
+  auth/
+    index.ts        ← reads AUTH_MODE, exports correct middleware
+    mockAuth.ts     ← mock session injection (MVP — fully implemented)
+    oidcAuth.ts     ← OIDC JWT validation (MVP — throw stub)
+    mockUsers.ts    ← fixture array (shared with seed script)
+    types.ts        ← AuthUser type
+```
+
+### AuthUser type (`types.ts`)
+
+```ts
+interface AuthUser {
+  id: string; // uuid — matches users.id in DB
+  email: string;
+  name: string;
+  role: 'admin' | 'manager' | 'user';
+}
+```
+
+### `index.ts` behavior
+
+- `AUTH_MODE=mock` → export `mockAuth.ts` middleware
+- `AUTH_MODE=oidc` → export `oidcAuth.ts` middleware
+- Any other value → throw `Error` at startup (fail fast on misconfiguration)
+
+### `mockAuth.ts` behavior
+
+- `req.session.user` exists → attach to `req.user`, call `next()`
+- No session → return `401` (FE global interceptor redirects to `/mock-login`)
+
+### `oidcAuth.ts` MVP
+
+```ts
+export const oidcAuthMiddleware = (): never => {
+  throw new Error('OIDC auth not implemented');
+};
+```
+
+---
+
+## §2 Mock Login Endpoints
+
+### `POST /api/auth/mock-login`
+
+- Body: `{ "role": "admin" | "manager" | "user" }`
+- Returns `404` if `AUTH_MODE !== 'mock'` (never exposed in prod)
+- Saves matching fixture user to `req.session.user`
+- Response: `200 { user: AuthUser }`
+
+### `POST /api/auth/logout`
+
+- `req.session.destroy()` → clears session cookie
+- Shared by mock and oidc modes
+
+### `GET /api/auth/me`
+
+- Passes through `validateADSession`
+- Returns `req.user`
+- Used by FE to restore current user on page refresh
+
+### Session config
+
+| Setting    | Value                                   |
+| ---------- | --------------------------------------- |
+| `httpOnly` | `true`                                  |
+| `sameSite` | `'strict'`                              |
+| `maxAge`   | 8 hours                                 |
+| Dev store  | `MemoryStore` (express-session default) |
+
+---
+
+## §3 Mock User Fixtures
+
+Stored in `backend/src/auth/mockUsers.ts`. Imported by both `mockAuth.ts` and the 6-7 seed script.
+
+| role      | id (uuid)                              | email                 | name           |
+| --------- | -------------------------------------- | --------------------- | -------------- |
+| `admin`   | `00000000-0000-0000-0000-000000000001` | `admin@company.com`   | `Mock Admin`   |
+| `manager` | `00000000-0000-0000-0000-000000000002` | `manager@company.com` | `Mock Manager` |
+| `user`    | `00000000-0000-0000-0000-000000000003` | `user@company.com`    | `Mock User`    |
+
+Fixed UUIDs allow test fixtures, seed data, and mock auth to all reference the same identifiers without magic strings.
+
+**DB seed (Phase 6-7):** Insert all three rows into `users` using `INSERT ... ON CONFLICT DO NOTHING`. Idempotent — safe to re-run.
+
+---
+
+## §4 FE `/mock-login` Page
+
+### Route registration
+
+- Active only when `VITE_AUTH_MODE=mock`
+- `VITE_AUTH_MODE=oidc`: direct navigation to `/mock-login` → redirect to `/`
+- Component is lazy-loaded (dynamic import) → excluded from prod bundle via tree-shaking
+
+### Page behavior
+
+1. Dropdown with three options: Admin / Manager / User
+2. "로그인" button → `POST /api/auth/mock-login { role }`
+3. Success → redirect to originally requested path (or `/`)
+4. Session expiry / 401 → FE global interceptor redirects to `/mock-login`
+
+### Prod build isolation
+
+`VITE_AUTH_MODE` is inlined at build time. The `mock` branch is tree-shaken out of the production bundle. Dynamic import ensures the mock-login chunk is never included in prod.
+
+---
+
+## §5 Environment Variables
+
+| Variable         | Dev value | Prod value | Note                                           |
+| ---------------- | --------- | ---------- | ---------------------------------------------- |
+| `AUTH_MODE`      | `mock`    | `oidc`     | BE — controls middleware selection             |
+| `VITE_AUTH_MODE` | `mock`    | `oidc`     | FE — controls route registration and API calls |
+
+Both variables must be set consistently. Mismatch (BE=oidc + FE=mock) will cause login to fail silently.
+
+---
+
+## §6 Dependency on Phase 6-7
+
+Mock auth is functional without a DB (middleware and session work in memory).
+However, any write API that has `FK → users.id` requires the 3 seed rows to exist.
+
+**Recommended order:**
+
+1. Implement 6-6 (auth middleware + endpoints + FE page)
+2. Smoke-test with `GET /api/auth/me` — no DB needed
+3. Implement 6-7 (migrations + seed including mock user rows)
+4. Full flow test with VOC create / comment (FK-dependent)


### PR DESCRIPTION
## Summary

- Phase 6-6 인증 Mock 전략 브레인스토밍 결과 설계 문서 작성
- `docs/specs/plans/phase6-6-auth-mock-design.md` 신규 생성

## 주요 결정

- **미들웨어**: 팩토리 패턴 (`auth/index.ts` → `mockAuth.ts` / `oidcAuth.ts`)
- **Mock 로그인**: `POST /api/auth/mock-login` + `GET /api/auth/me` + `POST /api/auth/logout`
- **픽스처**: Admin/Manager/User 3개, 고정 UUID (`...0001~0003`), 6-7 시드 공유
- **FE**: `/mock-login` React 라우트, `VITE_AUTH_MODE=mock`일 때만 활성화, dynamic import로 prod 번들 격리

## Test plan

- [ ] 스펙 문서 내용 검토
- [ ] next-session-tasks.md Phase 6-6 항목과 일치 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)