### PR TITLE
docs: Phase 6-7 DB 마이그레이션 설계 + 구현 계획

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Status
 
-This is a **VOC (Voice of Customer) management system** currently in **Phase 6 implementation** — frontend and backend are scaffolded with working source code. See `docs/specs/requires/requirements.md` for the product spec and `docs/specs/requires/design.md` for the complete design system.
+This is a **greenfield VOC (Voice of Customer) management system** currently in the design/requirements phase. No source code exists yet. See `docs/specs/requires/requirements.md` for the product spec and `docs/specs/requires/design.md` for the complete design system.
 
 ## Planned Tech Stack
 
@@ -19,13 +19,13 @@ This is a **VOC (Voice of Customer) management system** currently in **Phase 6 i
 
 ## Sub-directory Guides
 
-Each working directory has a focused `CLAUDE.md` with its own commands, architecture, and rules:
+Each working directory has a focused `AGENTS.md` with its own commands, architecture, and rules:
 
-- `frontend/CLAUDE.md` — React SPA, hooks, state, full design tokens
-- `backend/CLAUDE.md` — Express REST API, DB schema, middleware
-- `prototype/CLAUDE.md` — visual exploration HTML, full design tokens
+- `frontend/AGENTS.md` — React SPA, hooks, state, full design tokens
+- `backend/AGENTS.md` — Express REST API, DB schema, middleware
+- `prototype/AGENTS.md` — visual exploration HTML, full design tokens
 
-**Rule:** when working inside a sub-directory, read its `CLAUDE.md` first. This file covers cross-cutting governance only.
+**Rule:** when working inside a sub-directory, read its `AGENTS.md` first. This file covers cross-cutting governance only.
 
 ## Docker
 
@@ -35,13 +35,13 @@ docker compose up    # Start all services (FE + BE + Postgres)
 
 ## Architecture Overview
 
-Three-tier app: React SPA → Express REST API → PostgreSQL. Detailed architecture lives in each sub-directory's `CLAUDE.md` and in `docs/specs/requires/`.
+Three-tier app: React SPA → Express REST API → PostgreSQL. Detailed architecture lives in each sub-directory's `AGENTS.md` and in `docs/specs/requires/`.
 
 ## Design System (Pointer)
 
 Full spec: `docs/specs/requires/design.md`. Full token reference: §10 CSS Reference.
 
-**Hard rule (echoed in `frontend/CLAUDE.md` and `prototype/CLAUDE.md`):**
+**Hard rule (echoed in `frontend/AGENTS.md` and `prototype/AGENTS.md`):**
 
 - Always use CSS custom properties — `var(--bg-app)`, `var(--brand)`, `var(--text-primary)`, etc.
 - **Never write hex values** (no `#5e6ad2`, no `#ffffff`). No raw OKLCH either — go through the token.
@@ -50,11 +50,10 @@ Full spec: `docs/specs/requires/design.md`. Full token reference: §10 CSS Refer
 
 ## Start Every Session
 
-1. Read `claude-progress.txt` (first 30 lines only)
+1. Read `Codex-progress.txt` (first 30 lines only)
 2. Read `docs/specs/plans/next-session-tasks.md` to find current Phase and pending tasks
 3. Read relevant spec in `docs/` (selectively — only what's needed)
 4. Continue from progress file — don't re-read what you already know
-5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete any entries whose work is already reflected in specs or git (delete file + remove from index; do not archive)
 
 ## Core Rules
 
@@ -63,22 +62,22 @@ Full spec: `docs/specs/requires/design.md`. Full token reference: §10 CSS Refer
 - **No re-read** — never re-read a file already in session context (exception: modified files)
 - **Tail test output** — pipe test output through `| tail -20`; never print full traces
 - **Git workflow** — always create a feature branch first, commit and push there. Never commit or push directly to main. Branch naming: `docs/<topic>`, `feat/<topic>`, `fix/<topic>`.
-  - PRs are opened by the user, not by Claude
+  - PRs are opened by the user, not by Codex
   - Merge PRs with `gh pr merge <n> --merge --delete-branch` — `--squash` and `--rebase` are forbidden
     - `--squash`: destroys commit history
     - `--rebase`: replays commits directly onto main, erasing PR boundaries
     - `--merge`: preserves both the merge commit (PR boundary) and individual commits ✓
   - After merging, delete the local branch: `git branch -D <branch>`
   - main changes only via PR — direct push and force push are forbidden
-  - These rules are enforced by hookify rules in `.claude/hookify.block-*.local.md`
+  - These rules are enforced by hookify rules in `.Codex/hookify.block-*.local.md`
 - Run tests before committing; follow existing code style (read 2-3 nearby files first)
 - No features beyond what the task requires (YAGNI)
-- CLAUDE.md stays under 200 lines
+- AGENTS.md stays under 200 lines
 
 ## Session Continuity
 
 Every design decision → written to spec or ADR before session ends.
-Every phase completion → update `claude-progress.txt` + git commit.
+Every phase completion → update `Codex-progress.txt` + git commit.
 No implementation without a written spec section covering it.
 
 ## Document Structure
@@ -121,7 +120,7 @@ docs/specs/
 | ---------------------------------------- | ----------------------------- |
 | Spec (design decision, constraint)       | Implementation plan           |
 | Implementation plan (task added/removed) | Spec section it implements    |
-| CLAUDE.md (new rule)                     | Spec if rule affects behavior |
+| AGENTS.md (new rule)                     | Spec if rule affects behavior |
 
 ## Session Rules
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -4,9 +4,9 @@ Express REST API for the VOC management system. Read root `CLAUDE.md` first for 
 
 ## Status
 
-Not yet scaffolded. This file is a spec stub — it captures architectural decisions so design-phase planning stays consistent.
+Phase 6 implementation in progress. `src/` is scaffolded with `index.ts`, `auth/`, and `routes/`.
 
-## Commands (once scaffolded)
+## Commands
 
 ```bash
 npm run dev                                      # ts-node-dev watch

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -4,13 +4,13 @@
 
 → **`docs/specs/plans/next-session-tasks.md`** 참조 (전체 Phase 계획)
 
-현재 위치: Phase 0 ✅ / Phase 1 ✅ / Phase 2 ✅ / Phase 3 ✅ / Phase 4 ✅ / Phase 5 ✅ / Phase 6 진행 중 → **다음: PR #22 머지 → Codex 리뷰 → 6-7 DB 마이그레이션**
+현재 위치: Phase 0 ✅ / Phase 1 ✅ / Phase 2 ✅ / Phase 3 ✅ / Phase 4 ✅ / Phase 5 ✅ / Phase 6 진행 중 → **다음: 6-7 설계 문서 PR 머지 → writing-plans → 구현**
 
 ### 다음 세션 우선순위
 
-1. **PR #22 머지** (`docs/sync-phase6-impl-to-requirements`) — 충돌 해소 완료, 머지 대기
-2. **Codex 리뷰** — Phase 6-6 구현 코드베이스 전체 리뷰
-3. **6-7 DB 마이그레이션 & 시드** (node-pg-migrate) — 다음 블로킹
+1. **6-7 설계 문서 PR 머지** — `docs/phase6-7-db-migration-design` 브랜치, 설계 확정
+2. **6-7 구현 계획 작성** (writing-plans 스킬) — 설계 문서 기반 구현 태스크 분해
+3. **6-7 구현** — node-pg-migrate 설치, 마이그레이션 파일 6개, entrypoint.sh, dev_seed.sql
 4. **6-5 FE-BE API 계약** (OpenAPI codegen)
 5. **6-3 BE 테스트 전략** (Jest + Supertest)
    ※ 설비 마스터 MSSQL 스키마(`external-masters.md §3`) — 담당자 자료 수집 후 별도 보완

--- a/docs/specs/plans/2026-04-24-phase6-7-db-migration-design.md
+++ b/docs/specs/plans/2026-04-24-phase6-7-db-migration-design.md
@@ -1,0 +1,169 @@
+# Phase 6-7: DB 마이그레이션 & 시드 전략
+
+> 작성일: 2026-04-24
+> 상태: 설계 확정 — 구현 대기
+
+## 결정 요약
+
+| 항목              | 결정                                                     |
+| ----------------- | -------------------------------------------------------- |
+| 마이그레이션 도구 | **node-pg-migrate** (이미 확정, next-session-tasks.md)   |
+| 실행 시점         | **자동** — BE Docker entrypoint에서 migrate → dev 순서   |
+| 파일 구조         | **도메인별 분리 (6파일)**                                |
+| 시드 전략         | **별도 스크립트** — `npm run db:seed` 최초 1회 수동 실행 |
+| 테스트 DB         | **6-3에서 결정** — 지금 스코프 외                        |
+
+---
+
+## 파일 구조
+
+```
+backend/
+├── migrations/
+│   ├── 001_extensions.sql        pgvector CREATE EXTENSION
+│   ├── 002_core_tables.sql       users, systems, menus, voc_types
+│   ├── 003_vocs.sql              vocs, voc_history, voc_payload_reviews, voc_payload_history
+│   ├── 004_tags.sql              tags, voc_tags, tag_rules
+│   ├── 005_content.sql           comments, voc_internal_notes, attachments, notices, faq_categories, faqs
+│   └── 006_settings.sql          dashboard_settings, notifications
+├── seeds/
+│   └── dev_seed.sql              개발용 초기 데이터
+├── entrypoint.sh                 migrate → npm run dev
+└── src/
+    └── (기존 코드 변경 없음)
+```
+
+`pgmigrations` 테이블은 node-pg-migrate가 자동 생성 — 어떤 파일까지 실행됐는지 추적.
+
+---
+
+## npm 스크립트
+
+`backend/package.json`에 추가:
+
+```json
+"db:migrate": "node-pg-migrate up -m migrations",
+"db:migrate:down": "node-pg-migrate down -m migrations",
+"db:seed": "psql $DATABASE_URL -f seeds/dev_seed.sql"
+```
+
+---
+
+## entrypoint.sh
+
+```sh
+#!/bin/sh
+set -e
+npm run db:migrate
+exec npm run dev
+```
+
+---
+
+## Dockerfile 변경
+
+```dockerfile
+# 기존 마지막 줄
+CMD ["npm", "run", "dev"]
+
+# 변경 후
+COPY backend/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+CMD ["/app/entrypoint.sh"]
+```
+
+---
+
+## 실행 흐름
+
+```
+docker compose up
+  └── postgres healthy 대기 (depends_on: service_healthy — 이미 설정됨)
+  └── BE 컨테이너 시작
+      └── entrypoint.sh
+          ├── npm run db:migrate
+          │   └── pgmigrations 체크 → 미실행 파일만 순서대로 실행
+          └── npm run dev (Express 서버 시작)
+
+# 최초 1회 (개발자 수동)
+npm run db:seed
+```
+
+---
+
+## 마이그레이션 파일별 테이블 매핑
+
+### 001_extensions.sql
+
+- `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
+- `CREATE EXTENSION IF NOT EXISTS vector;`
+
+### 002_core_tables.sql
+
+- `users` — id(uuid), ad_username, display_name, email, role CHECK('user','manager','admin'), is_active bool, created_at
+- `systems` — id(uuid), name, slug(UNIQUE), is_archived bool
+- `menus` — id(uuid), system_id(FK→systems), name, slug, is_archived. (system_id, slug) UNIQUE
+- `voc_types` — id(uuid), name, slug(UNIQUE), color(text), sort_order int, is_archived bool
+
+### 003_vocs.sql
+
+- `vocs` — 전체 컬럼 (requirements.md §4 기준)
+  - embedding vector(1536) NULL — MVP 미사용, pgvector 예약
+  - structured_payload jsonb NULL
+  - structured_payload_draft jsonb NULL
+  - review_status text CHECK('unverified','approved','rejected','pending_deletion') NULL
+  - embed_stale boolean DEFAULT false
+  - resolution_quality text CHECK('근본해결','임시조치') NULL
+  - drop_reason text CHECK('중복','정책거부','재현불가','범위외','기타') NULL
+  - source text NOT NULL DEFAULT 'manual' CHECK('manual','import')
+  - deleted_at, created_at, updated_at
+- `voc_history` — id(uuid), voc_id(FK→vocs CASCADE), field, old_value, new_value, changed_by(FK→users), changed_at
+- `voc_payload_reviews` — id(uuid), voc_id(FK→vocs CASCADE), action CHECK('submission','deletion'), reviewer_id(FK→users), decision CHECK('approved','rejected'), comment text, is_self_review bool DEFAULT false, created_at
+- `voc_payload_history` — id(uuid), voc_id(FK→vocs CASCADE), payload jsonb NOT NULL, submitted_by(FK→users), submitted_at, final_state CHECK('approved','rejected','deleted','active'), is_current bool DEFAULT false
+
+### 004_tags.sql
+
+- `tags` — id(uuid), name, slug(UNIQUE), kind text CHECK('general','menu'), created_at
+- `voc_tags` — voc_id(FK→vocs CASCADE), tag_id(FK→tags CASCADE), source text NOT NULL DEFAULT 'manual' CHECK('manual','rule'), created_at. PK: (voc_id, tag_id)
+- `tag_rules` — id(uuid), name, pattern text, kind text CHECK('general'), tag_id(FK→tags), is_active bool DEFAULT true, sort_order int, created_at
+
+### 005_content.sql
+
+- `comments` — id(uuid), voc_id(FK→vocs CASCADE), author_id(FK→users), body text NOT NULL, created_at, updated_at
+- `voc_internal_notes` — id(bigserial), voc_id(FK→vocs CASCADE), author_id(FK→users), body text NOT NULL, created_at, updated_at, deleted_at NULL
+- `attachments` — id(uuid), voc_id(FK→vocs CASCADE), uploader_id(FK→users), filename text, mime_type text, size_bytes int, storage_path text, created_at
+- `notices` — id(uuid), title, body text, level text CHECK('normal','important','urgent'), is_popup bool, is_visible bool, visible_from date NULL, visible_to date NULL, author_id(FK→users), deleted_at NULL, created_at, updated_at
+- `faq_categories` — id(uuid), name, slug(UNIQUE), sort_order int, is_archived bool
+- `faqs` — id(uuid), question text, answer text, category_id(FK→faq_categories), is_visible bool, sort_order int, author_id(FK→users), deleted_at NULL, created_at, updated_at
+
+### 006_settings.sql
+
+- `dashboard_settings` — id(uuid), user_id(FK→users NULL=Admin 기본값), widget_order jsonb, widget_visibility jsonb, widget_sizes jsonb, default_date_range text CHECK('7d','30d','90d','custom'), heatmap_default_x_axis text CHECK('status','priority','tag'), locked_fields jsonb, updated_at. UNIQUE(user_id)
+- `notifications` — id(uuid), user_id(FK→users), type text CHECK('comment','status_change','assigned'), voc_id(FK→vocs), read_at timestamptz NULL, created_at
+
+---
+
+## 시드 데이터 (dev_seed.sql)
+
+`INSERT ... ON CONFLICT DO NOTHING` — 재실행 안전.
+
+| 테이블      | 내용                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| `users`     | 3명 — UUID는 6-6 mock fixtures와 동일 (`...0001`=admin, `...0002`=manager, `...0003`=user) |
+| `systems`   | "분석 시스템", "생산관리 시스템"                                                           |
+| `menus`     | 각 시스템당 3–4개 ("기타" 포함)                                                            |
+| `voc_types` | 버그(빨강), 기능 요청(파랑), 개선 제안(초록), 문의(회색)                                   |
+| `tags`      | general 5개, menu 2개                                                                      |
+| `vocs`      | 10건 — status·priority 다양하게 분포 (대시보드 위젯이 유의미하게 보이도록)                 |
+| `comments`  | VOC당 1–2건                                                                                |
+
+---
+
+## 기술부채 & 연계 사항
+
+| 항목                                              | 처리 시점                                  |
+| ------------------------------------------------- | ------------------------------------------ |
+| HNSW 인덱스 (`vector_cosine_ops`)                 | 임베딩 기능 도입 시 별도 마이그레이션      |
+| `sequence_no` 채번 로직 (시스템·연도 단위 unique) | 003_vocs.sql에서 시퀀스 또는 트리거로 구현 |
+| 테스트 DB 전략                                    | **6-3 BE 테스트 전략**에서 결정            |
+| `ts-node-dev` → `tsx` 교체                        | 6-6 이전 또는 6-7 (PR #14 defer 목록)      |

--- a/docs/specs/plans/2026-04-24-phase6-7-db-migration-impl.md
+++ b/docs/specs/plans/2026-04-24-phase6-7-db-migration-impl.md
@@ -1,0 +1,807 @@
+# Phase 6-7: DB 마이그레이션 & 시드 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** node-pg-migrate 기반으로 6개 마이그레이션 파일 + entrypoint.sh + dev_seed.sql을 구현하여 `docker compose up` 시 자동으로 DB 스키마가 생성되도록 한다.
+
+**Architecture:** `backend/entrypoint.sh`가 Docker 시작 시 `npm run db:migrate`를 먼저 실행한 뒤 Express dev 서버를 기동한다. 마이그레이션은 도메인별 6개 SQL 파일로 분리하며 node-pg-migrate가 `pgmigrations` 테이블로 실행 이력을 추적한다. 시드는 별도 `npm run db:seed` 스크립트로 최초 1회 수동 실행한다.
+
+**Tech Stack:** node-pg-migrate, pg, PostgreSQL 16, pgvector, Docker Compose
+
+---
+
+## File Map
+
+| 액션   | 경로                                     | 역할                                                                               |
+| ------ | ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| MODIFY | `backend/package.json`                   | node-pg-migrate·pg 의존성 + db:migrate·db:seed 스크립트                            |
+| MODIFY | `backend/Dockerfile`                     | postgresql-client 설치 + CMD → entrypoint.sh                                       |
+| CREATE | `backend/entrypoint.sh`                  | migrate → npm run dev 실행 순서                                                    |
+| CREATE | `backend/migrations/001_extensions.sql`  | pgvector, uuid-ossp extension                                                      |
+| CREATE | `backend/migrations/002_core_tables.sql` | users, systems, menus, voc_types + updated_at 트리거 함수                          |
+| CREATE | `backend/migrations/003_vocs.sql`        | vocs, voc_sequence_counters, voc_history, voc_payload_reviews, voc_payload_history |
+| CREATE | `backend/migrations/004_tags.sql`        | tags, voc_tags, tag_rules                                                          |
+| CREATE | `backend/migrations/005_content.sql`     | comments, voc_internal_notes, attachments, notices, faq_categories, faqs           |
+| CREATE | `backend/migrations/006_settings.sql`    | dashboard_settings, notifications                                                  |
+| CREATE | `backend/seeds/dev_seed.sql`             | 개발용 초기 데이터 (ON CONFLICT DO NOTHING)                                        |
+
+---
+
+## Task 1: node-pg-migrate 설치 + npm 스크립트 추가
+
+**Files:**
+
+- Modify: `backend/package.json`
+
+- [ ] **Step 1: node-pg-migrate + pg 패키지 설치**
+
+```bash
+cd /path/to/vocpage
+npm install --workspace=backend node-pg-migrate pg
+npm install --workspace=backend --save-dev @types/pg
+```
+
+- [ ] **Step 2: 설치 확인**
+
+```bash
+npm list --workspace=backend node-pg-migrate pg
+```
+
+Expected 출력 (버전은 다를 수 있음):
+
+```
+@vocpage/backend@0.0.1
+├── node-pg-migrate@7.x.x
+└── pg@8.x.x
+```
+
+- [ ] **Step 3: package.json 스크립트 추가**
+
+`backend/package.json`의 `"scripts"` 블록을 아래로 교체:
+
+```json
+"scripts": {
+  "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+  "build": "tsc",
+  "start": "node dist/index.js",
+  "test": "jest --runInBand",
+  "typecheck": "tsc --noEmit",
+  "db:migrate": "node-pg-migrate up -m migrations",
+  "db:migrate:down": "node-pg-migrate down -m migrations",
+  "db:seed": "psql $DATABASE_URL -f seeds/dev_seed.sql"
+}
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add backend/package.json package-lock.json
+git commit -m "chore(db): install node-pg-migrate and add db scripts"
+```
+
+---
+
+## Task 2: 001_extensions.sql
+
+**Files:**
+
+- Create: `backend/migrations/001_extensions.sql`
+
+- [ ] **Step 1: migrations 디렉터리 생성 + 파일 작성**
+
+`backend/migrations/001_extensions.sql`:
+
+```sql
+-- pgvector: 임베딩 벡터 컬럼 (embedding vector(1536)) 지원
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- uuid-ossp: uuid_generate_v4() 함수 제공
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/001_extensions.sql
+git commit -m "feat(db): add 001_extensions migration (pgvector, uuid-ossp)"
+```
+
+---
+
+## Task 3: 002_core_tables.sql
+
+**Files:**
+
+- Create: `backend/migrations/002_core_tables.sql`
+
+- [ ] **Step 1: 파일 작성**
+
+`backend/migrations/002_core_tables.sql`:
+
+```sql
+-- updated_at 자동 갱신 트리거 함수 (공통 재사용)
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- users: AD 기반 사용자. MVP에서는 mock fixture와 UUID 일치 필수
+CREATE TABLE users (
+  id            uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  ad_username   text        NOT NULL UNIQUE,
+  display_name  text        NOT NULL,
+  email         text        NOT NULL UNIQUE,
+  role          text        NOT NULL DEFAULT 'user'
+                            CHECK (role IN ('user', 'manager', 'admin')),
+  is_active     boolean     NOT NULL DEFAULT true,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- systems: VOC가 속하는 원천 시스템 (분석시스템, 생산관리 등)
+CREATE TABLE systems (
+  id          uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  name        text        NOT NULL,
+  slug        text        NOT NULL UNIQUE,
+  is_archived boolean     NOT NULL DEFAULT false
+);
+
+-- menus: 시스템 내 메뉴 (화면 단위)
+CREATE TABLE menus (
+  id          uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  system_id   uuid        NOT NULL REFERENCES systems(id),
+  name        text        NOT NULL,
+  slug        text        NOT NULL,
+  is_archived boolean     NOT NULL DEFAULT false,
+  UNIQUE (system_id, slug)
+);
+
+-- voc_types: VOC 분류 (버그·기능요청·개선제안·문의)
+CREATE TABLE voc_types (
+  id          uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  name        text        NOT NULL,
+  slug        text        NOT NULL UNIQUE,
+  color       text        NOT NULL DEFAULT 'gray',
+  sort_order  int         NOT NULL DEFAULT 0,
+  is_archived boolean     NOT NULL DEFAULT false
+);
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/002_core_tables.sql
+git commit -m "feat(db): add 002_core_tables migration (users, systems, menus, voc_types)"
+```
+
+---
+
+## Task 4: 003_vocs.sql
+
+**Files:**
+
+- Create: `backend/migrations/003_vocs.sql`
+
+- [ ] **Step 1: 파일 작성**
+
+`backend/migrations/003_vocs.sql`:
+
+```sql
+-- 시스템×연도별 sequence_no 카운터 테이블
+CREATE TABLE voc_sequence_counters (
+  system_id uuid NOT NULL REFERENCES systems(id),
+  year      int  NOT NULL,
+  last_seq  int  NOT NULL DEFAULT 0,
+  PRIMARY KEY (system_id, year)
+);
+
+-- sequence_no 자동 채번 트리거 함수
+-- BEFORE INSERT 시점에 실행 → created_at DEFAULT(now())가 이미 적용된 상태
+CREATE OR REPLACE FUNCTION generate_voc_sequence_no()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_year int;
+  v_seq  int;
+BEGIN
+  v_year := EXTRACT(YEAR FROM NEW.created_at)::int;
+
+  INSERT INTO voc_sequence_counters (system_id, year, last_seq)
+  VALUES (NEW.system_id, v_year, 1)
+  ON CONFLICT (system_id, year)
+  DO UPDATE SET last_seq = voc_sequence_counters.last_seq + 1
+  RETURNING last_seq INTO v_seq;
+
+  NEW.sequence_no := v_seq;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- vocs: VOC 메인 테이블
+CREATE TABLE vocs (
+  id                        uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  title                     text        NOT NULL,
+  body                      text        NOT NULL,
+  status                    text        NOT NULL DEFAULT '접수'
+                                        CHECK (status IN ('접수','검토중','처리중','완료','드랍')),
+  priority                  text        NOT NULL DEFAULT 'medium'
+                                        CHECK (priority IN ('low','medium','high','urgent')),
+  reporter_id               uuid        NOT NULL REFERENCES users(id),
+  assignee_id               uuid        REFERENCES users(id),
+  system_id                 uuid        NOT NULL REFERENCES systems(id),
+  menu_id                   uuid        REFERENCES menus(id),
+  voc_type_id               uuid        REFERENCES voc_types(id),
+  sequence_no               int,
+  structured_payload        jsonb,
+  structured_payload_draft  jsonb,
+  review_status             text        CHECK (review_status IN ('unverified','approved','rejected','pending_deletion')),
+  embed_stale               boolean     NOT NULL DEFAULT false,
+  embedding                 vector(1536),
+  resolution_quality        text        CHECK (resolution_quality IN ('근본해결','임시조치')),
+  drop_reason               text        CHECK (drop_reason IN ('중복','정책거부','재현불가','범위외','기타')),
+  source                    text        NOT NULL DEFAULT 'manual'
+                                        CHECK (source IN ('manual','import')),
+  deleted_at                timestamptz,
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_voc_sequence_no
+  BEFORE INSERT ON vocs
+  FOR EACH ROW
+  WHEN (NEW.sequence_no IS NULL)
+  EXECUTE FUNCTION generate_voc_sequence_no();
+
+CREATE TRIGGER trg_vocs_updated_at
+  BEFORE UPDATE ON vocs
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- voc_history: 필드 변경 이력
+CREATE TABLE voc_history (
+  id          uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  voc_id      uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  field       text        NOT NULL,
+  old_value   text,
+  new_value   text,
+  changed_by  uuid        NOT NULL REFERENCES users(id),
+  changed_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- voc_payload_reviews: structured_payload 리뷰 이력
+CREATE TABLE voc_payload_reviews (
+  id              uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  voc_id          uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  action          text        NOT NULL CHECK (action IN ('submission','deletion')),
+  reviewer_id     uuid        NOT NULL REFERENCES users(id),
+  decision        text        NOT NULL CHECK (decision IN ('approved','rejected')),
+  comment         text,
+  is_self_review  boolean     NOT NULL DEFAULT false,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- voc_payload_history: structured_payload 제출 스냅샷
+CREATE TABLE voc_payload_history (
+  id            uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  voc_id        uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  payload       jsonb       NOT NULL,
+  submitted_by  uuid        NOT NULL REFERENCES users(id),
+  submitted_at  timestamptz NOT NULL DEFAULT now(),
+  final_state   text        CHECK (final_state IN ('approved','rejected','deleted','active')),
+  is_current    boolean     NOT NULL DEFAULT false
+);
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/003_vocs.sql
+git commit -m "feat(db): add 003_vocs migration (vocs + sequence trigger + history tables)"
+```
+
+---
+
+## Task 5: 004_tags.sql
+
+**Files:**
+
+- Create: `backend/migrations/004_tags.sql`
+
+- [ ] **Step 1: 파일 작성**
+
+`backend/migrations/004_tags.sql`:
+
+```sql
+-- tags: general(자동 태깅 대상) | menu(메뉴 연결 태그)
+CREATE TABLE tags (
+  id         uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  name       text        NOT NULL,
+  slug       text        NOT NULL UNIQUE,
+  kind       text        NOT NULL DEFAULT 'general'
+                         CHECK (kind IN ('general','menu')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- voc_tags: VOC ↔ 태그 N:M (source: manual 수동 | rule 자동 규칙)
+CREATE TABLE voc_tags (
+  voc_id     uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  tag_id     uuid        NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+  source     text        NOT NULL DEFAULT 'manual'
+                         CHECK (source IN ('manual','rule')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (voc_id, tag_id)
+);
+
+-- tag_rules: kind='general' 자동 부착 규칙 (키워드·정규식 매칭)
+CREATE TABLE tag_rules (
+  id         uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  name       text        NOT NULL,
+  pattern    text        NOT NULL,
+  kind       text        NOT NULL DEFAULT 'general'
+                         CHECK (kind IN ('general')),
+  tag_id     uuid        NOT NULL REFERENCES tags(id),
+  is_active  boolean     NOT NULL DEFAULT true,
+  sort_order int         NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/004_tags.sql
+git commit -m "feat(db): add 004_tags migration (tags, voc_tags, tag_rules)"
+```
+
+---
+
+## Task 6: 005_content.sql
+
+**Files:**
+
+- Create: `backend/migrations/005_content.sql`
+
+- [ ] **Step 1: 파일 작성**
+
+`backend/migrations/005_content.sql`:
+
+```sql
+-- comments: VOC 댓글 (User 이상 열람, Manager/Admin 포함)
+CREATE TABLE comments (
+  id         uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  voc_id     uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  author_id  uuid        NOT NULL REFERENCES users(id),
+  body       text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_comments_updated_at
+  BEFORE UPDATE ON comments
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- voc_internal_notes: 내부 메모 (Manager/Admin 전용, User에게 404)
+CREATE TABLE voc_internal_notes (
+  id         bigserial   PRIMARY KEY,
+  voc_id     uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  author_id  uuid        NOT NULL REFERENCES users(id),
+  body       text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz
+);
+
+CREATE TRIGGER trg_voc_internal_notes_updated_at
+  BEFORE UPDATE ON voc_internal_notes
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- attachments: VOC 첨부파일 메타데이터 (실파일은 Docker named volume uploads_data)
+CREATE TABLE attachments (
+  id           uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  voc_id       uuid        NOT NULL REFERENCES vocs(id) ON DELETE CASCADE,
+  uploader_id  uuid        NOT NULL REFERENCES users(id),
+  filename     text        NOT NULL,
+  mime_type    text        NOT NULL,
+  size_bytes   int         NOT NULL,
+  storage_path text        NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- notices: 공지사항
+CREATE TABLE notices (
+  id           uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  title        text        NOT NULL,
+  body         text        NOT NULL,
+  level        text        NOT NULL DEFAULT 'normal'
+                           CHECK (level IN ('normal','important','urgent')),
+  is_popup     boolean     NOT NULL DEFAULT false,
+  is_visible   boolean     NOT NULL DEFAULT true,
+  visible_from date,
+  visible_to   date,
+  author_id    uuid        NOT NULL REFERENCES users(id),
+  deleted_at   timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_notices_updated_at
+  BEFORE UPDATE ON notices
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- faq_categories: FAQ 카테고리
+CREATE TABLE faq_categories (
+  id          uuid    NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  name        text    NOT NULL,
+  slug        text    NOT NULL UNIQUE,
+  sort_order  int     NOT NULL DEFAULT 0,
+  is_archived boolean NOT NULL DEFAULT false
+);
+
+-- faqs: FAQ 항목
+CREATE TABLE faqs (
+  id          uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  question    text        NOT NULL,
+  answer      text        NOT NULL,
+  category_id uuid        NOT NULL REFERENCES faq_categories(id),
+  is_visible  boolean     NOT NULL DEFAULT true,
+  sort_order  int         NOT NULL DEFAULT 0,
+  author_id   uuid        NOT NULL REFERENCES users(id),
+  deleted_at  timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_faqs_updated_at
+  BEFORE UPDATE ON faqs
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/005_content.sql
+git commit -m "feat(db): add 005_content migration (comments, notes, attachments, notices, faqs)"
+```
+
+---
+
+## Task 7: 006_settings.sql
+
+**Files:**
+
+- Create: `backend/migrations/006_settings.sql`
+
+- [ ] **Step 1: 파일 작성**
+
+`backend/migrations/006_settings.sql`:
+
+```sql
+-- dashboard_settings: 사용자별 대시보드 설정 (user_id NULL = Admin 기본값)
+CREATE TABLE dashboard_settings (
+  id                    uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  user_id               uuid        REFERENCES users(id) UNIQUE,
+  widget_order          jsonb       NOT NULL DEFAULT '[]',
+  widget_visibility     jsonb       NOT NULL DEFAULT '{}',
+  widget_sizes          jsonb       NOT NULL DEFAULT '{}',
+  default_date_range    text        NOT NULL DEFAULT '30d'
+                                    CHECK (default_date_range IN ('7d','30d','90d','custom')),
+  heatmap_default_x_axis text       NOT NULL DEFAULT 'status'
+                                    CHECK (heatmap_default_x_axis IN ('status','priority','tag')),
+  locked_fields         jsonb       NOT NULL DEFAULT '[]',
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_dashboard_settings_updated_at
+  BEFORE UPDATE ON dashboard_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+-- notifications: 알림 (comment·status_change·assigned)
+CREATE TABLE notifications (
+  id         uuid        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+  user_id    uuid        NOT NULL REFERENCES users(id),
+  type       text        NOT NULL CHECK (type IN ('comment','status_change','assigned')),
+  voc_id     uuid        NOT NULL REFERENCES vocs(id),
+  read_at    timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/migrations/006_settings.sql
+git commit -m "feat(db): add 006_settings migration (dashboard_settings, notifications)"
+```
+
+---
+
+## Task 8: entrypoint.sh + Dockerfile 수정
+
+**Files:**
+
+- Create: `backend/entrypoint.sh`
+- Modify: `backend/Dockerfile`
+
+- [ ] **Step 1: entrypoint.sh 작성**
+
+`backend/entrypoint.sh`:
+
+```sh
+#!/bin/sh
+set -e
+npm run db:migrate
+exec npm run dev
+```
+
+- [ ] **Step 2: Dockerfile 수정**
+
+`backend/Dockerfile`의 전체 내용을 아래로 교체:
+
+```dockerfile
+FROM node:22-alpine AS development
+
+# psql 클라이언트: db:seed 스크립트(psql $DATABASE_URL -f seeds/dev_seed.sql) 실행에 필요
+RUN apk add --no-cache postgresql-client
+
+WORKDIR /app
+
+# workspace manifest 먼저 복사
+COPY package.json package-lock.json ./
+COPY frontend/package.json ./frontend/
+COPY backend/package.json ./backend/
+
+# 루트에서 설치
+RUN npm ci
+
+# 소스 복사
+COPY backend/ ./backend/
+
+WORKDIR /app/backend
+
+RUN chmod +x entrypoint.sh
+
+EXPOSE 3000
+
+CMD ["./entrypoint.sh"]
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add backend/entrypoint.sh backend/Dockerfile
+git commit -m "feat(db): add entrypoint.sh and update Dockerfile (migrate-then-dev)"
+```
+
+---
+
+## Task 9: dev_seed.sql
+
+**Files:**
+
+- Create: `backend/seeds/dev_seed.sql`
+
+- [ ] **Step 1: seeds 디렉터리 생성 + 파일 작성**
+
+`backend/seeds/dev_seed.sql`:
+
+```sql
+-- 재실행 안전: ON CONFLICT DO NOTHING
+-- UUID는 6-6 mockUsers.ts fixture와 동일해야 auth 미들웨어와 연동됨
+
+-- users (3명 — mock fixture UUID 고정)
+INSERT INTO users (id, ad_username, display_name, email, role) VALUES
+  ('00000000-0000-0000-0000-000000000001', 'mock_admin',   'Mock Admin',   'admin@company.com',   'admin'),
+  ('00000000-0000-0000-0000-000000000002', 'mock_manager', 'Mock Manager', 'manager@company.com', 'manager'),
+  ('00000000-0000-0000-0000-000000000003', 'mock_user',    'Mock User',    'user@company.com',    'user')
+ON CONFLICT (id) DO NOTHING;
+
+-- systems (2개)
+INSERT INTO systems (id, name, slug) VALUES
+  ('10000000-0000-0000-0000-000000000001', '분석 시스템',   'analysis'),
+  ('10000000-0000-0000-0000-000000000002', '생산관리 시스템', 'production')
+ON CONFLICT (id) DO NOTHING;
+
+-- menus (각 시스템당 3-4개)
+INSERT INTO menus (id, system_id, name, slug) VALUES
+  ('20000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', '대시보드',   'dashboard'),
+  ('20000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', '리포트',     'report'),
+  ('20000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000001', '기타',       'etc'),
+  ('20000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000002', '생산계획',   'plan'),
+  ('20000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000002', '실적관리',   'performance'),
+  ('20000000-0000-0000-0000-000000000006', '10000000-0000-0000-0000-000000000002', '품질관리',   'quality'),
+  ('20000000-0000-0000-0000-000000000007', '10000000-0000-0000-0000-000000000002', '기타',       'etc')
+ON CONFLICT (id) DO NOTHING;
+
+-- voc_types (4종)
+INSERT INTO voc_types (id, name, slug, color, sort_order) VALUES
+  ('30000000-0000-0000-0000-000000000001', '버그',      'bug',         'red',   1),
+  ('30000000-0000-0000-0000-000000000002', '기능 요청', 'feature',     'blue',  2),
+  ('30000000-0000-0000-0000-000000000003', '개선 제안', 'improvement', 'green', 3),
+  ('30000000-0000-0000-0000-000000000004', '문의',      'inquiry',     'gray',  4)
+ON CONFLICT (id) DO NOTHING;
+
+-- tags (general 5개, menu 2개)
+INSERT INTO tags (id, name, slug, kind) VALUES
+  ('40000000-0000-0000-0000-000000000001', '성능',   'performance', 'general'),
+  ('40000000-0000-0000-0000-000000000002', '오류',   'error',       'general'),
+  ('40000000-0000-0000-0000-000000000003', 'UI',     'ui',          'general'),
+  ('40000000-0000-0000-0000-000000000004', '데이터', 'data',        'general'),
+  ('40000000-0000-0000-0000-000000000005', '권한',   'permission',  'general'),
+  ('40000000-0000-0000-0000-000000000006', '대시보드 메뉴', 'menu-dashboard', 'menu'),
+  ('40000000-0000-0000-0000-000000000007', '생산계획 메뉴', 'menu-plan',      'menu')
+ON CONFLICT (id) DO NOTHING;
+
+-- vocs (10건 — status·priority 다양 분포, 대시보드 위젯이 유의미하게 표시되도록)
+-- sequence_no는 트리거가 자동 채번
+INSERT INTO vocs (id, title, body, status, priority, reporter_id, assignee_id, system_id, menu_id, voc_type_id, source) VALUES
+  ('50000000-0000-0000-0000-000000000001', '대시보드 로딩 속도 개선 요청', '분석 시스템 대시보드가 데이터 로드 시 10초 이상 걸립니다.',
+   '접수', 'high',   '00000000-0000-0000-0000-000000000003', NULL, '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', '30000000-0000-0000-0000-000000000003', 'manual'),
+  ('50000000-0000-0000-0000-000000000002', '리포트 다운로드 오류', 'CSV 다운로드 버튼 클릭 시 500 에러가 발생합니다.',
+   '검토중', 'urgent', '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000002', '30000000-0000-0000-0000-000000000001', 'manual'),
+  ('50000000-0000-0000-0000-000000000003', '생산계획 날짜 필터 버그', '시작일과 종료일 역전 시 빈 결과 대신 에러 메시지 없이 전체 데이터를 반환합니다.',
+   '처리중', 'medium', '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000004', '30000000-0000-0000-0000-000000000001', 'manual'),
+  ('50000000-0000-0000-0000-000000000004', '품질관리 기능 추가 요청', '불량 유형별 트렌드 차트 기능이 필요합니다.',
+   '완료', 'low',    '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000006', '30000000-0000-0000-0000-000000000002', 'manual'),
+  ('50000000-0000-0000-0000-000000000005', '실적 데이터 오차 문의', '목표 대비 실적이 음수로 표시되는 경우가 있습니다.',
+   '드랍', 'medium', '00000000-0000-0000-0000-000000000003', NULL, '10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000005', '30000000-0000-0000-0000-000000000004', 'manual'),
+  ('50000000-0000-0000-0000-000000000006', '권한 오류 — 일반 사용자 관리자 메뉴 접근', '일반 사용자가 관리자 전용 설정 메뉴에 접근 가능합니다.',
+   '접수', 'urgent', '00000000-0000-0000-0000-000000000003', NULL, '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000003', '30000000-0000-0000-0000-000000000001', 'manual'),
+  ('50000000-0000-0000-0000-000000000007', '분석 리포트 필터 UI 개선', '현재 드롭다운 방식 필터를 멀티셀렉트로 변경 요청합니다.',
+   '검토중', 'low',   '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000002', '30000000-0000-0000-0000-000000000003', 'manual'),
+  ('50000000-0000-0000-0000-000000000008', '생산계획 Jira 이관 데이터 정합성', 'Jira에서 이관된 VOC 중 담당자가 비어 있는 항목이 있습니다.',
+   '처리중', 'high',  '00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000004', '30000000-0000-0000-0000-000000000004', 'import'),
+  ('50000000-0000-0000-0000-000000000009', '대시보드 위젯 순서 저장 안 됨', '페이지 새로고침 후 위젯 순서가 초기화됩니다.',
+   '완료', 'medium', '00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', '30000000-0000-0000-0000-000000000001', 'manual'),
+  ('50000000-0000-0000-0000-000000000010', '기타 — 로그인 후 리다이렉트 오류', '로그인 완료 후 이전 페이지가 아닌 홈으로 이동합니다.',
+   '접수', 'medium', '00000000-0000-0000-0000-000000000003', NULL, '10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000003', '30000000-0000-0000-0000-000000000004', 'manual')
+ON CONFLICT (id) DO NOTHING;
+
+-- comments (VOC당 1-2건)
+INSERT INTO comments (id, voc_id, author_id, body) VALUES
+  ('60000000-0000-0000-0000-000000000001', '50000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002', '담당자 배정 예정입니다. 내일까지 확인하겠습니다.'),
+  ('60000000-0000-0000-0000-000000000002', '50000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002', '서버 로그 확인 중입니다.'),
+  ('60000000-0000-0000-0000-000000000003', '50000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000003', '재현 방법: 특정 날짜 범위에서만 발생하는 것 같습니다.'),
+  ('60000000-0000-0000-0000-000000000004', '50000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002', '수정 배포 예정일: 다음 스프린트'),
+  ('60000000-0000-0000-0000-000000000005', '50000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000002', '트렌드 차트 기능 v1.2에 포함 완료되었습니다.'),
+  ('60000000-0000-0000-0000-000000000006', '50000000-0000-0000-0000-000000000009', '00000000-0000-0000-0000-000000000002', '로컬스토리지 저장 로직 버그 수정 완료.'),
+  ('60000000-0000-0000-0000-000000000007', '50000000-0000-0000-0000-000000000007', '00000000-0000-0000-0000-000000000002', '멀티셀렉트 컴포넌트 라이브러리 검토 중입니다.')
+ON CONFLICT (id) DO NOTHING;
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add backend/seeds/dev_seed.sql
+git commit -m "feat(db): add dev_seed.sql (users, systems, menus, voc_types, tags, 10 vocs, comments)"
+```
+
+---
+
+## Task 10: E2E 스모크 테스트
+
+> 이 태스크는 Docker 환경에서 실행. `docker compose up` 이전에 모든 파일이 커밋되어 있어야 한다.
+
+**Prerequisites:** PostgreSQL docker 컨테이너가 실행 중이거나 `docker compose up`으로 시작 가능한 상태.
+
+- [ ] **Step 1: 기존 볼륨 초기화 (클린 슬레이트)**
+
+```bash
+cd /path/to/vocpage
+docker compose down -v
+```
+
+Expected: postgres_data 볼륨 삭제 확인.
+
+- [ ] **Step 2: docker compose up (백그라운드)**
+
+```bash
+docker compose up --build -d
+```
+
+- [ ] **Step 3: 마이그레이션 로그 확인**
+
+```bash
+docker compose logs backend | grep -E "migrate|error|Error" | head -20
+```
+
+Expected 포함 로그:
+
+```
+Migrating files: 001_extensions, 002_core_tables, 003_vocs, 004_tags, 005_content, 006_settings
+```
+
+`error` 라인이 없어야 한다.
+
+- [ ] **Step 4: 테이블 존재 확인**
+
+```bash
+docker compose exec postgres psql -U vocpage -d vocpage -c "\dt"
+```
+
+Expected: 아래 테이블 목록이 모두 출력됨:
+
+```
+attachments, comments, dashboard_settings, faq_categories, faqs,
+menus, notifications, notices, pgmigrations, systems, tag_rules, tags,
+users, voc_history, voc_internal_notes, voc_payload_history, voc_payload_reviews,
+voc_sequence_counters, voc_tags, voc_types, vocs
+```
+
+- [ ] **Step 5: 시드 실행 (호스트에서)**
+
+```bash
+# 호스트에서 직접 실행 (psql 필요) — 포트는 docker-compose.yml 확인
+DATABASE_URL=postgres://vocpage:vocpage@localhost:5433/vocpage npm run --workspace=backend db:seed
+```
+
+또는 backend 컨테이너 내부에서:
+
+```bash
+docker compose exec backend sh -c "npm run db:seed"
+```
+
+Expected: 오류 없이 완료.
+
+- [ ] **Step 6: 시드 데이터 확인**
+
+```bash
+docker compose exec postgres psql -U vocpage -d vocpage -c "
+SELECT
+  (SELECT count(*) FROM users)    AS users,
+  (SELECT count(*) FROM systems)  AS systems,
+  (SELECT count(*) FROM vocs)     AS vocs,
+  (SELECT count(*) FROM comments) AS comments;
+"
+```
+
+Expected:
+
+```
+ users | systems | vocs | comments
+-------+---------+------+----------
+     3 |       2 |   10 |        7
+```
+
+- [ ] **Step 7: sequence_no 트리거 확인**
+
+```bash
+docker compose exec postgres psql -U vocpage -d vocpage -c "
+SELECT id, system_id, sequence_no FROM vocs ORDER BY system_id, sequence_no LIMIT 5;
+"
+```
+
+Expected: `sequence_no` 컬럼이 NULL이 아니고 시스템별로 1부터 순차 채번됨.
+
+- [ ] **Step 8: 최종 커밋**
+
+```bash
+git add .
+git commit -m "feat(db): phase 6-7 DB migration and seed complete — smoke test passed"
+```
+
+---
+
+## Self-Review 체크
+
+**Spec 커버리지:**
+
+- ✅ node-pg-migrate 설치 (Task 1)
+- ✅ 6개 마이그레이션 파일 (Tasks 2-7)
+- ✅ entrypoint.sh (Task 8)
+- ✅ Dockerfile CMD 변경 (Task 8)
+- ✅ dev_seed.sql (Task 9)
+- ✅ sequence_no 트리거 (003_vocs.sql, Task 4)
+- ✅ mock UUID 일치 검증 (dev_seed.sql)
+- ✅ E2E 검증 (Task 10)
+
+**미포함 (설계 명세 외):**
+
+- HNSW 인덱스 — 임베딩 기능 도입 시 별도 마이그레이션
+- issue_code — 미결 항목(🟠), 6-5 이후 결정
+- 테스트 DB 전략 — 6-3에서 결정

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -272,10 +272,15 @@ docs/specs/reviews/
 
 ### 6-7. DB 마이그레이션 & 시드 전략
 
-- [ ] 마이그레이션 방식 결정 (수동 SQL 파일 vs node-pg-migrate vs Flyway)
-- [ ] 마이그레이션 파일 구조 및 명명 규칙 결정
-- [ ] prototype.html 예시 데이터 기반 시드 fixture 작성 계획
-- [ ] **pgvector 확장 초기 마이그레이션에 포함**: `CREATE EXTENSION IF NOT EXISTS vector;` + `vocs.embedding vector(1536) NULL` 컬럼 생성 (MVP 미사용, 향후 유사검색/RAG용 예약). Docker 이미지는 `pgvector/pgvector:pg16` 사용.
+> 설계 확정: `docs/specs/plans/2026-04-24-phase6-7-db-migration-design.md`
+> 브랜치: `docs/phase6-7-db-migration-design` (PR 머지 대기)
+
+- [x] 마이그레이션 도구: **node-pg-migrate**
+- [x] 실행 시점: **자동** (Docker entrypoint.sh — migrate → dev)
+- [x] 파일 구조: **도메인별 6파일** (001_extensions ~ 006_settings)
+- [x] 시드 전략: **별도 스크립트** (`npm run db:seed`, 최초 1회 수동)
+- [x] 테스트 DB: 6-3에서 결정
+- [ ] **구현**: node-pg-migrate 설치 + 마이그레이션 파일 6개 + entrypoint.sh + dev_seed.sql
 
 ### 6-8. 상태 관리 방식 확정
 

--- a/docs/specs/reviews/phase6/phase6-6-auth-mock-pr-review.md
+++ b/docs/specs/reviews/phase6/phase6-6-auth-mock-pr-review.md
@@ -1,0 +1,108 @@
+# Phase 6-6 Auth Mock PR Review
+
+> Date: 2026-04-24
+> Scope: PR branch `docs/sync-phase6-impl-to-requirements`
+> Review target: Phase 6-6 auth mock implementation and related dev environment wiring
+
+## Summary
+
+Phase 6-6 auth mock implementation has passing unit/type/build checks, but the PR has environment integration gaps that can break local Docker/dev usage after merge.
+
+Primary blockers before merge:
+
+1. Docker backend healthcheck still targets the removed `/health` route.
+2. Frontend auth client ignores `VITE_API_BASE_URL` and has no Vite `/api` proxy.
+
+Secondary issues:
+
+1. Missing `SESSION_SECRET` falls back to a known public value.
+2. OIDC stub does not fail at boot, despite the approved Phase 6-6 plan saying it should.
+
+## Findings
+
+### P1 — Docker healthcheck now points at a removed route
+
+- File: `backend/src/index.ts:26`
+- Related file: `docker-compose.yml:41`
+- Current behavior: backend exposes `GET /api/health`.
+- Existing Docker behavior: backend healthcheck calls `http://localhost:3000/health`.
+- Risk: backend container remains unhealthy, and frontend does not start because it depends on `backend.condition: service_healthy`.
+- Recommended fix:
+  - Either update Docker healthcheck to `/api/health`, or
+  - Keep a compatibility alias at `/health`.
+- Preferred direction: update `docker-compose.yml` to `/api/health` and ensure requirements/plans consistently reference the same healthcheck path.
+
+### P1 — Frontend auth client ignores the configured backend URL
+
+- File: `frontend/src/api/auth.ts:11`
+- Related files:
+  - `.env.example:22`
+  - `frontend/vite.config.ts`
+- Current behavior: auth client calls relative URLs such as `/api/auth/mock-login`.
+- Existing configuration: `.env.example` defines `VITE_API_BASE_URL=http://localhost:3000`.
+- Missing piece: Vite dev server has no `/api` proxy.
+- Risk: in Docker/dev, the browser served from `:5173` sends auth requests to the frontend dev server instead of the backend. Mock login can fail outside mocked unit tests.
+- Recommended fix options:
+  - Use `VITE_API_BASE_URL` in the FE auth client, with CORS/session cookie settings aligned on the backend.
+  - Or add a Vite `/api` proxy to the backend and keep relative URLs.
+- Preferred direction: for local dev, add a Vite proxy for `/api` to avoid cross-origin cookie complexity. Revisit explicit API base handling when 6-5 FE-BE API contract and deployment topology are finalized.
+
+### P2 — Missing `SESSION_SECRET` can silently fall back to a public secret
+
+- File: `backend/src/index.ts:13-15`
+- Current behavior: when `SESSION_SECRET` is missing, the server uses `dev-only-secret-change-in-prod`.
+- Previous behavior: startup failed when required env vars were missing.
+- Spec conflict: `requirements.md` treats `SESSION_SECRET` as required and states it should be a 32+ character random secret.
+- Risk: staging/production can boot with a known session signing secret if env wiring is incomplete.
+- Recommended fix:
+  - Restore fail-fast validation for `SESSION_SECRET`, or
+  - Gate the fallback strictly behind explicit local/development mode.
+- Preferred direction: fail fast unless `NODE_ENV === 'development'` and `AUTH_MODE === 'mock'`.
+
+### P2 — OIDC stub does not fail at boot as the approved plan says
+
+- File: `backend/src/index.ts:6-7`
+- Related files:
+  - `backend/src/auth/index.ts:4-8`
+  - `backend/src/auth/oidcAuth.ts:4-5`
+  - `docs/specs/plans/phase6-6-auth-mock-design.md`
+- Approved plan: `AUTH_MODE=oidc` is a stub that throws at boot time.
+- Current behavior: `createAuthMiddleware()` returns `oidcAuthMiddleware`, but does not invoke it. Server can boot in `AUTH_MODE=oidc`.
+- Risk: staging/production can appear healthy while OIDC auth is not implemented.
+- Recommended fix:
+  - Throw directly from `createAuthMiddleware()` for `AUTH_MODE=oidc` until real OIDC is implemented, or
+  - Update the approved plan if booting with an unimplemented stub is intentional.
+- Preferred direction: keep the approved plan and fail fast for `AUTH_MODE=oidc`.
+
+## Verification Performed
+
+Commands run during review:
+
+```bash
+npm test --workspace backend -- --runInBand | tail -20
+npm test --workspace frontend -- --run | tail -20
+npm run typecheck --workspace backend | tail -20
+npm run typecheck --workspace frontend | tail -20
+npm run build --workspace backend | tail -20
+npm run build --workspace frontend | tail -20
+```
+
+Results:
+
+- Backend tests: passed, 7 tests.
+- Frontend tests: passed, 8 tests.
+- Backend typecheck: passed.
+- Frontend typecheck: passed.
+- Backend build: passed.
+- Frontend build: passed.
+
+Note: frontend test run emitted a sandbox-only Vite websocket `EPERM` message, but tests completed successfully.
+
+## Merge Recommendation
+
+Do not merge until both P1 findings are fixed or explicitly accepted:
+
+1. Healthcheck path must match the backend route.
+2. Auth requests must reach the backend in local Docker/dev.
+
+P2 findings can be fixed in the same PR with low implementation cost and should be addressed before staging use.

--- a/docs/specs/reviews/phase6/pr-22-sync-pr-review.md
+++ b/docs/specs/reviews/phase6/pr-22-sync-pr-review.md
@@ -1,0 +1,82 @@
+# Phase 6: PR #22 (Sync Phase 6-4/6-6 Impl to Requirements) - 적대적 리뷰 (Adversarial Review)
+
+> Date: 2026-04-24
+> Scope: PR branch `docs/sync-phase6-impl-to-requirements` (PR #22)
+> Reviewer: Antigravity
+
+## 총평 (Summary)
+
+**[Merge 반려 권고 - Blocked]**
+
+본 PR은 구현 과정에서 파생된 설계 결정들을 요구사항 문서(`requirements.md` 등)에 동기화하는 것을 목적으로 하나, **치명적인 시스템 일관성 파괴, 보안/인증 설정의 취약한 타협, 그리고 명세 누락**을 포함하고 있습니다. 명세가 코드를 주도해야 하는데, 현재 문서 업데이트는 코드의 결함이나 미완성 상태를 정당화하기 위해 명세를 훼손하는 방향으로 이루어졌습니다.
+
+아래 P1(크리티컬) 및 P2(메이저) 이슈를 해결하기 전에는 병합(Merge)을 승인할 수 없습니다.
+
+---
+
+## 🛑 P1 - 크리티컬 (Critical Issues)
+
+### 1. 보안 및 인증 설계 타협 (VITE_AUTH_MODE vs AUTH_MODE)
+
+- **문제 위치**: `docs/specs/plans/phase6-6-auth-mock-design.md` §5 및 `requirements.md` §14.1
+- **문제 내용**:
+  - 문서에서는 `VITE_AUTH_MODE`와 `AUTH_MODE`를 각각 설정해야 하며, **"불일치 시 조용히 로그인 실패함 (Mismatch will cause login to fail silently)"**이라고 기재되어 있습니다.
+  - 또한 `createAuthMiddleware()`가 잘못된 값이면 즉시 throw한다고 명시했으나, 실제 PR 21의 구현 코드는 OIDC 모드에서 예외를 던지지 않고 무시한 채 서버를 기동시킵니다.
+- **적대적 비판 (Adversarial Critique)**:
+  - **왜 시스템의 치명적 결함을 문서에 '스펙'인 것처럼 기록합니까?** 인증 모드의 불일치는 조용히 실패(Silent failure)해서는 안 되며, 애플리케이션 기동 자체를 막아야(Fail-fast) 합니다. 개발자가 두 개의 환경 변수를 실수로 다르게 설정했다고 해서 원인 모를 인증 실패 디버깅에 시간을 낭비하게 만드는 것은 최악의 DX입니다. 백엔드에서 설정된 모드를 FE가 초기 부팅 시 동적으로 가져가거나, 빌드 타임에 검증하는 로직을 추가해야 합니다.
+
+### 2. '좀비 서브태스크(Zombie Sub-task)' 허용으로 인한 상태 불일치
+
+- **문제 위치**: `requirements.md` §8.2 상태 전환 및 규칙
+- **문제 내용**: "미완료 Sub-task가 있는 부모 VOC를 '완료'로 전환 시 경고 메시지 후 강제 진행 가능. Sub-task 상태는 변경되지 않으며 담당자가 개별 처리."
+- **적대적 비판 (Adversarial Critique)**:
+  - 부모 VOC가 '완료' 되었는데 자식 VOC가 '처리중'인 상태는 **계층형 데이터 모델의 논리적 모순**입니다.
+  - SLA 계산 시 치명적 오류를 발생시킵니다. 시스템은 이 VOC가 완료되었다고 보고할 텐데, 서브태스크 담당자의 KPI 에이징은 계속 카운트됩니까?
+  - 부모를 강제로 닫으려면 자식도 `Cascade Close` 처리를 하거나, 자식이 모두 완료될 때까지 부모의 완료 처리를 강력히 차단해야 합니다. 편리함을 위해 데이터 무결성을 희생하는 스펙은 수용 불가합니다.
+
+### 3. 로컬 Dev 환경 포트 맵핑 오류 (네트워크 단절)
+
+- **문제 위치**: `requirements.md` §14.2 및 `.env.example`
+- **문제 내용**:
+  - `requirements.md`에는 `backend: ... host 3001 → container 3000`으로 맵핑한다고 정의했습니다.
+  - 그러나 동일 PR의 `.env.example`에는 `VITE_API_BASE_URL=http://localhost:3000`이 여전히 기재되어 있습니다.
+- **적대적 비판 (Adversarial Critique)**:
+  - 호스트 머신에서 FE가(5173 포트) 실행될 때 `localhost:3000`으로 API 요청을 보내면 백엔드 컨테이너(3001 포트로 포워딩 됨)에 도달하지 못하고 연결이 거부됩니다(Connection Refused). 이 PR을 머지하고 클론받는 모든 프론트엔드 개발자의 로컬 환경이 즉시 고장납니다. 두 설정 중 하나를 맞춰야 합니다.
+
+---
+
+## ⚠️ P2 - 메이저 (Major Issues)
+
+### 4. 애매모호한 검증 스펙 (보안 취약점 야기)
+
+- **문제 위치**: `requirements.md` §8.10
+- **문제 내용**: 시스템명/메뉴명 입력 시 "주요특수문자 허용"이라고 두루뭉술하게 명시.
+- **적대적 비판 (Adversarial Critique)**:
+  - "주요특수문자"라는 용어는 공학적으로 존재하지 않습니다. 따옴표(`'`), 꺾쇠(`<`, `>`)도 주요특수문자로 보고 허용하여 XSS나 SQL Injection 벡터를 열어둘 것입니까?
+  - 정규표현식(`^[a-zA-Z0-9가-힣\s\-_]+$`) 형태로 허용 가능한 문자열 셋을 정확히 정의해야 합니다.
+
+### 5. 유령 테스트 시나리오 (Phantom E2E Scenarios)
+
+- **문제 위치**: `requirements.md` §13.1 테스트 레이어 구분
+- **문제 내용**: E2E 대상 항목에 **"핵심 플로우 (아래 목록)"**이라고 적어두었으나, 문서 아래에 해당 목록이 존재하지 않습니다.
+- **적대적 비판 (Adversarial Critique)**:
+  - 검증할 핵심 플로우 목록조차 작성하지 않고 "동기화 완료"를 선언하는 것은 태만입니다. 어떤 시나리오가 E2E 대상인지 정확히 명시하십시오.
+
+### 6. Phase 6-7의 범위 변질 (Scope Creep)
+
+- **문제 위치**: `requirements.md` §6.1 Backend
+- **문제 내용**: "OIDC 실 연결은 Phase 6-7"이라고 명시함.
+- **적대적 비판 (Adversarial Critique)**:
+  - `next-session-tasks.md` 및 `claude-progress.txt`에 명시된 Phase 6-7의 목표는 **"DB 마이그레이션 & 시드"**입니다. DB 스키마 작업을 하는 Phase에 OIDC 연동 구현을 끼워넣는 것은 명백한 스코프 크립(Scope Creep)입니다. OIDC 실 연동은 별도의 인프라/인증 티켓(예: Phase 6-8)으로 분리해야 합니다.
+
+---
+
+## 💡 액션 아이템 (Required Actions)
+
+본 PR 머지 전 아래 수정 사항을 반영하십시오:
+
+1. **포트 충돌 해결**: `VITE_API_BASE_URL` 값을 `3001`로 수정하거나, Docker compose 포트 포워딩을 `3000:3000`으로 통일.
+2. **좀비 서브태스크 방어**: 부모 VOC 완료 시 자식 상태에 대한 정합성 유지 스펙 재정의 (Cascade Close 또는 완전 차단).
+3. **특수문자 화이트리스트화**: 허용할 특수문자를 정규식이나 리스트(`-`, `_` 등) 형태로 구체적 명시.
+4. **E2E 테스트 목록 작성**: "(아래 목록)"이라 적어놓고 빠진 실제 핵심 플로우 목록 보충.
+5. **Fail-fast 강제화 명세**: 두 개의 `AUTH_MODE` 변수 불일치 시 Silent failure를 허용한다는 타협안을 삭제하고, 불일치 검증 로직 구현을 강제하는 명세로 롤백.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,9 +4,9 @@ React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-c
 
 ## Status
 
-Not yet scaffolded. This file is a spec stub — it captures architectural decisions so design-phase planning stays consistent.
+Phase 6 implementation in progress. `src/` is scaffolded with `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, and `api/`.
 
-## Commands (once scaffolded)
+## Commands
 
 ```bash
 npm run dev                              # Vite dev server
@@ -29,6 +29,7 @@ Token pipeline: `src/tokens.ts` → `tailwind.config.ts` (utility classes) + CSS
 Full token reference: `docs/specs/requires/design.md §10 CSS Reference` and `§12 Token Architecture`.
 
 **When to use which:**
+
 - Layout / spacing / flex / grid → Tailwind utility (`flex gap-2 px-4`)
 - Static color on a standard element → Tailwind utility (`bg-brand text-primary`)
 - Dynamic color passed to JS (charts, Toast UI, canvas) → import from `tokens.ts` directly
@@ -36,6 +37,7 @@ Full token reference: `docs/specs/requires/design.md §10 CSS Reference` and `§
 - Custom CSS / `@apply` → CSS var (`color: var(--text-primary)`)
 
 **Hard rules:**
+
 - Never write hex or raw OKLCH values outside of `src/tokens.ts`
 - If a token doesn't exist for what you need, add it to `src/tokens.ts` + `design.md §12` first, then use it
 - Never duplicate a token value — one source, two surfaces (Tailwind + CSS vars)


### PR DESCRIPTION
## Summary

- Phase 6-7 DB 마이그레이션 & 시드 전략 설계 확정 (`docs/specs/plans/2026-04-24-phase6-7-db-migration-design.md`)
- 구현 계획 작성 (`docs/specs/plans/2026-04-24-phase6-7-db-migration-impl.md`) — node-pg-migrate + 6 migration files + entrypoint.sh + dev_seed.sql, 10 tasks
- CLAUDE.md / backend/CLAUDE.md / frontend/CLAUDE.md 상태 업데이트 (greenfield → Phase 6 implementation)
- AGENTS.md 추가 (Codex 가이드)
- Phase 6-6 auth mock PR 리뷰 + PR #22 적대적 리뷰 문서 추가

## Next

구현 브랜치 `feat/phase6-7-db-migration`에서 구현 계획 실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)