### PR TITLE
fix: Phase 7 코드 리뷰 결함 수정 R7-1~R7-10

### DIFF
--- a/backend/src/__tests__/notifications.test.ts
+++ b/backend/src/__tests__/notifications.test.ts
@@ -181,9 +181,14 @@ describe('Notification endpoints', () => {
     });
   });
 
-  // ── Bulk read on GET ───────────────────────────────────────────────────────
+  // ── PATCH /api/notifications/read-all (R7-7) ──────────────────────────────
 
-  describe('Bulk-read on GET /api/notifications', () => {
+  describe('PATCH /api/notifications/read-all', () => {
+    it('returns 401 when not authenticated', async () => {
+      const res = await request(app).patch('/api/notifications/read-all');
+      expect(res.status).toBe(401);
+    });
+
     it('marks all unread as read so unread-count becomes 0', async () => {
       const agent = request.agent(app);
       await agent.post('/api/auth/mock-login').send({ role: 'admin' });
@@ -195,11 +200,28 @@ describe('Notification endpoints', () => {
       const before = await agent.get('/api/notifications/unread-count');
       expect(before.body.count).toBeGreaterThan(0);
 
-      const list = await agent.get('/api/notifications');
-      expect(list.status).toBe(200);
+      const patch = await agent.patch('/api/notifications/read-all');
+      expect(patch.status).toBe(200);
+      expect(patch.body.ok).toBe(true);
 
       const after = await agent.get('/api/notifications/unread-count');
       expect(after.body.count).toBe(0);
+    });
+
+    it('is idempotent: calling read-all twice returns 200 both times', async () => {
+      const agent = request.agent(app);
+      await agent.post('/api/auth/mock-login').send({ role: 'admin' });
+      await clearNotifications(pool, fixtures.adminId);
+
+      await insertNotification(pool, { userId: fixtures.adminId, type: 'comment', vocId });
+
+      const first = await agent.patch('/api/notifications/read-all');
+      expect(first.status).toBe(200);
+      const second = await agent.patch('/api/notifications/read-all');
+      expect(second.status).toBe(200);
+
+      const count = await agent.get('/api/notifications/unread-count');
+      expect(count.body.count).toBe(0);
     });
   });
 
@@ -257,8 +279,7 @@ describe('Notification endpoints', () => {
       expect(res.status).toBe(200);
       const types = (res.body as Array<{ type: string }>).map((n) => n.type);
       expect(types).toContain('assigned');
-      // The bulk-read on GET means the old one might also be filtered before SELECT runs;
-      // either way, only 1 row should be returned.
+      // Old notification: filtered by read_at < 30 days ago. Recent unread: included.
       expect(res.body.length).toBe(1);
     });
   });

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+import type { AuthUser } from '../auth/types';
+
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  if (!req.user) {
+    res.status(401).json({ error: 'UNAUTHORIZED' });
+    return;
+  }
+  next();
+}
+
+export function requireManager(req: Request, res: Response, next: NextFunction): void {
+  const user = req.user as AuthUser | undefined;
+  if (!user || (user.role !== 'manager' && user.role !== 'admin')) {
+    res.status(403).json({ error: 'FORBIDDEN' });
+    return;
+  }
+  next();
+}
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  const user = req.user as AuthUser | undefined;
+  if (!user || user.role !== 'admin') {
+    res.status(403).json({ error: 'FORBIDDEN' });
+    return;
+  }
+  next();
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,30 +1,12 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { pool } from '../db';
 import logger from '../logger';
 import type { AuthUser } from '../auth/types';
+import { requireAuth, requireAdmin } from '../middleware/auth';
 
 export const adminRouter = Router();
 export const systemsPublicRouter = Router();
 export const vocTypesPublicRouter = Router();
-
-// ── Auth middleware helpers ──────────────────────────────────────────────────
-
-function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  if (!req.user) {
-    res.status(401).json({ error: 'UNAUTHORIZED' });
-    return;
-  }
-  next();
-}
-
-function requireAdmin(req: Request, res: Response, next: NextFunction): void {
-  const user = req.user as AuthUser | undefined;
-  if (!user || user.role !== 'admin') {
-    res.status(403).json({ error: 'FORBIDDEN' });
-    return;
-  }
-  next();
-}
 
 // ── Systems (Admin) ──────────────────────────────────────────────────────────
 
@@ -62,23 +44,30 @@ adminRouter.post(
       return;
     }
 
+    // R7-5: wrap in transaction — orphan system impossible if menu insert fails
+    const client = await pool.connect();
     try {
-      const sysResult = await pool.query(
+      await client.query('BEGIN');
+      const sysResult = await client.query(
         `INSERT INTO systems (name, slug) VALUES ($1, $2) RETURNING *`,
         [name, slug],
       );
       const system = sysResult.rows[0] as { id: string };
 
-      const menuResult = await pool.query(
+      const menuResult = await client.query(
         `INSERT INTO menus (system_id, name, slug) VALUES ($1, $2, $3) RETURNING *`,
         [system.id, '기타', 'other'],
       );
       const menu = menuResult.rows[0];
 
+      await client.query('COMMIT');
       res.status(201).json({ system, menu });
     } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
       logger.error({ err }, 'POST /api/admin/systems failed');
       res.status(500).json({ error: 'INTERNAL_ERROR' });
+    } finally {
+      client.release();
     }
   },
 );

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -1,28 +1,10 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { pool } from '../db';
 import logger from '../logger';
 import type { AuthUser } from '../auth/types';
+import { requireAuth, requireManager } from '../middleware/auth';
 
 export const dashboardRouter = Router();
-
-// ── Auth middleware helpers ──────────────────────────────────────────────────
-
-function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  if (!req.user) {
-    res.status(401).json({ error: 'UNAUTHORIZED' });
-    return;
-  }
-  next();
-}
-
-function requireManager(req: Request, res: Response, next: NextFunction): void {
-  const user = req.user as AuthUser | undefined;
-  if (!user || (user.role !== 'manager' && user.role !== 'admin')) {
-    res.status(403).json({ error: 'FORBIDDEN' });
-    return;
-  }
-  next();
-}
 
 // ── Filter helpers ───────────────────────────────────────────────────────────
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,18 +1,11 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { pool } from '../db';
 import logger from '../logger';
 import type { AuthUser } from '../auth/types';
+import { requireAuth } from '../middleware/auth';
 import { RETENTION_DAYS } from '../services/notifications';
 
 export const notificationRouter = Router();
-
-function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  if (!req.user) {
-    res.status(401).json({ error: 'UNAUTHORIZED' });
-    return;
-  }
-  next();
-}
 
 function buildMessage(type: string, vocTitle: string, newStatus?: string): string {
   if (type === 'comment') return `"${vocTitle}" VOC에 새 댓글이 달렸습니다.`;
@@ -22,21 +15,11 @@ function buildMessage(type: string, vocTitle: string, newStatus?: string): strin
   return '';
 }
 
-// GET /api/notifications — opening the panel marks all as read in bulk (spec §8.14).
+// GET /api/notifications — returns recent notifications (read-only, spec §8.14 bulk-read is explicit via PATCH /read-all)
 notificationRouter.get('/', requireAuth, async (req: Request, res: Response): Promise<void> => {
   const user = req.user as AuthUser;
 
   try {
-    // 1. Bulk-mark all unread as read for this user.
-    await pool.query(
-      `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
-      [user.id],
-    );
-
-    // 2. Select recent notifications, excluding soft-deleted VOCs and notifications
-    //    that have been read for more than RETENTION_DAYS days.
-    //    NOTE: status_change messages currently use the VOC's *current* status from the
-    //    join — point-in-time accuracy is a known limitation (no metadata column yet).
     const result = await pool.query(
       `SELECT n.id, n.user_id, n.type, n.voc_id,
               n.read_at IS NOT NULL AS is_read,
@@ -83,6 +66,25 @@ notificationRouter.get('/', requireAuth, async (req: Request, res: Response): Pr
   }
 });
 
+// PATCH /api/notifications/read-all — idempotent bulk mark-as-read (R7-7: split from GET)
+notificationRouter.patch(
+  '/read-all',
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    try {
+      await pool.query(
+        `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
+        [user.id],
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error({ err }, 'PATCH /api/notifications/read-all failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);
+
 // GET /api/notifications/unread-count
 notificationRouter.get(
   '/unread-count',
@@ -109,7 +111,6 @@ notificationRouter.get(
       const count = typeof row.count === 'string' ? parseInt(row.count, 10) : (row.count ?? 0);
       const maxTs = row.max_ts == null ? '0' : String(row.max_ts);
       const hasUrgent = row.has_urgent ?? false;
-      // ETag includes max_ts so a new alert with the same count still busts caches.
       const etag = `W/"${count}-${maxTs}"`;
 
       const ifNoneMatch = req.headers['if-none-match'];
@@ -127,7 +128,7 @@ notificationRouter.get(
   },
 );
 
-// PATCH /api/notifications/:id/read — idempotent, only flips when still unread.
+// PATCH /api/notifications/:id/read — idempotent single-notification mark-as-read
 notificationRouter.patch(
   '/:id/read',
   requireAuth,
@@ -151,7 +152,6 @@ notificationRouter.patch(
         return;
       }
 
-      // Idempotent: only update unread rows; already-read rows preserve their original read_at.
       await pool.query(
         `UPDATE notifications SET read_at = NOW() WHERE id = $1 AND user_id = $2 AND read_at IS NULL`,
         [id, user.id],

--- a/backend/src/routes/payload.ts
+++ b/backend/src/routes/payload.ts
@@ -1,0 +1,355 @@
+import { Router, Request, Response } from 'express';
+import { pool } from '../db';
+import logger from '../logger';
+import type { AuthUser } from '../auth/types';
+import { requireAuth, requireManager } from '../middleware/auth';
+import { masterCache } from '../services/masterCache';
+import { STATUS_TRANSITIONS } from '../utils/voc';
+
+export const payloadRouter = Router({ mergeParams: true });
+
+// ── POST /api/vocs/:id/payload ────────────────────────────────────────────────
+
+payloadRouter.post(
+  '/:id/payload',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    const {
+      equipment,
+      maker,
+      model,
+      process: proc,
+      symptom,
+      root_cause,
+      resolution,
+      status: newStatus,
+    } = req.body as {
+      equipment?: string;
+      maker?: string;
+      model?: string;
+      process?: string;
+      symptom?: string;
+      root_cause?: string;
+      resolution?: string;
+      status?: string;
+      unverified_fields?: string[];
+    };
+
+    if (!symptom?.trim() || !root_cause?.trim() || !resolution?.trim()) {
+      res.status(400).json({ error: 'VALIDATION_FAILED' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { rows } = await client.query(
+        `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+        [id],
+      );
+      if (rows.length === 0) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const voc = rows[0] as {
+        status: string;
+        assignee_id: string | null;
+        review_status: string | null;
+      };
+
+      // MEDIUM-2: permission check before transition check to prevent info leakage.
+      if (user.role !== 'admin' && voc.assignee_id !== user.id) {
+        await client.query('ROLLBACK');
+        res.status(403).json({ error: 'FORBIDDEN' });
+        return;
+      }
+
+      // LOW-1: block submission while deletion is pending.
+      if (voc.review_status === 'pending_deletion') {
+        await client.query('ROLLBACK');
+        res.status(400).json({
+          error: 'INVALID_STATUS_FOR_PAYLOAD',
+          message: 'Cannot submit payload while deletion is pending',
+        });
+        return;
+      }
+
+      const effectiveStatus = newStatus ?? voc.status;
+      if (effectiveStatus !== '완료' && effectiveStatus !== '드랍') {
+        await client.query('ROLLBACK');
+        res.status(400).json({ error: 'INVALID_STATUS_FOR_PAYLOAD' });
+        return;
+      }
+      if (newStatus && !STATUS_TRANSITIONS[voc.status]?.includes(newStatus)) {
+        await client.query('ROLLBACK');
+        res.status(400).json({ error: 'INVALID_TRANSITION' });
+        return;
+      }
+
+      // M2: never trust FE's unverified_fields flags — BE recomputes via master cache (§16.3).
+      const payloadForVerify = { equipment, maker, model, process: proc };
+      const payload = {
+        equipment,
+        maker,
+        model,
+        process: proc,
+        symptom,
+        root_cause,
+        resolution,
+        unverified_fields: masterCache.verifyPayload(payloadForVerify),
+      };
+      const wasApproved = voc.review_status === 'approved';
+
+      await client.query(
+        `UPDATE voc_payload_history SET is_current = false WHERE voc_id = $1 AND is_current = true`,
+        [id],
+      );
+      const histResult = await client.query(
+        `INSERT INTO voc_payload_history (voc_id, payload, submitted_by, final_state, is_current)
+         VALUES ($1, $2, $3, 'active', true) RETURNING *`,
+        [id, JSON.stringify(payload), user.id],
+      );
+      await client.query(
+        `UPDATE vocs SET structured_payload = $1, review_status = 'unverified', embed_stale = $2,
+           status = COALESCE($3, status), updated_at = now() WHERE id = $4`,
+        [JSON.stringify(payload), wasApproved, newStatus ?? null, id],
+      );
+      await client.query('COMMIT');
+      res.json(histResult.rows[0]);
+    } catch (err: unknown) {
+      await client.query('ROLLBACK').catch(() => {});
+      if ((err as { code?: string }).code === '23505') {
+        res.status(409).json({ error: 'CONCURRENT_SUBMISSION' });
+        return;
+      }
+      logger.error({ err }, 'POST /api/vocs/:id/payload failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    } finally {
+      client.release();
+    }
+  },
+);
+
+// ── PATCH /api/vocs/:id/payload-draft ─────────────────────────────────────────
+
+payloadRouter.patch(
+  '/:id/payload-draft',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    const { draft } = req.body as { draft?: Record<string, unknown> };
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT id, status, assignee_id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
+        [id],
+      );
+      if (rows.length === 0) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const voc = rows[0] as { status: string; assignee_id: string | null };
+      if (user.role !== 'admin' && voc.assignee_id !== user.id) {
+        res.status(403).json({ error: 'FORBIDDEN' });
+        return;
+      }
+      if (voc.status !== '완료' && voc.status !== '드랍') {
+        res.status(400).json({ error: 'INVALID_STATUS_FOR_DRAFT' });
+        return;
+      }
+      const draftValue = draft && Object.keys(draft).length > 0 ? JSON.stringify(draft) : null;
+      await pool.query(
+        `UPDATE vocs SET structured_payload_draft = $1, updated_at = now() WHERE id = $2`,
+        [draftValue, id],
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error({ err }, 'PATCH /api/vocs/:id/payload-draft failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);
+
+// ── GET /api/vocs/:id/payload-history ─────────────────────────────────────────
+
+payloadRouter.get(
+  '/:id/payload-history',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    try {
+      const { rows } = await pool.query(
+        `SELECT id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
+        [id],
+      );
+      if (rows.length === 0) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const histResult = await pool.query(
+        `SELECT * FROM voc_payload_history WHERE voc_id = $1 ORDER BY submitted_at DESC`,
+        [id],
+      );
+      res.json(histResult.rows);
+    } catch (err) {
+      logger.error({ err }, 'GET /api/vocs/:id/payload-history failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);
+
+// ── POST /api/vocs/:id/payload-review ─────────────────────────────────────────
+
+payloadRouter.post(
+  '/:id/payload-review',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    const { decision, comment } = req.body as { decision?: string; comment?: string | null };
+
+    if (decision !== 'approved' && decision !== 'rejected') {
+      res.status(400).json({ error: 'VALIDATION_FAILED' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query(
+        `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+        [id],
+      );
+      if (rows.length === 0) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const voc = rows[0] as { review_status: string | null };
+      const rs = voc.review_status;
+      if (rs !== 'unverified' && rs !== 'pending_deletion') {
+        await client.query('ROLLBACK');
+        res.status(400).json({ error: 'INVALID_REVIEW_STATUS' });
+        return;
+      }
+
+      // MEDIUM-1: MVP self-review prevention
+      const histRow = await client.query(
+        `SELECT submitted_by FROM voc_payload_history WHERE voc_id = $1 AND is_current = true`,
+        [id],
+      );
+      if (histRow.rows.length > 0 && histRow.rows[0].submitted_by === user.id) {
+        await client.query('ROLLBACK');
+        res.status(403).json({ error: 'SELF_REVIEW_NOT_ALLOWED' });
+        return;
+      }
+
+      const action = rs === 'unverified' ? 'submission' : 'deletion';
+
+      await client.query(
+        `INSERT INTO voc_payload_reviews (voc_id, action, reviewer_id, decision, comment)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [id, action, user.id, decision, comment ?? null],
+      );
+
+      if (action === 'submission') {
+        if (decision === 'approved') {
+          await client.query(
+            `UPDATE vocs SET review_status = 'approved', embed_stale = false, updated_at = now() WHERE id = $1`,
+            [id],
+          );
+          await client.query(
+            `UPDATE voc_payload_history SET final_state = 'approved' WHERE voc_id = $1 AND is_current = true`,
+            [id],
+          );
+        } else {
+          await client.query(
+            `UPDATE vocs SET review_status = 'rejected', updated_at = now() WHERE id = $1`,
+            [id],
+          );
+          await client.query(
+            `UPDATE voc_payload_history SET final_state = 'rejected', is_current = false WHERE voc_id = $1 AND is_current = true`,
+            [id],
+          );
+        }
+      } else {
+        if (decision === 'approved') {
+          await client.query(
+            `UPDATE vocs SET structured_payload = NULL, review_status = NULL, updated_at = now() WHERE id = $1`,
+            [id],
+          );
+          await client.query(
+            `UPDATE voc_payload_history SET final_state = 'deleted', is_current = false WHERE voc_id = $1 AND is_current = true`,
+            [id],
+          );
+        } else {
+          await client.query(
+            `UPDATE vocs SET review_status = 'approved', updated_at = now() WHERE id = $1`,
+            [id],
+          );
+        }
+      }
+
+      await client.query('COMMIT');
+      res.json({ ok: true });
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      logger.error({ err }, 'POST /api/vocs/:id/payload-review failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    } finally {
+      client.release();
+    }
+  },
+);
+
+// ── POST /api/vocs/:id/payload-delete-request ─────────────────────────────────
+
+payloadRouter.post(
+  '/:id/payload-delete-request',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const { id } = req.params;
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const { rows } = await client.query(
+        `SELECT review_status FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+        [id],
+      );
+      if (rows.length === 0) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      if (rows[0].review_status !== 'approved') {
+        await client.query('ROLLBACK');
+        res
+          .status(400)
+          .json({ error: 'INVALID_STATUS', message: 'review_status must be approved' });
+        return;
+      }
+      await client.query(
+        `UPDATE vocs SET review_status = 'pending_deletion', updated_at = now() WHERE id = $1`,
+        [id],
+      );
+      await client.query('COMMIT');
+      res.json({ ok: true });
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      logger.error({ err }, 'POST /api/vocs/:id/payload-delete-request failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    } finally {
+      client.release();
+    }
+  },
+);

--- a/backend/src/routes/subtasks.ts
+++ b/backend/src/routes/subtasks.ts
@@ -1,0 +1,238 @@
+import { Router, Request, Response } from 'express';
+import { pool } from '../db';
+import logger from '../logger';
+import type { AuthUser } from '../auth/types';
+import { requireAuth, requireManager } from '../middleware/auth';
+import { applyTagRules } from '../services/autoTag';
+import { masterCache } from '../services/masterCache';
+import { calcDueDate } from '../utils/voc';
+
+export const subtasksRouter = Router({ mergeParams: true });
+
+// ── GET /api/vocs/:id/subtasks ────────────────────────────────────────────────
+
+subtasksRouter.get(
+  '/:id/subtasks',
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    try {
+      // R7-1: verify parent exists and enforce ownership for user role
+      const parent = await pool.query(
+        `SELECT id, author_id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
+        [id],
+      );
+      if (parent.rowCount === 0) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      if (user.role === 'user' && (parent.rows[0] as { author_id: string }).author_id !== user.id) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const { rows } = await pool.query(
+        `SELECT * FROM vocs WHERE parent_id = $1 AND deleted_at IS NULL ORDER BY created_at ASC`,
+        [id],
+      );
+      res.json(rows);
+    } catch (err) {
+      logger.error({ err }, 'GET /api/vocs/:id/subtasks failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);
+
+// ── POST /api/vocs/:id/subtasks ───────────────────────────────────────────────
+
+subtasksRouter.post(
+  '/:id/subtasks',
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    const { title, body, priority, voc_type_id, assignee_id } = req.body as {
+      title?: string;
+      body?: string;
+      priority?: string;
+      voc_type_id?: string;
+      assignee_id?: string;
+    };
+
+    if (!title || !title.trim()) {
+      res.status(400).json({ error: 'VALIDATION_FAILED' });
+      return;
+    }
+    if (!voc_type_id) {
+      res.status(400).json({ error: 'VALIDATION_FAILED' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { rows: parentRows } = await client.query(
+        `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
+        [id],
+      );
+      if (parentRows.length === 0) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const parent = parentRows[0] as {
+        id: string;
+        parent_id: string | null;
+        issue_code: string;
+        system_id: string;
+        menu_id: string;
+      };
+
+      if (parent.parent_id) {
+        await client.query('ROLLBACK');
+        res.status(400).json({ error: 'SUBTASK_NESTING_NOT_ALLOWED' });
+        return;
+      }
+
+      const { rows: typeRows } = await client.query(
+        `SELECT id FROM voc_types WHERE id = $1 AND is_archived = false`,
+        [voc_type_id],
+      );
+      if (!typeRows[0]) {
+        await client.query('ROLLBACK');
+        res.status(400).json({ error: 'INVALID_VOC_TYPE' });
+        return;
+      }
+
+      if (assignee_id) {
+        const { rows: userRows } = await client.query(`SELECT id FROM users WHERE id = $1`, [
+          assignee_id,
+        ]);
+        if (!userRows[0]) {
+          await client.query('ROLLBACK');
+          res.status(400).json({ error: 'INVALID_ASSIGNEE' });
+          return;
+        }
+      }
+
+      const { rows: countRows } = await client.query(
+        `SELECT COUNT(*)::int + 1 AS next_n FROM vocs WHERE parent_id = $1`,
+        [id],
+      );
+      const nextN = countRows[0].next_n as number;
+      const issueCode = `${parent.issue_code}-${nextN}`;
+      const effectivePriority = priority ?? 'medium';
+      const dueDate = calcDueDate(effectivePriority);
+
+      const { rows: createdRows } = await client.query(
+        `INSERT INTO vocs (title, body, status, priority, author_id, system_id, menu_id, voc_type_id, assignee_id, parent_id, issue_code, sequence_no, due_date, source)
+         VALUES ($1, $2, '접수', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'manual')
+         RETURNING *`,
+        [
+          title,
+          body ?? '',
+          effectivePriority,
+          user.id,
+          parent.system_id,
+          parent.menu_id,
+          voc_type_id,
+          assignee_id ?? null,
+          id,
+          issueCode,
+          nextN,
+          dueDate,
+        ],
+      );
+
+      await client.query('COMMIT');
+
+      const created = createdRows[0] as { id: string; title: string; body: string | null };
+
+      applyTagRules(created.id, created.title, created.body ?? '', pool).catch((err) =>
+        logger.warn({ err }, 'subtask auto-tag failed'),
+      );
+
+      res.status(201).json(created);
+    } catch (err: unknown) {
+      await client.query('ROLLBACK');
+      if ((err as { code?: string }).code === '23505') {
+        res.status(409).json({ error: 'CONCURRENT_SUBTASK_CREATION' });
+        return;
+      }
+      logger.error({ err }, 'POST /api/vocs/:id/subtasks failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    } finally {
+      client.release();
+    }
+  },
+);
+
+// ── GET /api/vocs/:id/incomplete-subtasks ─────────────────────────────────────
+
+subtasksRouter.get(
+  '/:id/incomplete-subtasks',
+  requireAuth,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    const { id } = req.params;
+    try {
+      // R7-1: verify parent exists and enforce ownership for user role
+      const parent = await pool.query(
+        `SELECT id, author_id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
+        [id],
+      );
+      if (parent.rowCount === 0) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      if (user.role === 'user' && (parent.rows[0] as { author_id: string }).author_id !== user.id) {
+        res.status(404).json({ error: 'NOT_FOUND' });
+        return;
+      }
+      const { rows } = await pool.query(
+        `SELECT COUNT(*)::int AS count FROM vocs
+         WHERE parent_id = $1 AND deleted_at IS NULL AND status NOT IN ('완료','드랍')`,
+        [id],
+      );
+      res.json({ count: rows[0].count });
+    } catch (err) {
+      logger.error({ err }, 'GET /api/vocs/:id/incomplete-subtasks failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);
+
+// ── POST /api/vocs/:id/masters/refresh ──────────────────────────────────────
+
+subtasksRouter.post(
+  '/:id/masters/refresh',
+  requireAuth,
+  requireManager,
+  async (req: Request, res: Response): Promise<void> => {
+    const user = req.user as AuthUser;
+    try {
+      const result = await masterCache.refresh(user.id);
+      if (!result.swapped) {
+        res.status(503).json(result);
+        return;
+      }
+      res.json(result);
+    } catch (err: unknown) {
+      if (
+        err !== null &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code: string }).code === 'RATE_LIMITED'
+      ) {
+        res.status(429).json({
+          error: 'RATE_LIMITED',
+          retryAfter: (err as unknown as { retryAfter: number }).retryAfter,
+        });
+        return;
+      }
+      logger.error({ err }, 'POST /api/vocs/:id/masters/refresh failed');
+      res.status(500).json({ error: 'INTERNAL_ERROR' });
+    }
+  },
+);

--- a/backend/src/routes/vocs.ts
+++ b/backend/src/routes/vocs.ts
@@ -1,53 +1,15 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { pool } from '../db';
 import logger from '../logger';
 import type { AuthUser } from '../auth/types';
+import { requireAuth, requireManager } from '../middleware/auth';
 import { applyTagRules } from '../services/autoTag';
 import { emitNotification } from '../services/notifications';
-import { masterCache } from '../services/masterCache';
+import { calcDueDate, STATUS_TRANSITIONS } from '../utils/voc';
+import { subtasksRouter } from './subtasks';
+import { payloadRouter } from './payload';
 
 export const vocRouter = Router();
-
-const DUE_DATE_DAYS: Record<string, number> = {
-  urgent: 7,
-  high: 14,
-  medium: 30,
-  low: 90,
-};
-
-const STATUS_TRANSITIONS: Record<string, string[]> = {
-  접수: ['검토중', '드랍'],
-  검토중: ['처리중', '드랍'],
-  처리중: ['완료', '드랍'],
-  완료: ['처리중'],
-  드랍: ['검토중', '처리중'],
-};
-
-// ── Auth middleware helpers ──────────────────────────────────────────────────
-
-function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  if (!req.user) {
-    res.status(401).json({ error: 'UNAUTHORIZED' });
-    return;
-  }
-  next();
-}
-
-function requireManager(req: Request, res: Response, next: NextFunction): void {
-  const user = req.user as AuthUser | undefined;
-  if (!user || (user.role !== 'manager' && user.role !== 'admin')) {
-    res.status(403).json({ error: 'FORBIDDEN' });
-    return;
-  }
-  next();
-}
-
-function calcDueDate(priority: string): string {
-  const days = DUE_DATE_DAYS[priority] ?? 30;
-  const d = new Date();
-  d.setDate(d.getDate() + days);
-  return d.toISOString(); // UTC 'Z' format — avoids local-timezone offset strings that confuse pg-mem
-}
 
 // ── GET /api/vocs ─────────────────────────────────────────────────────────────
 
@@ -79,7 +41,6 @@ vocRouter.get('/', requireAuth, async (req: Request, res: Response): Promise<voi
   const params: unknown[] = [];
   let idx = 1;
 
-  // Role-based filter
   if (user.role === 'user') {
     conditions.push(`v.author_id = $${idx++}`);
     params.push(user.id);
@@ -199,7 +160,6 @@ vocRouter.get('/:id', requireAuth, async (req: Request, res: Response): Promise<
 
     const voc = result.rows[0] as { author_id: string };
 
-    // User can only access their own VOCs
     if (user.role === 'user' && voc.author_id !== user.id) {
       res.status(404).json({ error: 'NOT_FOUND' });
       return;
@@ -242,10 +202,7 @@ vocRouter.patch('/:id', requireAuth, async (req: Request, res: Response): Promis
     }
 
     // M2: Sub-task system_id/menu_id are immutable
-    const patchBody = req.body as {
-      system_id?: string;
-      menu_id?: string;
-    };
+    const patchBody = req.body as { system_id?: string; menu_id?: string };
     if (voc.parent_id && (patchBody.system_id !== undefined || patchBody.menu_id !== undefined)) {
       res.status(400).json({ error: 'SUBTASK_SYSTEM_MENU_IMMUTABLE' });
       return;
@@ -265,7 +222,6 @@ vocRouter.patch('/:id', requireAuth, async (req: Request, res: Response): Promis
     const params: unknown[] = [];
     let idx = 1;
 
-    // User: only title and body
     if (title !== undefined) {
       updates.push(`title = $${idx++}`);
       params.push(title);
@@ -275,7 +231,6 @@ vocRouter.patch('/:id', requireAuth, async (req: Request, res: Response): Promis
       params.push(body);
     }
 
-    // Manager/Admin: additional fields
     if (user.role === 'manager' || user.role === 'admin') {
       if (assignee_id !== undefined) {
         updates.push(`assignee_id = $${idx++}`);
@@ -285,7 +240,6 @@ vocRouter.patch('/:id', requireAuth, async (req: Request, res: Response): Promis
         updates.push(`priority = $${idx++}`);
         params.push(priority);
       }
-      // due_date: explicit value wins; otherwise recalculate from priority change
       if (due_date !== undefined) {
         updates.push(`due_date = $${idx++}`);
         params.push(due_date);
@@ -321,7 +275,6 @@ vocRouter.patch('/:id', requireAuth, async (req: Request, res: Response): Promis
         logger.warn({ err }, 'auto-tag failed on patch'),
       );
     }
-    // fire-and-forget: notify new assignee — skip self-assign and no-op re-assignments.
     if (
       assignee_id !== undefined &&
       updated.assignee_id &&
@@ -346,7 +299,7 @@ vocRouter.patch(
   requireManager,
   async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
-    const { status } = req.body as { status?: string; comment?: string };
+    const { status } = req.body as { status?: string };
 
     if (!status) {
       res.status(400).json({ error: 'MISSING_STATUS' });
@@ -379,7 +332,6 @@ vocRouter.patch(
       const updatedVoc = result.rows[0] as { author_id: string };
       res.json(result.rows[0]);
 
-      // fire-and-forget: notify VOC author of status change
       emitNotification({
         pool,
         userId: updatedVoc.author_id,
@@ -389,364 +341,6 @@ vocRouter.patch(
     } catch (err) {
       logger.error({ err }, 'PATCH /api/vocs/:id/status failed');
       res.status(500).json({ error: 'INTERNAL_ERROR' });
-    }
-  },
-);
-
-// ── POST /api/vocs/:id/payload ────────────────────────────────────────────────
-
-vocRouter.post(
-  '/:id/payload',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const user = req.user as AuthUser;
-    const { id } = req.params;
-    const {
-      equipment,
-      maker,
-      model,
-      process: proc,
-      symptom,
-      root_cause,
-      resolution,
-      status: newStatus,
-    } = req.body as {
-      equipment?: string;
-      maker?: string;
-      model?: string;
-      process?: string;
-      symptom?: string;
-      root_cause?: string;
-      resolution?: string;
-      status?: string;
-      unverified_fields?: string[];
-    };
-
-    if (!symptom?.trim() || !root_cause?.trim() || !resolution?.trim()) {
-      res.status(400).json({ error: 'VALIDATION_FAILED' });
-      return;
-    }
-
-    const client = await pool.connect();
-    try {
-      await client.query('BEGIN');
-
-      // C2: row-level lock to serialize concurrent payload submissions on the same VOC.
-      const { rows } = await client.query(
-        `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'NOT_FOUND' });
-        return;
-      }
-      const voc = rows[0] as {
-        status: string;
-        assignee_id: string | null;
-        review_status: string | null;
-      };
-
-      // MEDIUM-2: permission check before transition check to prevent info leakage.
-      if (user.role !== 'admin' && voc.assignee_id !== user.id) {
-        await client.query('ROLLBACK');
-        res.status(403).json({ error: 'FORBIDDEN' });
-        return;
-      }
-
-      // LOW-1: block submission while deletion is pending.
-      if (voc.review_status === 'pending_deletion') {
-        await client.query('ROLLBACK');
-        res
-          .status(400)
-          .json({
-            error: 'INVALID_STATUS_FOR_PAYLOAD',
-            message: 'Cannot submit payload while deletion is pending',
-          });
-        return;
-      }
-
-      // M1: status may be transitioned together with payload submission.
-      const effectiveStatus = newStatus ?? voc.status;
-      if (effectiveStatus !== '완료' && effectiveStatus !== '드랍') {
-        await client.query('ROLLBACK');
-        res.status(400).json({ error: 'INVALID_STATUS_FOR_PAYLOAD' });
-        return;
-      }
-      if (newStatus && !STATUS_TRANSITIONS[voc.status]?.includes(newStatus)) {
-        await client.query('ROLLBACK');
-        res.status(400).json({ error: 'INVALID_TRANSITION' });
-        return;
-      }
-
-      // M2: requirements.md §4 — never trust FE's unverified_fields flags.
-      // BE recomputes via external master cache (§16.3, Phase 7-10).
-      // §16.3: unverified_fields is part of structured_payload by spec design.
-      // FE display may be stale until next submit — acceptable per MVP spec.
-      const payloadForVerify = { equipment, maker, model, process: proc };
-      const payload = {
-        equipment,
-        maker,
-        model,
-        process: proc,
-        symptom,
-        root_cause,
-        resolution,
-        unverified_fields: masterCache.verifyPayload(payloadForVerify),
-      };
-      // M5: wasApproved derived from the FOR UPDATE row inside the transaction.
-      const wasApproved = voc.review_status === 'approved';
-
-      await client.query(
-        `UPDATE voc_payload_history SET is_current = false WHERE voc_id = $1 AND is_current = true`,
-        [id],
-      );
-      const histResult = await client.query(
-        `INSERT INTO voc_payload_history (voc_id, payload, submitted_by, final_state, is_current)
-         VALUES ($1, $2, $3, 'active', true) RETURNING *`,
-        [id, JSON.stringify(payload), user.id],
-      );
-      await client.query(
-        `UPDATE vocs SET structured_payload = $1, review_status = 'unverified', embed_stale = $2,
-           status = COALESCE($3, status), updated_at = now() WHERE id = $4`,
-        [JSON.stringify(payload), wasApproved, newStatus ?? null, id],
-      );
-      await client.query('COMMIT');
-      res.json(histResult.rows[0]);
-    } catch (err: unknown) {
-      await client.query('ROLLBACK').catch(() => {});
-      // C2: UNIQUE INDEX on voc_payload_history(voc_id) WHERE is_current=true
-      // can still race in transaction overlap; surface 409 instead of 500.
-      if ((err as { code?: string }).code === '23505') {
-        res.status(409).json({ error: 'CONCURRENT_SUBMISSION' });
-        return;
-      }
-      logger.error({ err }, 'POST /api/vocs/:id/payload failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    } finally {
-      client.release();
-    }
-  },
-);
-
-// ── PATCH /api/vocs/:id/payload-draft ─────────────────────────────────────────
-
-vocRouter.patch(
-  '/:id/payload-draft',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const user = req.user as AuthUser;
-    const { id } = req.params;
-    const { draft } = req.body as { draft?: Record<string, unknown> };
-
-    try {
-      const { rows } = await pool.query(
-        `SELECT id, status, assignee_id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
-        [id],
-      );
-      if (rows.length === 0) {
-        res.status(404).json({ error: 'NOT_FOUND' });
-        return;
-      }
-      const voc = rows[0] as { status: string; assignee_id: string | null };
-      if (user.role !== 'admin' && voc.assignee_id !== user.id) {
-        res.status(403).json({ error: 'FORBIDDEN' });
-        return;
-      }
-      // M4: draft only meaningful while VOC is in a payload-eligible state.
-      if (voc.status !== '완료' && voc.status !== '드랍') {
-        res.status(400).json({ error: 'INVALID_STATUS_FOR_DRAFT' });
-        return;
-      }
-      const draftValue = draft && Object.keys(draft).length > 0 ? JSON.stringify(draft) : null;
-      await pool.query(
-        `UPDATE vocs SET structured_payload_draft = $1, updated_at = now() WHERE id = $2`,
-        [draftValue, id],
-      );
-      res.json({ ok: true });
-    } catch (err) {
-      logger.error({ err }, 'PATCH /api/vocs/:id/payload-draft failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    }
-  },
-);
-
-// ── GET /api/vocs/:id/payload-history ─────────────────────────────────────────
-
-vocRouter.get(
-  '/:id/payload-history',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const { id } = req.params;
-    try {
-      const { rows } = await pool.query(
-        `SELECT id FROM vocs WHERE id = $1 AND deleted_at IS NULL`,
-        [id],
-      );
-      if (rows.length === 0) {
-        res.status(404).json({ error: 'NOT_FOUND' });
-        return;
-      }
-      const histResult = await pool.query(
-        `SELECT * FROM voc_payload_history WHERE voc_id = $1 ORDER BY submitted_at DESC`,
-        [id],
-      );
-      res.json(histResult.rows);
-    } catch (err) {
-      logger.error({ err }, 'GET /api/vocs/:id/payload-history failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    }
-  },
-);
-
-// ── POST /api/vocs/:id/payload-review ─────────────────────────────────────────
-
-vocRouter.post(
-  '/:id/payload-review',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const user = req.user as AuthUser;
-    const { id } = req.params;
-    const { decision, comment } = req.body as { decision?: string; comment?: string | null };
-
-    if (decision !== 'approved' && decision !== 'rejected') {
-      res.status(400).json({ error: 'VALIDATION_FAILED' });
-      return;
-    }
-
-    const client = await pool.connect();
-    try {
-      await client.query('BEGIN');
-      const { rows } = await client.query(
-        `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'NOT_FOUND' });
-        return;
-      }
-      const voc = rows[0] as { review_status: string | null };
-      const rs = voc.review_status;
-      if (rs !== 'unverified' && rs !== 'pending_deletion') {
-        await client.query('ROLLBACK');
-        res.status(400).json({ error: 'INVALID_REVIEW_STATUS' });
-        return;
-      }
-
-      // MEDIUM-1: MVP self-review prevention — check submitted_by against reviewer.
-      const histRow = await client.query(
-        `SELECT submitted_by FROM voc_payload_history WHERE voc_id = $1 AND is_current = true`,
-        [id],
-      );
-      if (histRow.rows.length > 0 && histRow.rows[0].submitted_by === user.id) {
-        await client.query('ROLLBACK');
-        res.status(403).json({ error: 'SELF_REVIEW_NOT_ALLOWED' });
-        return;
-      }
-
-      const action = rs === 'unverified' ? 'submission' : 'deletion';
-
-      await client.query(
-        `INSERT INTO voc_payload_reviews (voc_id, action, reviewer_id, decision, comment)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [id, action, user.id, decision, comment ?? null],
-      );
-
-      if (action === 'submission') {
-        if (decision === 'approved') {
-          await client.query(
-            `UPDATE vocs SET review_status = 'approved', embed_stale = false, updated_at = now() WHERE id = $1`,
-            [id],
-          );
-          await client.query(
-            `UPDATE voc_payload_history SET final_state = 'approved' WHERE voc_id = $1 AND is_current = true`,
-            [id],
-          );
-        } else {
-          await client.query(
-            `UPDATE vocs SET review_status = 'rejected', updated_at = now() WHERE id = $1`,
-            [id],
-          );
-          await client.query(
-            `UPDATE voc_payload_history SET final_state = 'rejected', is_current = false WHERE voc_id = $1 AND is_current = true`,
-            [id],
-          );
-        }
-      } else {
-        // deletion
-        if (decision === 'approved') {
-          await client.query(
-            `UPDATE vocs SET structured_payload = NULL, review_status = NULL, updated_at = now() WHERE id = $1`,
-            [id],
-          );
-          await client.query(
-            `UPDATE voc_payload_history SET final_state = 'deleted', is_current = false WHERE voc_id = $1 AND is_current = true`,
-            [id],
-          );
-        } else {
-          await client.query(
-            `UPDATE vocs SET review_status = 'approved', updated_at = now() WHERE id = $1`,
-            [id],
-          );
-        }
-      }
-
-      await client.query('COMMIT');
-      res.json({ ok: true });
-    } catch (err) {
-      await client.query('ROLLBACK').catch(() => {});
-      logger.error({ err }, 'POST /api/vocs/:id/payload-review failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    } finally {
-      client.release();
-    }
-  },
-);
-
-// ── POST /api/vocs/:id/payload-delete-request ─────────────────────────────────
-
-vocRouter.post(
-  '/:id/payload-delete-request',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const { id } = req.params;
-    const client = await pool.connect();
-    try {
-      await client.query('BEGIN');
-      const { rows } = await client.query(
-        `SELECT review_status FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'NOT_FOUND' });
-        return;
-      }
-      if (rows[0].review_status !== 'approved') {
-        await client.query('ROLLBACK');
-        res
-          .status(400)
-          .json({ error: 'INVALID_STATUS', message: 'review_status must be approved' });
-        return;
-      }
-      await client.query(
-        `UPDATE vocs SET review_status = 'pending_deletion', updated_at = now() WHERE id = $1`,
-        [id],
-      );
-      await client.query('COMMIT');
-      res.json({ ok: true });
-    } catch (err) {
-      await client.query('ROLLBACK').catch(() => {});
-      logger.error({ err }, 'POST /api/vocs/:id/payload-delete-request failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    } finally {
-      client.release();
     }
   },
 );
@@ -774,7 +368,6 @@ vocRouter.delete('/:id', requireAuth, async (req: Request, res: Response): Promi
 
     const voc = vocRows[0] as { id: string; author_id: string };
 
-    // C2: users may only delete their own VOCs; manager/admin can delete any
     if (user.role === 'user' && voc.author_id !== user.id) {
       await client.query('ROLLBACK');
       res.status(403).json({ error: 'FORBIDDEN' });
@@ -789,8 +382,6 @@ vocRouter.delete('/:id', requireAuth, async (req: Request, res: Response): Promi
     await client.query(`UPDATE vocs SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL`, [
       id,
     ]);
-
-    // Sub-task cascade soft delete
     await client.query(
       `UPDATE vocs SET deleted_at = NOW() WHERE parent_id = $1 AND deleted_at IS NULL`,
       [id],
@@ -807,209 +398,7 @@ vocRouter.delete('/:id', requireAuth, async (req: Request, res: Response): Promi
   }
 });
 
-// ── GET /api/vocs/:id/subtasks ────────────────────────────────────────────────
+// ── Sub-routers (R7-10) ───────────────────────────────────────────────────────
 
-vocRouter.get('/:id/subtasks', requireAuth, async (req: Request, res: Response): Promise<void> => {
-  const { id } = req.params;
-  try {
-    const parent = await pool.query(`SELECT id FROM vocs WHERE id = $1 AND deleted_at IS NULL`, [
-      id,
-    ]);
-    if (parent.rowCount === 0) {
-      res.status(404).json({ error: 'NOT_FOUND' });
-      return;
-    }
-    const { rows } = await pool.query(
-      `SELECT * FROM vocs WHERE parent_id = $1 AND deleted_at IS NULL ORDER BY created_at ASC`,
-      [id],
-    );
-    res.json(rows);
-  } catch (err) {
-    logger.error({ err }, 'GET /api/vocs/:id/subtasks failed');
-    res.status(500).json({ error: 'INTERNAL_ERROR' });
-  }
-});
-
-// ── POST /api/vocs/:id/subtasks ───────────────────────────────────────────────
-
-vocRouter.post('/:id/subtasks', requireAuth, async (req: Request, res: Response): Promise<void> => {
-  const user = req.user as AuthUser;
-  const { id } = req.params;
-  const { title, body, priority, voc_type_id, assignee_id } = req.body as {
-    title?: string;
-    body?: string;
-    priority?: string;
-    voc_type_id?: string;
-    assignee_id?: string;
-  };
-
-  if (!title || !title.trim()) {
-    res.status(400).json({ error: 'VALIDATION_FAILED' });
-    return;
-  }
-  if (!voc_type_id) {
-    res.status(400).json({ error: 'VALIDATION_FAILED' });
-    return;
-  }
-
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-
-    // Lock parent row to serialize concurrent sub-task creation
-    const { rows: parentRows } = await client.query(
-      `SELECT * FROM vocs WHERE id = $1 AND deleted_at IS NULL FOR UPDATE`,
-      [id],
-    );
-    if (parentRows.length === 0) {
-      await client.query('ROLLBACK');
-      res.status(404).json({ error: 'NOT_FOUND' });
-      return;
-    }
-    const parent = parentRows[0] as {
-      id: string;
-      parent_id: string | null;
-      issue_code: string;
-      system_id: string;
-      menu_id: string;
-    };
-
-    // 1-level limit
-    if (parent.parent_id) {
-      await client.query('ROLLBACK');
-      res.status(400).json({ error: 'SUBTASK_NESTING_NOT_ALLOWED' });
-      return;
-    }
-
-    // M4: voc_type_id existence check (inside transaction)
-    const { rows: typeRows } = await client.query(
-      `SELECT id FROM voc_types WHERE id = $1 AND is_archived = false`,
-      [voc_type_id],
-    );
-    if (!typeRows[0]) {
-      await client.query('ROLLBACK');
-      res.status(400).json({ error: 'INVALID_VOC_TYPE' });
-      return;
-    }
-
-    // M4: assignee_id existence check (if provided)
-    if (assignee_id) {
-      const { rows: userRows } = await client.query(`SELECT id FROM users WHERE id = $1`, [
-        assignee_id,
-      ]);
-      if (!userRows[0]) {
-        await client.query('ROLLBACK');
-        res.status(400).json({ error: 'INVALID_ASSIGNEE' });
-        return;
-      }
-    }
-
-    // Sequential numbering — include soft-deleted to prevent reuse
-    const { rows: countRows } = await client.query(
-      `SELECT COUNT(*)::int + 1 AS next_n FROM vocs WHERE parent_id = $1`,
-      [id],
-    );
-    const nextN = countRows[0].next_n as number;
-    const issueCode = `${parent.issue_code}-${nextN}`;
-    const effectivePriority = priority ?? 'medium';
-    const dueDate = calcDueDate(effectivePriority);
-
-    // Pre-populate sequence_no & issue_code so the BEFORE INSERT trigger (WHEN sequence_no IS NULL) does not fire.
-    const { rows: createdRows } = await client.query(
-      `INSERT INTO vocs (title, body, status, priority, author_id, system_id, menu_id, voc_type_id, assignee_id, parent_id, issue_code, sequence_no, due_date, source)
-         VALUES ($1, $2, '접수', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'manual')
-         RETURNING *`,
-      [
-        title,
-        body ?? '',
-        effectivePriority,
-        user.id,
-        parent.system_id,
-        parent.menu_id,
-        voc_type_id,
-        assignee_id ?? null,
-        id,
-        issueCode,
-        nextN,
-        dueDate,
-      ],
-    );
-
-    await client.query('COMMIT');
-
-    const created = createdRows[0] as { id: string; title: string; body: string | null };
-
-    // Sub-task auto-tagging — fire-and-forget outside transaction
-    applyTagRules(created.id, created.title, created.body ?? '', pool).catch((err) =>
-      logger.warn({ err }, 'subtask auto-tag failed'),
-    );
-
-    res.status(201).json(created);
-  } catch (err: unknown) {
-    await client.query('ROLLBACK');
-    if ((err as { code?: string }).code === '23505') {
-      res.status(409).json({ error: 'CONCURRENT_SUBTASK_CREATION' });
-      return;
-    }
-    logger.error({ err }, 'POST /api/vocs/:id/subtasks failed');
-    res.status(500).json({ error: 'INTERNAL_ERROR' });
-  } finally {
-    client.release();
-  }
-});
-
-// ── GET /api/vocs/:id/incomplete-subtasks ─────────────────────────────────────
-
-vocRouter.get(
-  '/:id/incomplete-subtasks',
-  requireAuth,
-  async (req: Request, res: Response): Promise<void> => {
-    const { id } = req.params;
-    try {
-      const { rows } = await pool.query(
-        `SELECT COUNT(*)::int AS count FROM vocs
-         WHERE parent_id = $1 AND deleted_at IS NULL AND status NOT IN ('완료','드랍')`,
-        [id],
-      );
-      res.json({ count: rows[0].count });
-    } catch (err) {
-      logger.error({ err }, 'GET /api/vocs/:id/incomplete-subtasks failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    }
-  },
-);
-
-// ── POST /api/vocs/:id/masters/refresh ──────────────────────────────────────
-// :id is accepted but ignored — triggers global master cache refresh (§16.3).
-
-vocRouter.post(
-  '/:id/masters/refresh',
-  requireAuth,
-  requireManager,
-  async (req: Request, res: Response): Promise<void> => {
-    const user = req.user as AuthUser;
-    try {
-      const result = await masterCache.refresh(user.id);
-      if (!result.swapped) {
-        res.status(503).json(result);
-        return;
-      }
-      res.json(result);
-    } catch (err: unknown) {
-      if (
-        err !== null &&
-        typeof err === 'object' &&
-        'code' in err &&
-        (err as { code: string }).code === 'RATE_LIMITED'
-      ) {
-        res.status(429).json({
-          error: 'RATE_LIMITED',
-          retryAfter: (err as unknown as { retryAfter: number }).retryAfter,
-        });
-        return;
-      }
-      logger.error({ err }, 'POST /api/vocs/:id/masters/refresh failed');
-      res.status(500).json({ error: 'INTERNAL_ERROR' });
-    }
-  },
-);
+vocRouter.use('/', subtasksRouter);
+vocRouter.use('/', payloadRouter);

--- a/backend/src/services/autoTag.ts
+++ b/backend/src/services/autoTag.ts
@@ -1,18 +1,46 @@
 import type { Pool } from 'pg';
 
+// R7-9: TTL cache for tag_rules — avoids a DB round-trip on every VOC save/edit
+interface RulesCacheEntry {
+  rules: Array<{ id: string; pattern: string; tag_id: string }>;
+  expiresAt: number;
+}
+
+const RULES_TTL_MS = 5 * 60 * 1000; // 5 min
+let rulesCache: RulesCacheEntry | null = null;
+
+async function getTagRules(
+  pool: Pool,
+): Promise<Array<{ id: string; pattern: string; tag_id: string }>> {
+  if (rulesCache && Date.now() < rulesCache.expiresAt) {
+    return rulesCache.rules;
+  }
+  const res = await pool.query(
+    `SELECT id, pattern, tag_id FROM tag_rules WHERE is_active = true ORDER BY sort_order ASC, created_at ASC`,
+  );
+  rulesCache = {
+    rules: res.rows as Array<{ id: string; pattern: string; tag_id: string }>,
+    expiresAt: Date.now() + RULES_TTL_MS,
+  };
+  return rulesCache.rules;
+}
+
+/** Invalidate the in-memory rules cache (call after tag_rules mutations). */
+export function invalidateTagRulesCache(): void {
+  rulesCache = null;
+}
+
 export async function applyTagRules(
   vocId: string,
   title: string,
   body: string,
   pool: Pool,
 ): Promise<void> {
-  const rulesRes = await pool.query(
-    `SELECT id, pattern, tag_id FROM tag_rules WHERE is_active = true ORDER BY sort_order ASC, created_at ASC`,
-  );
+  const rules = await getTagRules(pool); // R7-9: cached
   const text = `${title} ${body}`;
   const matchedTagIds = new Set<string>();
 
-  for (const rule of rulesRes.rows as { id: string; pattern: string; tag_id: string }[]) {
+  for (const rule of rules) {
     try {
       const re = new RegExp(rule.pattern, 'i');
       if (re.test(text)) {
@@ -23,24 +51,31 @@ export async function applyTagRules(
     }
   }
 
-  for (const tagId of matchedTagIds) {
+  // R7-8: batch INSERT via VALUES list instead of per-tag loop
+  if (matchedTagIds.size > 0) {
+    const tagIdArray = [...matchedTagIds];
+    const placeholders = tagIdArray.map((_, i) => `($1, $${i + 2}, 'rule')`).join(', ');
     await pool.query(
-      `INSERT INTO voc_tags (voc_id, tag_id, source) VALUES ($1, $2, 'rule')
+      `INSERT INTO voc_tags (voc_id, tag_id, source) VALUES ${placeholders}
        ON CONFLICT (voc_id, tag_id) DO NOTHING`,
-      [vocId, tagId],
+      [vocId, ...tagIdArray],
     );
   }
 
+  // Remove stale rule-sourced tags that no longer match
   const existing = await pool.query(
     `SELECT tag_id FROM voc_tags WHERE voc_id = $1 AND source = 'rule'`,
     [vocId],
   );
-  for (const row of existing.rows as { tag_id: string }[]) {
-    if (!matchedTagIds.has(row.tag_id)) {
-      await pool.query(
-        `DELETE FROM voc_tags WHERE voc_id = $1 AND tag_id = $2 AND source = 'rule'`,
-        [vocId, row.tag_id],
-      );
-    }
+  const toDelete = (existing.rows as { tag_id: string }[])
+    .map((r) => r.tag_id)
+    .filter((id) => !matchedTagIds.has(id));
+
+  if (toDelete.length > 0) {
+    const delPlaceholders = toDelete.map((_, i) => `$${i + 2}`).join(', ');
+    await pool.query(
+      `DELETE FROM voc_tags WHERE voc_id = $1 AND tag_id IN (${delPlaceholders}) AND source = 'rule'`,
+      [vocId, ...toDelete],
+    );
   }
 }

--- a/backend/src/services/masterCache.ts
+++ b/backend/src/services/masterCache.ts
@@ -34,7 +34,6 @@ export interface MasterState {
   loaded_at?: string;
 }
 
-// Payload shape used for verifyPayload
 export interface StructuredPayload {
   equipment?: string;
   maker?: string;
@@ -47,24 +46,56 @@ export interface StructuredPayload {
   [key: string]: unknown;
 }
 
+// R7-6: pre-computed normalized Sets for O(1) membership checks in verifyPayload
+interface VerifySets {
+  equipment: Set<string>;
+  maker: Set<string>;
+  model: Set<string>;
+  process: Set<string>;
+  db_tables: Set<string>;
+  jobs: Set<string>;
+  sps: Set<string>;
+  programs: Set<string>;
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const COOLDOWN_MS = 5 * 60 * 1000;
 
-// ── Stub loaders ──────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function normalize(s: string): string {
   return s.trim().toLowerCase();
 }
 
+// R7-6: build Sets once at cache-load time; reused on every verifyPayload call
+function buildVerifySets(state: MasterState): VerifySets {
+  const { equipment: eq, db, program: prog } = state;
+  return {
+    equipment: new Set((eq?.equipment ?? []).map(normalize)),
+    maker: new Set((eq?.maker ?? []).map(normalize)),
+    model: new Set((eq?.model ?? []).map(normalize)),
+    process: new Set((eq?.process ?? []).map(normalize)),
+    db_tables: new Set((db?.db_tables ?? []).map(normalize)),
+    jobs: new Set((db?.jobs ?? []).map(normalize)),
+    sps: new Set((db?.sps ?? []).map(normalize)),
+    programs: new Set((prog?.programs ?? []).map(normalize)),
+  };
+}
+
+// ── Stub loaders ──────────────────────────────────────────────────────────────
+
+// R7-3: async I/O — no blocking reads on the event loop
 async function loadFromStub(
   configDir: string,
 ): Promise<{ equipment: EquipmentCache; program: ProgramCache }> {
   const eqPath = path.join(configDir, 'equipment-stub.json');
   const progPath = path.join(configDir, 'programs.json');
 
-  const eqRaw = fs.readFileSync(eqPath, 'utf8');
-  const progRaw = fs.readFileSync(progPath, 'utf8');
+  const [eqRaw, progRaw] = await Promise.all([
+    fs.promises.readFile(eqPath, 'utf8'),
+    fs.promises.readFile(progPath, 'utf8'),
+  ]);
 
   const eq = JSON.parse(eqRaw) as {
     equipment: string[];
@@ -100,6 +131,9 @@ class MasterCacheService {
     mode: 'cold_start',
   };
 
+  // R7-6: pre-computed sets, rebuilt on every state swap
+  private verifySets: VerifySets = buildVerifySets(this.state);
+
   private lastRefreshByUser: Record<string, number> = {};
   private configDir: string;
 
@@ -115,25 +149,29 @@ class MasterCacheService {
       const db = await loadDbStub();
       const now = new Date().toISOString();
       this.state = { equipment, db, program, mode: 'live', loaded_at: now };
+      this.verifySets = buildVerifySets(this.state); // R7-6
       this.writeSnapshot().catch((err) =>
         logger.warn({ err }, 'masterCache: writeSnapshot failed (non-fatal)'),
       );
       return;
     } catch (err) {
-      console.warn('[masterCache] stub load failed, trying snapshot:', err);
+      // R7-4: structured logging
+      logger.warn({ err }, 'masterCache: stub load failed, trying snapshot');
     }
 
     try {
-      const snap = this.readSnapshot();
+      const snap = await this.readSnapshot(); // R7-3: async
       this.state = { ...snap, mode: 'snapshot' };
+      this.verifySets = buildVerifySets(this.state); // R7-6
       return;
     } catch (err) {
-      console.warn('[masterCache] snapshot load failed, falling back to cold_start:', err);
+      // R7-4: structured logging
+      logger.warn({ err }, 'masterCache: snapshot load failed, falling back to cold_start');
     }
 
-    // Only set cold_start if not already in a valid live/snapshot state
     if (this.state.mode === 'cold_start') {
       this.state = { equipment: null, db: null, program: null, mode: 'cold_start' };
+      this.verifySets = buildVerifySets(this.state); // R7-6
     }
   }
 
@@ -149,7 +187,6 @@ class MasterCacheService {
       }
     | { swapped: false; error: string; kept_loaded_at: string | undefined }
   > {
-    // GC expired cooldown entries
     const gcBefore = Date.now() - COOLDOWN_MS * 2;
     for (const [uid, ts] of Object.entries(this.lastRefreshByUser)) {
       if (ts < gcBefore) delete this.lastRefreshByUser[uid];
@@ -170,6 +207,7 @@ class MasterCacheService {
       const loaded_at = new Date().toISOString();
 
       this.state = { equipment, db, program, mode: 'live', loaded_at };
+      this.verifySets = buildVerifySets(this.state); // R7-6
       this.lastRefreshByUser[userId] = now;
 
       this.writeSnapshot().catch((err) =>
@@ -194,28 +232,26 @@ class MasterCacheService {
     }
   }
 
+  // R7-6: O(1) Set lookups instead of O(n) .map(normalize).includes() per call
   verifyPayload(payload: StructuredPayload): string[] {
     const unverified: string[] = [];
     const { equipment: eq, db, program: prog } = this.state;
+    const sets = this.verifySets;
 
-    // Equipment master fields
     if (!eq) {
       if (payload.equipment) unverified.push('equipment');
       if (payload.maker) unverified.push('maker');
       if (payload.model) unverified.push('model');
       if (payload.process) unverified.push('process');
     } else {
-      if (payload.equipment && !eq.equipment.map(normalize).includes(normalize(payload.equipment)))
+      if (payload.equipment && !sets.equipment.has(normalize(payload.equipment)))
         unverified.push('equipment');
-      if (payload.maker && !eq.maker.map(normalize).includes(normalize(payload.maker)))
-        unverified.push('maker');
-      if (payload.model && !eq.model.map(normalize).includes(normalize(payload.model)))
-        unverified.push('model');
-      if (payload.process && !eq.process.map(normalize).includes(normalize(payload.process)))
+      if (payload.maker && !sets.maker.has(normalize(payload.maker))) unverified.push('maker');
+      if (payload.model && !sets.model.has(normalize(payload.model))) unverified.push('model');
+      if (payload.process && !sets.process.has(normalize(payload.process)))
         unverified.push('process');
     }
 
-    // DB master fields
     const relDbTables = payload.related_db_tables;
     const relJobs = payload.related_jobs;
     const relSps = payload.related_sps;
@@ -224,20 +260,17 @@ class MasterCacheService {
       if (relJobs?.length) unverified.push('related_jobs');
       if (relSps?.length) unverified.push('related_sps');
     } else {
-      if (relDbTables?.some((v) => !db.db_tables.map(normalize).includes(normalize(v))))
+      if (relDbTables?.some((v) => !sets.db_tables.has(normalize(v))))
         unverified.push('related_db_tables');
-      if (relJobs?.some((v) => !db.jobs.map(normalize).includes(normalize(v))))
-        unverified.push('related_jobs');
-      if (relSps?.some((v) => !db.sps.map(normalize).includes(normalize(v))))
-        unverified.push('related_sps');
+      if (relJobs?.some((v) => !sets.jobs.has(normalize(v)))) unverified.push('related_jobs');
+      if (relSps?.some((v) => !sets.sps.has(normalize(v)))) unverified.push('related_sps');
     }
 
-    // Program master fields
     const relProgs = payload.related_programs;
     if (!prog) {
       if (relProgs?.length) unverified.push('related_programs');
     } else {
-      if (relProgs?.some((v) => !prog.programs.map(normalize).includes(normalize(v))))
+      if (relProgs?.some((v) => !sets.programs.has(normalize(v))))
         unverified.push('related_programs');
     }
 
@@ -292,9 +325,10 @@ class MasterCacheService {
     await fs.promises.rename(tmpPath, snapshotPath);
   }
 
-  private readSnapshot(): MasterState {
+  // R7-3: async readFile instead of blocking readFileSync
+  private async readSnapshot(): Promise<MasterState> {
     const snapshotPath = path.join(this.configDir, 'snapshot.json');
-    const raw = fs.readFileSync(snapshotPath, 'utf8');
+    const raw = await fs.promises.readFile(snapshotPath, 'utf8');
     return JSON.parse(raw) as MasterState;
   }
 }

--- a/backend/src/utils/voc.ts
+++ b/backend/src/utils/voc.ts
@@ -1,0 +1,22 @@
+export const DUE_DATE_DAYS: Record<string, number> = {
+  urgent: 7,
+  high: 14,
+  medium: 30,
+  low: 90,
+};
+
+export const STATUS_TRANSITIONS: Record<string, string[]> = {
+  접수: ['검토중', '드랍'],
+  검토중: ['처리중', '드랍'],
+  처리중: ['완료', '드랍'],
+  완료: ['처리중'],
+  드랍: ['검토중', '처리중'],
+};
+
+export function calcDueDate(priority: string): string {
+  const days = DUE_DATE_DAYS[priority] ?? 30;
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  // UTC 'Z' format — avoids local-timezone offset strings that confuse pg-mem
+  return d.toISOString();
+}

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -4,7 +4,7 @@
 
 → **`docs/specs/plans/next-session-tasks.md`** 참조 (전체 Phase 계획)
 
-현재 위치: Phase 0~6 ✅ / Phase 7-1 ✅ / 7-2/2a ✅ / 7-3 ✅ / 7-4 ✅ / 7-5 ✅ / 7-6 ✅ / 7-7 ✅ / 7-8 ✅ / 7-9 ✅ / 7-10 ✅ / 7-11 ✅ → **Phase 7 완료 → 다음: Phase 8 운영 실구현**
+현재 위치: Phase 0~6 ✅ / Phase 7 전체 ✅ (리뷰 완료 80/100 B+) → **다음: Phase 7 리뷰 결함 수정 R7-1~R7-7 → Phase 8 운영 실구현**
 
 브랜치: `feat/phase7-7-notifications` → main 머지 완료
 테스트: 17 suites, 227 passed, 0 failures

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -418,6 +418,33 @@ docs/specs/reviews/
 
 ---
 
+## Phase 7 리뷰 결함 수정 (2026-04-25 코드 리뷰 결과)
+
+> 리뷰 범위: `7c7b108..a579dda` (Phase 7-1 ~ 7-11 전체)
+> 종합 점수: **80/100 (B+)** — Critical 없음, Important 6건, 특이 API 설계 결함 1건
+> **Phase 8 착수 전** 아래 항목 처리 권장 (순서대로 우선순위)
+
+| ID   | 위치                                                        | 문제                                                                                                      | 심각도    |
+| ---- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------- |
+| R7-1 | `vocs.ts` — `GET /:id/subtasks`, `/:id/incomplete-subtasks` | `requireAuth`만 있고 부모 VOC 소유권 검증 없음 → 타 user의 subtask 조회 가능                              | Important |
+| R7-2 | `vocs.ts`, `admin.ts`, `notifications.ts`, `dashboard.ts`   | `requireAuth/Manager/Admin` 4파일 중복 정의 → `backend/src/middleware/auth.ts` 추출                       | Important |
+| R7-3 | `masterCache.ts:66-67`                                      | `fs.readFileSync` (동기 블로킹 I/O) → `fs.promises.readFile` 교체                                         | Important |
+| R7-4 | `masterCache.ts:123,131`                                    | `console.warn` → `logger.warn` (pino 구조화 로깅 불일치)                                                  | Important |
+| R7-5 | `admin.ts:76-88`                                            | system 생성 + 기본 메뉴("기타") 생성이 트랜잭션 없이 분리 → 고아 system 가능                              | Important |
+| R7-6 | `masterCache.verifyPayload`                                 | 매 호출마다 `eq.equipment.map(normalize)` 전체 변환 → 캐시 시점 Set 빌드로 O(1)화                         | Important |
+| R7-7 | `notifications.ts:33-36`                                    | `GET /api/notifications` 에서 `UPDATE` 실행 (멱등성 위반) → `PATCH /api/notifications/read-all` 분리 권장 | API 설계  |
+
+### 추가 개선 (여유 시 처리)
+
+| ID    | 내용                                                              |
+| ----- | ----------------------------------------------------------------- |
+| R7-8  | `autoTag.ts` 단건 INSERT 루프 → UNNEST 배치 INSERT                |
+| R7-9  | `autoTag.ts` tag_rules 조회 인메모리 캐싱                         |
+| R7-10 | `vocs.ts` 1015줄 → `routes/subtasks.ts`, `routes/payload.ts` 분리 |
+| R7-11 | `VocPage.tsx` React Query `staleTime` 명시적 설정 추가            |
+
+---
+
 ## Phase 8: 운영 실구현 + 배포
 
 > **목표**: production 준비 완료 + 실 환경 배포.

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -58,3 +58,12 @@ export async function markRead(id: string): Promise<void> {
   // 404 is acceptable (already-deleted notification); other failures bubble up.
   if (!res.ok && res.status !== 404) throw new Error('markRead failed');
 }
+
+// R7-7: explicit bulk mark-as-read — call when opening the notification panel
+export async function markAllRead(): Promise<void> {
+  const res = await fetch(`${BASE}/notifications/read-all`, {
+    method: 'PATCH',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('markAllRead failed');
+}

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,6 +1,12 @@
 import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
-import { AppNotification, getNotifications, getUnreadCount, markRead } from '../api/notifications';
+import {
+  AppNotification,
+  getNotifications,
+  getUnreadCount,
+  markRead,
+  markAllRead,
+} from '../api/notifications';
 
 export type { AppNotification };
 
@@ -42,9 +48,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
   const refetchPanel = useCallback(async () => {
     try {
+      // R7-7: explicit PATCH /read-all before fetching (GET is now read-only)
+      await markAllRead();
       const data = await getNotifications();
       setNotifications(data);
-      // Bulk-read happens server-side on this endpoint; reset unread state locally.
       setUnreadCount(0);
       setHasUrgentUnread(false);
     } catch (err) {


### PR DESCRIPTION
## Summary

- **R7-1**: GET /subtasks, GET /incomplete-subtasks — user role 소유권 검증 추가
- **R7-2**: requireAuth/requireManager 중복 제거 → `middleware/auth.ts` 추출
- **R7-3**: masterCache 동기 I/O → `fs.promises` 비동기 전환
- **R7-4**: console.warn → pino `logger.warn({ err }, ...)` 구조화 로깅
- **R7-5**: POST /systems — system+menu 생성 트랜잭션으로 묶음
- **R7-6**: verifyPayload O(n) array scan → Pre-computed Set O(1) 조회
- **R7-7**: GET /notifications 부수효과 제거 → PATCH /read-all 신규 엔드포인트
- **R7-8**: autoTag 배치 INSERT/DELETE (VALUES placeholder, pg-mem 호환)
- **R7-9**: tag_rules 5분 TTL 인메모리 캐시 추가
- **R7-10**: vocs.ts 분리 → subtasks.ts + payload.ts + utils/voc.ts

## Test plan

- [x] Backend: 17 suites, 229 passed (기존 227 → +2)
- [x] Frontend: 6 suites, 25 passed
- [x] TypeScript: FE + BE 모두 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)