### PR TITLE
Align VOC list UI with benchmark

### DIFF
--- a/backend/src/routes/subtasks.ts
+++ b/backend/src/routes/subtasks.ts
@@ -6,6 +6,7 @@ import { requireAuth, requireManager } from '../middleware/auth';
 import { applyTagRules } from '../services/autoTag';
 import { masterCache } from '../services/masterCache';
 import { calcDueDate } from '../utils/voc';
+import { attachListMetadata, hasParentIdColumn } from './vocMetadata';
 
 export const subtasksRouter = Router({ mergeParams: true });
 
@@ -31,11 +32,31 @@ subtasksRouter.get(
         res.status(404).json({ error: 'NOT_FOUND' });
         return;
       }
+      if (!(await hasParentIdColumn())) {
+        res.json([]);
+        return;
+      }
       const { rows } = await pool.query(
-        `SELECT * FROM vocs WHERE parent_id = $1 AND deleted_at IS NULL ORDER BY created_at ASC`,
+        `SELECT v.*,
+                u.display_name AS assignee_name,
+                au.display_name AS author_name,
+                vt.name AS voc_type_name,
+                s.name AS system_name,
+                m.name AS menu_name
+         FROM vocs v
+         LEFT JOIN users u ON v.assignee_id = u.id
+         LEFT JOIN users au ON v.author_id = au.id
+         LEFT JOIN voc_types vt ON v.voc_type_id = vt.id
+         LEFT JOIN systems s ON v.system_id = s.id
+         LEFT JOIN menus m ON v.menu_id = m.id
+         WHERE v.parent_id = $1 AND v.deleted_at IS NULL
+         ORDER BY v.created_at ASC`,
         [id],
       );
-      res.json(rows);
+      const subtasks = await attachListMetadata(
+        rows as Array<Record<string, unknown> & { id: string }>,
+      );
+      res.json(subtasks);
     } catch (err) {
       logger.error({ err }, 'GET /api/vocs/:id/subtasks failed');
       res.status(500).json({ error: 'INTERNAL_ERROR' });

--- a/backend/src/routes/vocMetadata.ts
+++ b/backend/src/routes/vocMetadata.ts
@@ -1,0 +1,67 @@
+import { pool } from '../db';
+
+export type VocRow = Record<string, unknown> & { id: string };
+
+let hasParentIdColumnCache: boolean | null = null;
+
+export async function hasParentIdColumn(): Promise<boolean> {
+  if (hasParentIdColumnCache !== null) return hasParentIdColumnCache;
+
+  try {
+    await pool.query('SELECT parent_id FROM vocs LIMIT 0');
+    hasParentIdColumnCache = true;
+  } catch (err) {
+    if ((err as { code?: string }).code === '42703') {
+      hasParentIdColumnCache = false;
+    } else {
+      throw err;
+    }
+  }
+
+  return hasParentIdColumnCache;
+}
+
+export async function attachListMetadata(rows: VocRow[]): Promise<VocRow[]> {
+  if (rows.length === 0) return rows;
+
+  const ids = rows.map((row) => row.id);
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(',');
+  const canUseParentId = await hasParentIdColumn();
+
+  const [countResult, tagResult] = await Promise.all([
+    canUseParentId
+      ? pool.query(
+          `SELECT parent_id, COUNT(*)::int AS count
+           FROM vocs
+           WHERE parent_id IN (${placeholders}) AND deleted_at IS NULL
+           GROUP BY parent_id`,
+          ids,
+        )
+      : Promise.resolve({ rows: [] }),
+    pool.query(
+      `SELECT vtg.voc_id, t.id, t.name
+       FROM voc_tags vtg
+       JOIN tags t ON vtg.tag_id = t.id
+       WHERE vtg.voc_id IN (${placeholders})`,
+      ids,
+    ),
+  ]);
+
+  const counts = new Map<string, number>();
+  countResult.rows.forEach((row: { parent_id: string; count: number }) => {
+    counts.set(row.parent_id, row.count);
+  });
+
+  const tags = new Map<string, Array<{ id: string; name: string }>>();
+  tagResult.rows.forEach((row: { voc_id: string; id: string; name: string }) => {
+    const vocTags = tags.get(row.voc_id) ?? [];
+    vocTags.push({ id: row.id, name: row.name });
+    tags.set(row.voc_id, vocTags);
+  });
+
+  return rows.map((row) => ({
+    ...row,
+    subtask_count: counts.get(row.id) ?? 0,
+    tags: tags.get(row.id) ?? [],
+  }));
+}

--- a/backend/src/routes/vocs.ts
+++ b/backend/src/routes/vocs.ts
@@ -8,6 +8,7 @@ import { emitNotification } from '../services/notifications';
 import { STATUS_TRANSITIONS } from '../utils/voc';
 import { subtasksRouter } from './subtasks';
 import { payloadRouter } from './payload';
+import { attachListMetadata, hasParentIdColumn, type VocRow } from './vocMetadata';
 
 export const vocRouter = Router();
 
@@ -38,7 +39,11 @@ vocRouter.get('/', requireAuth, async (req: Request, res: Response): Promise<voi
   const sortCol = allowedSorts.includes(sort ?? '') ? sort : 'created_at';
   const orderDir = order === 'asc' ? 'ASC' : 'DESC';
 
+  const canUseParentId = await hasParentIdColumn();
   const conditions: string[] = ['v.deleted_at IS NULL'];
+  if (canUseParentId) {
+    conditions.push('v.parent_id IS NULL');
+  }
   const params: unknown[] = [];
   let idx = 1;
 
@@ -98,22 +103,17 @@ vocRouter.get('/', requireAuth, async (req: Request, res: Response): Promise<voi
     const total = parseInt(countResult.rows[0].count, 10);
 
     const dataResult = await pool.query(
-      `SELECT v.*, u.display_name AS assignee_name, vt.name AS voc_type_name,
-              COALESCE(
-                json_agg(json_build_object('id', t.id, 'name', t.name)) FILTER (WHERE t.id IS NOT NULL),
-                '[]'
-              ) AS tags
+      `SELECT v.*, u.display_name AS assignee_name, vt.name AS voc_type_name
        FROM vocs v
        LEFT JOIN users u ON v.assignee_id = u.id
        LEFT JOIN voc_types vt ON v.voc_type_id = vt.id
-       LEFT JOIN voc_tags vtg ON v.id = vtg.voc_id
-       LEFT JOIN tags t ON vtg.tag_id = t.id
-       ${where} GROUP BY v.id, u.display_name, vt.name
+       ${where}
        ORDER BY v.${sortCol} ${orderDir} LIMIT $${idx} OFFSET $${idx + 1}`,
       [...params, limitNum, offset],
     );
 
-    res.json({ data: dataResult.rows, total, page: pageNum, limit: limitNum });
+    const data = await attachListMetadata(dataResult.rows as VocRow[]);
+    res.json({ data, total, page: pageNum, limit: limitNum });
   } catch (err) {
     logger.error({ err }, 'GET /api/vocs failed');
     res.status(500).json({ error: 'INTERNAL_ERROR' });
@@ -172,21 +172,14 @@ vocRouter.get('/:id', requireAuth, async (req: Request, res: Response): Promise<
               au.display_name AS author_name,
               vt.name AS voc_type_name,
               s.name AS system_name,
-              m.name AS menu_name,
-              COALESCE(
-                json_agg(json_build_object('id', t.id, 'name', t.name)) FILTER (WHERE t.id IS NOT NULL),
-                '[]'
-              ) AS tags
+              m.name AS menu_name
        FROM vocs v
        LEFT JOIN users u ON v.assignee_id = u.id
        LEFT JOIN users au ON v.author_id = au.id
        LEFT JOIN voc_types vt ON v.voc_type_id = vt.id
        LEFT JOIN systems s ON v.system_id = s.id
        LEFT JOIN menus m ON v.menu_id = m.id
-       LEFT JOIN voc_tags vtg ON v.id = vtg.voc_id
-       LEFT JOIN tags t ON vtg.tag_id = t.id
-       WHERE v.id = $1 AND v.deleted_at IS NULL
-       GROUP BY v.id, u.display_name, au.display_name, vt.name, s.name, m.name`,
+       WHERE v.id = $1 AND v.deleted_at IS NULL`,
       [id],
     );
 
@@ -195,7 +188,9 @@ vocRouter.get('/:id', requireAuth, async (req: Request, res: Response): Promise<
       return;
     }
 
-    const voc = result.rows[0] as { author_id: string };
+    const [voc] = (await attachListMetadata(result.rows as VocRow[])) as Array<
+      VocRow & { author_id: string }
+    >;
 
     if (user.role === 'user' && voc.author_id !== user.id) {
       res.status(404).json({ error: 'NOT_FOUND' });

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -4,14 +4,21 @@
 
 → **`docs/specs/plans/next-session-tasks.md`** 참조 (전체 Phase 계획)
 
-현재 위치: Phase 0~8 ✅ 완료 → 네비바/상태배지 버그픽스 PR #41 merge 완료 → **Phase 9 운영 실구현 + 배포 대기**
+현재 위치: Phase 0~8 ✅ 완료 → 네비바/상태배지 버그픽스 PR #41 merge 완료 → VOC 리스트 UI/UX benchmark 정렬 브랜치 작업 완료 → **Phase 9 운영 실구현 + 배포 대기**
 
-브랜치: main (origin/main 동기화 완료)
+브랜치: voc-list-ui-ux-benchmark
 
 최근 작업 (2026-04-26):
 - Phase 8 디자인 재작업 완료
 - benchmark/ 폴더 생성: prototype 전 페이지·인터렉션 스크린샷 24장 + INDEX.md
 - dashboard-v3.html 삭제 + docs 참조 제거
+- VOC 리스트 UI/UX benchmark 정렬:
+  - benchmark/01, benchmark/11 기준으로 리스트 컬럼 폭, title/tag 스캔성, 상태 배지 밀도 조정
+  - VOC 행 좌측 chevron affordance 추가
+  - subtask_count 기반 lazy load + inline child row 표시 구현
+  - backend /api/vocs metadata(subtask_count, tags) 병합 helper 추가
+  - parent_id 컬럼이 없는 기존 Docker DB에서도 /api/vocs가 깨지지 않도록 방어 처리
+  - 검증: frontend typecheck, frontend vitest 25/25, backend vocs/subtask 33/33 통과
 
 네비바/상태배지 버그픽스 (2026-04-26, PR #41 merge 완료):
 - Sidebar.tsx: 사이드바 배지(카운트) 완전 제거 + NavLink active 정확히 하이라이트

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -1,30 +1,43 @@
 # vocpage — 다음 세션 태스크 계획
 
-> 최종 업데이트: 2026-04-26 (PR #41 merge 완료)
+> 최종 업데이트: 2026-04-26 (VOC 리스트 UI/UX benchmark 정렬 완료)
 > 목표: **Phase 9 운영 실구현 + 배포**
 
 ## 현재 상태
 
-| 항목                     | 상태                                         |
-| ------------------------ | -------------------------------------------- |
-| Phase 0~7 구현           | ✅ 완료                                      |
-| Phase 8 디자인           | ✅ 완료 + 머지                               |
-| 프로토타입 벤치마크      | ✅ 완료 (`benchmark/` 폴더, 24장 + INDEX.md) |
-| 네비바/상태배지 버그픽스 | ✅ 완료 + 머지 (PR #41)                      |
-| Phase 9                  | ⏳ 대기                                      |
+| 항목                            | 상태                                         |
+| ------------------------------- | -------------------------------------------- |
+| Phase 0~7 구현                  | ✅ 완료                                      |
+| Phase 8 디자인                  | ✅ 완료 + 머지                               |
+| 프로토타입 벤치마크             | ✅ 완료 (`benchmark/` 폴더, 24장 + INDEX.md) |
+| 네비바/상태배지 버그픽스        | ✅ 완료 + 머지 (PR #41)                      |
+| VOC 리스트 UI/UX benchmark 정렬 | ✅ 완료                                      |
+| Phase 9                         | ⏳ 대기                                      |
 
 ---
 
 ## 다음 세션 시작 전
 
 1. ~~네비바/상태배지 버그픽스 PR 머지~~ ✅ 완료 (PR #41)
-2. Phase 9 작업 시작
+2. ~~VOC 리스트 UI/UX benchmark 정렬~~ ✅ 완료
+3. Phase 9 작업 시작
 
 ---
 
 ## Phase 8: 디자인 수정
 
 > ✅ 완료. 사용자 피드백 기반 UI/UX 재작업 완료.
+
+### VOC 리스트 UI/UX benchmark 정렬
+
+> ✅ 완료. `benchmark/01-voc-all-list.png`, `benchmark/11-voc-subvoc-expanded.png` 기준.
+
+- 리스트 컬럼 폭과 제목/태그 스캔성 조정
+- 상태 배지 밀도 축소
+- VOC 행 좌측 chevron affordance 추가
+- `subtask_count` 기반 lazy load + inline child row 표시
+- `parent_id` 컬럼이 없는 기존 로컬 Docker DB에서도 `/api/vocs`가 깨지지 않도록 backend 방어 처리
+- 검증: frontend typecheck, frontend Vitest 25/25, backend VOC/subtask Jest 33/33
 
 ---
 

--- a/frontend/src/api/vocs.ts
+++ b/frontend/src/api/vocs.ts
@@ -29,6 +29,8 @@ export interface VocSummary {
   voc_type_name: string | null;
   tags: Array<{ id: string; name: string }>;
   due_date: string | null;
+  parent_id: string | null;
+  subtask_count: number;
   created_at: string;
   updated_at: string;
 }
@@ -42,7 +44,6 @@ export interface VocDetail extends VocSummary {
   structured_payload_draft: Record<string, unknown> | null;
   review_status: string | null;
   source: string;
-  parent_id: string | null;
 }
 
 export interface VocListResponse {

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -43,11 +43,11 @@ export function StatusBadge({ status }: { status: string }) {
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: '5px',
-        minHeight: '20px',
-        padding: '1px 8px',
+        gap: '4px',
+        minHeight: '19px',
+        padding: '1px 7px',
         borderRadius: '9999px',
-        fontSize: '12px',
+        fontSize: '11.5px',
         fontWeight: 600,
         backgroundColor: cfg.bg,
         border: `1px solid ${cfg.border}`,
@@ -57,8 +57,8 @@ export function StatusBadge({ status }: { status: string }) {
     >
       <span
         style={{
-          width: '6px',
-          height: '6px',
+          width: '5px',
+          height: '5px',
           borderRadius: '50%',
           backgroundColor: cfg.dot,
           flexShrink: 0,

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -100,6 +100,7 @@ const userAreaStyle: React.CSSProperties = {
   borderTop: '1px solid var(--border-subtle)',
   padding: '12px 14px',
   flexShrink: 0,
+  minWidth: 0,
 };
 
 const userNameStyle: React.CSSProperties = {
@@ -377,7 +378,7 @@ export function Sidebar() {
           >
             {user?.name ? user.name.charAt(0) : <User size={13} color="white" />}
           </div>
-          <div style={{ overflow: 'hidden', flex: 1 }}>
+          <div style={{ overflow: 'hidden', flex: 1, minWidth: 0 }}>
             <div style={userNameStyle}>{user?.name ?? '—'}</div>
             <div style={userRoleStyle}>{user?.role ?? ''}</div>
           </div>

--- a/frontend/src/components/voc/VocList.tsx
+++ b/frontend/src/components/voc/VocList.tsx
@@ -1,5 +1,6 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import type { VocSummary } from '../../api/vocs';
+import { listSubtasks, type VocSummary } from '../../api/vocs';
 import { VocRow } from './VocRow';
 import { Pagination } from '../common/Pagination';
 
@@ -19,16 +20,66 @@ interface VocListProps {
 interface HeaderDef {
   label: string;
   sortKey?: string;
+  width?: string;
 }
 
 const HEADERS: HeaderDef[] = [
-  { label: '이슈 ID' },
+  { label: '이슈 ID', width: '150px' },
   { label: '제목' },
-  { label: '상태' },
-  { label: '담당자' },
-  { label: '우선순위', sortKey: 'priority' },
-  { label: '등록일', sortKey: 'created_at' },
+  { label: '상태', width: '88px' },
+  { label: '담당자', width: '108px' },
+  { label: '우선순위', sortKey: 'priority', width: '82px' },
+  { label: '등록일', sortKey: 'created_at', width: '90px' },
 ];
+
+type VocListItem = VocSummary & {
+  subtasks?: VocSummary[];
+  children?: VocSummary[];
+  child_vocs?: VocSummary[];
+};
+
+interface VocGroup {
+  parent: VocListItem;
+  children: VocListItem[];
+}
+
+function getInlineChildren(voc: VocListItem): VocListItem[] {
+  return [voc.subtasks, voc.children, voc.child_vocs].find((items) => Array.isArray(items)) ?? [];
+}
+
+function buildGroups(vocs: VocSummary[]): VocGroup[] {
+  const items = vocs as VocListItem[];
+  const byId = new Map(items.map((voc) => [voc.id, voc]));
+  const childrenByParent = new Map<string, VocListItem[]>();
+  const nestedChildIds = new Set<string>();
+
+  items.forEach((voc) => {
+    getInlineChildren(voc).forEach((child) => {
+      nestedChildIds.add(child.id);
+      const parentChildren = childrenByParent.get(voc.id) ?? [];
+      parentChildren.push(child);
+      childrenByParent.set(voc.id, parentChildren);
+    });
+
+    if (voc.parent_id && byId.has(voc.parent_id)) {
+      const parentChildren = childrenByParent.get(voc.parent_id) ?? [];
+      parentChildren.push(voc);
+      childrenByParent.set(voc.parent_id, parentChildren);
+    }
+  });
+
+  return items
+    .filter((voc) => !nestedChildIds.has(voc.id) && !(voc.parent_id && byId.has(voc.parent_id)))
+    .map((parent) => {
+      const seen = new Set<string>();
+      const children = (childrenByParent.get(parent.id) ?? []).filter((child) => {
+        if (seen.has(child.id)) return false;
+        seen.add(child.id);
+        return true;
+      });
+      return { parent, children };
+    });
+}
 
 export function VocList({
   vocs,
@@ -42,10 +93,61 @@ export function VocList({
   sortOrder = 'desc',
   onSort,
 }: VocListProps) {
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(() => new Set());
+  const [childrenByParent, setChildrenByParent] = useState<Record<string, VocSummary[]>>({});
+  const [loadingChildren, setLoadingChildren] = useState<Set<string>>(() => new Set());
+  const groups = useMemo(() => {
+    const baseGroups = buildGroups(vocs);
+    return baseGroups.map((group) => ({
+      ...group,
+      children: childrenByParent[group.parent.id] ?? group.children,
+    }));
+  }, [childrenByParent, vocs]);
+
+  useEffect(() => {
+    setExpandedRows(new Set());
+    setChildrenByParent({});
+    setLoadingChildren(new Set());
+  }, [vocs]);
+
+  const toggleExpanded = (voc: VocSummary, currentChildren: VocSummary[]) => {
+    setExpandedRows((current) => {
+      const next = new Set(current);
+      if (next.has(voc.id)) next.delete(voc.id);
+      else next.add(voc.id);
+      return next;
+    });
+
+    if (currentChildren.length > 0 || childrenByParent[voc.id] || (voc.subtask_count ?? 0) === 0) {
+      return;
+    }
+
+    setLoadingChildren((current) => new Set(current).add(voc.id));
+    listSubtasks(voc.id)
+      .then((children) => {
+        setChildrenByParent((current) => ({ ...current, [voc.id]: children }));
+      })
+      .catch(() => {
+        setChildrenByParent((current) => ({ ...current, [voc.id]: [] }));
+      })
+      .finally(() => {
+        setLoadingChildren((current) => {
+          const next = new Set(current);
+          next.delete(voc.id);
+          return next;
+        });
+      });
+  };
+
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       <div className="flex-1 overflow-auto">
-        <table className="w-full border-collapse text-sm">
+        <table className="w-full table-fixed border-collapse text-sm">
+          <colgroup>
+            {HEADERS.map(({ label, width }) => (
+              <col key={label} style={width ? { width } : undefined} />
+            ))}
+          </colgroup>
           <thead>
             <tr style={{ borderBottom: '1px solid var(--border)' }}>
               {HEADERS.map(({ label, sortKey }) => {
@@ -96,9 +198,31 @@ export function VocList({
                 </td>
               </tr>
             ) : (
-              vocs.map((voc) => (
-                <VocRow key={voc.id} voc={voc} onClick={() => onVocClick(voc.id)} />
-              ))
+              groups.map(({ parent, children }) => {
+                const isExpanded = expandedRows.has(parent.id);
+                const hasChildren = children.length > 0 || (parent.subtask_count ?? 0) > 0;
+                return (
+                  <Fragment key={parent.id}>
+                    <VocRow
+                      voc={parent}
+                      hasChildren={hasChildren}
+                      isExpanded={isExpanded}
+                      isLoadingChildren={loadingChildren.has(parent.id)}
+                      onToggleExpand={() => toggleExpanded(parent, children)}
+                      onClick={() => onVocClick(parent.id)}
+                    />
+                    {isExpanded &&
+                      children.map((child) => (
+                        <VocRow
+                          key={child.id}
+                          voc={child}
+                          isChild
+                          onClick={() => onVocClick(child.id)}
+                        />
+                      ))}
+                  </Fragment>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/frontend/src/components/voc/VocRow.tsx
+++ b/frontend/src/components/voc/VocRow.tsx
@@ -1,10 +1,15 @@
-import { UserX } from 'lucide-react';
+import { ChevronDown, ChevronRight, CornerDownRight, UserX } from 'lucide-react';
 import type { VocSummary } from '../../api/vocs';
 import { StatusBadge } from '../common/StatusBadge';
 import { PriorityBadge } from '../common/PriorityBadge';
 
 interface VocRowProps {
   voc: VocSummary;
+  isChild?: boolean;
+  hasChildren?: boolean;
+  isExpanded?: boolean;
+  isLoadingChildren?: boolean;
+  onToggleExpand?: () => void;
   onClick: () => void;
 }
 
@@ -14,12 +19,12 @@ function formatDate(iso: string): string {
 }
 
 const AVATAR_COLORS = [
-  { bg: 'var(--brand)', text: 'white' },
-  { bg: 'var(--status-green)', text: 'white' },
-  { bg: 'var(--status-purple)', text: 'white' },
-  { bg: 'var(--status-amber)', text: 'white' },
-  { bg: 'var(--status-red)', text: 'white' },
-  { bg: 'var(--status-emerald)', text: 'white' },
+  { bg: 'var(--brand)', text: 'var(--text-on-brand)' },
+  { bg: 'var(--status-green)', text: 'var(--text-on-brand)' },
+  { bg: 'var(--status-purple)', text: 'var(--text-on-brand)' },
+  { bg: 'var(--status-amber)', text: 'var(--text-on-brand)' },
+  { bg: 'var(--status-red)', text: 'var(--text-on-brand)' },
+  { bg: 'var(--status-emerald)', text: 'var(--text-on-brand)' },
 ];
 
 function avatarColor(name: string) {
@@ -77,7 +82,7 @@ function AssigneeCell({ name }: { name: string | null }) {
   }
   const { bg, text } = avatarColor(name);
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
       <span
         style={{
           width: '22px',
@@ -95,18 +100,36 @@ function AssigneeCell({ name }: { name: string | null }) {
       >
         {name.charAt(0)}
       </span>
-      <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{name}</span>
+      <span
+        className="truncate"
+        style={{ fontSize: '12px', color: 'var(--text-secondary)', minWidth: 0 }}
+      >
+        {name}
+      </span>
     </span>
   );
 }
 
-export function VocRow({ voc, onClick }: VocRowProps) {
+export function VocRow({
+  voc,
+  isChild = false,
+  hasChildren = false,
+  isExpanded = false,
+  isLoadingChildren = false,
+  onToggleExpand,
+  onClick,
+}: VocRowProps) {
   const typeBadge = getTypeBadgeStyle(voc.voc_type_name ?? null);
+  const titleColor = isChild ? 'var(--text-secondary)' : 'var(--text-primary)';
 
   return (
     <tr
       onClick={onClick}
-      style={{ borderBottom: '1px solid var(--border-subtle)', cursor: 'pointer' }}
+      style={{
+        borderBottom: '1px solid var(--border-subtle)',
+        cursor: 'pointer',
+        background: isChild ? 'color-mix(in srgb, var(--bg-surface) 62%, transparent)' : undefined,
+      }}
       className="hover:bg-[var(--bg-surface)] transition-colors"
     >
       {/* 이슈 ID */}
@@ -114,45 +137,133 @@ export function VocRow({ voc, onClick }: VocRowProps) {
         className="px-4 py-2.5 text-sm"
         style={{
           fontFamily: 'var(--font-code)',
-          color: 'var(--text-secondary)',
+          color: isChild ? 'var(--text-tertiary)' : 'var(--text-secondary)',
           whiteSpace: 'nowrap',
-          width: '168px',
         }}
       >
-        {voc.issue_code ?? '—'}
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
+          {isChild ? (
+            <span
+              aria-hidden="true"
+              style={{
+                width: '22px',
+                display: 'inline-flex',
+                justifyContent: 'center',
+                color: 'var(--text-quaternary)',
+                flexShrink: 0,
+              }}
+            >
+              <CornerDownRight size={14} />
+            </span>
+          ) : (
+            <button
+              type="button"
+              aria-label={isExpanded ? 'Sub-task 접기' : 'Sub-task 펼치기'}
+              aria-expanded={hasChildren ? isExpanded : undefined}
+              disabled={!hasChildren}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleExpand?.();
+              }}
+              style={{
+                width: '22px',
+                height: '22px',
+                border: 0,
+                padding: 0,
+                borderRadius: '4px',
+                background: 'transparent',
+                color: hasChildren ? 'var(--text-tertiary)' : 'var(--text-quaternary)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: hasChildren ? 'pointer' : 'default',
+                opacity: hasChildren ? 1 : 0.35,
+                flexShrink: 0,
+              }}
+            >
+              {isLoadingChildren ? (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: '5px',
+                    height: '5px',
+                    borderRadius: '50%',
+                    background: 'var(--text-quaternary)',
+                  }}
+                />
+              ) : isExpanded ? (
+                <ChevronDown size={15} />
+              ) : (
+                <ChevronRight size={15} />
+              )}
+            </button>
+          )}
+          <span className="truncate">{voc.issue_code ?? '—'}</span>
+        </span>
       </td>
 
       {/* 제목 (type badge + title + tags) */}
-      <td className="px-4 py-2.5" style={{ maxWidth: '0', width: '100%' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
-          {typeBadge && voc.voc_type_name && (
+      <td className="px-4 py-2.5" style={{ minWidth: 0 }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(0, 1fr) auto',
+            alignItems: 'center',
+            gap: '12px',
+            minWidth: 0,
+          }}
+        >
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '8px',
+              minWidth: 0,
+            }}
+          >
+            {!isChild && typeBadge && voc.voc_type_name && (
+              <span
+                style={{
+                  flexShrink: 0,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  padding: '1px 7px',
+                  borderRadius: '9999px',
+                  fontSize: '11px',
+                  fontWeight: 600,
+                  background: typeBadge.bg,
+                  border: `1px solid ${typeBadge.border}`,
+                  color: typeBadge.color,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <span style={{ marginRight: '3px', fontSize: '8px', lineHeight: 1 }}>●</span>
+                {voc.voc_type_name}
+              </span>
+            )}
             <span
+              className="truncate"
               style={{
-                flexShrink: 0,
-                display: 'inline-flex',
-                alignItems: 'center',
-                padding: '1px 7px',
-                borderRadius: '9999px',
-                fontSize: '11px',
-                fontWeight: 600,
-                background: typeBadge.bg,
-                border: `1px solid ${typeBadge.border}`,
-                color: typeBadge.color,
-                whiteSpace: 'nowrap',
+                color: titleColor,
+                fontSize: '14px',
+                fontWeight: isChild ? 500 : 600,
+                lineHeight: 1.45,
+                minWidth: 0,
               }}
             >
-              <span style={{ marginRight: '3px', fontSize: '8px', lineHeight: 1 }}>●</span>
-              {voc.voc_type_name}
+              {voc.title}
             </span>
-          )}
-          <span
-            className="text-sm font-medium truncate"
-            style={{ color: 'var(--text-primary)', flexShrink: 1 }}
-          >
-            {voc.title}
           </span>
           {voc.tags && voc.tags.length > 0 && (
-            <span style={{ display: 'inline-flex', gap: '4px', flexShrink: 0 }}>
+            <span
+              style={{
+                display: 'inline-flex',
+                justifyContent: 'flex-end',
+                gap: '4px',
+                minWidth: 0,
+                overflow: 'hidden',
+              }}
+            >
               {voc.tags.slice(0, 3).map((tag) => (
                 <span
                   key={tag.id}
@@ -165,6 +276,7 @@ export function VocRow({ voc, onClick }: VocRowProps) {
                     color: 'var(--text-tertiary)',
                     border: '1px solid var(--border-subtle)',
                     whiteSpace: 'nowrap',
+                    flexShrink: 0,
                   }}
                 >
                   {tag.name}
@@ -176,24 +288,24 @@ export function VocRow({ voc, onClick }: VocRowProps) {
       </td>
 
       {/* 상태 */}
-      <td className="px-4 py-2.5" style={{ whiteSpace: 'nowrap', width: '100px' }}>
+      <td className="px-3 py-2.5" style={{ whiteSpace: 'nowrap' }}>
         <StatusBadge status={voc.status} />
       </td>
 
       {/* 담당자 */}
-      <td className="px-4 py-2.5" style={{ whiteSpace: 'nowrap', width: '120px' }}>
+      <td className="px-3 py-2.5" style={{ whiteSpace: 'nowrap', minWidth: 0 }}>
         <AssigneeCell name={voc.assignee_name ?? null} />
       </td>
 
       {/* 우선순위 */}
-      <td className="px-4 py-2.5" style={{ whiteSpace: 'nowrap', width: '90px' }}>
+      <td className="px-3 py-2.5" style={{ whiteSpace: 'nowrap' }}>
         <PriorityBadge priority={voc.priority} />
       </td>
 
       {/* 등록일 */}
       <td
         className="px-4 py-2.5 text-xs"
-        style={{ color: 'var(--text-secondary)', whiteSpace: 'nowrap', width: '88px' }}
+        style={{ color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}
       >
         {formatDate(voc.created_at)}
       </td>

--- a/frontend/src/components/voc/VocTopbar.tsx
+++ b/frontend/src/components/voc/VocTopbar.tsx
@@ -35,14 +35,12 @@ export function VocTopbar({ total, onSearch, onCreateClick, title = '전체 VOC'
         height: '56px',
         background: 'var(--bg-panel)',
         borderBottom: '1px solid var(--border-subtle)',
+        minWidth: 0,
       }}
     >
       {/* Left: title + count + mode badges */}
-      <div className="flex items-center gap-2 shrink-0">
-        <h1
-          className="text-base font-semibold"
-          style={{ color: 'var(--text-primary)', letterSpacing: '-0.01em' }}
-        >
+      <div className="flex items-center gap-2" style={{ minWidth: 0 }}>
+        <h1 className="text-base font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
           {title}
         </h1>
         <span
@@ -104,7 +102,7 @@ export function VocTopbar({ total, onSearch, onCreateClick, title = '전체 VOC'
             placeholder="제목, 본문 검색..."
             onChange={handleInputChange}
             style={{
-              width: '220px',
+              width: 'clamp(180px, 18vw, 220px)',
               paddingLeft: '30px',
               paddingRight: '10px',
               paddingTop: '6px',
@@ -129,7 +127,6 @@ export function VocTopbar({ total, onSearch, onCreateClick, title = '전체 VOC'
             color: 'white',
             border: 'none',
             cursor: 'pointer',
-            letterSpacing: '-0.01em',
           }}
         >
           <Plus size={14} />새 VOC 등록


### PR DESCRIPTION
## Summary
- Align VOC list table layout, title/tag scanability, and status badge density with benchmark/01
- Add row chevron affordance plus lazy-loaded inline Sub-task rows matching benchmark/11
- Add backend VOC list metadata helper for tags/subtask_count, with parent_id-column fallback for older local Docker DBs
- Update progress docs for the completed UI/UX alignment

## Verification
- npm run typecheck -w frontend
- npm run test -w frontend -- --run
- npm run test -w backend -- --runInBand --testPathPattern='(vocs|subtask)\.test\.ts'
- git diff --check
- graphify update .