### PR TITLE
fix: design.md 스펙과 구현체 토큰/컴포넌트 정렬

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ docs/specs/
 - **No completion claims** — Never mark a task as done until the user explicitly says so
 - **No implementation without approval** — Never write actual BE/FE code until the user explicitly says to start implementation
 - **Debate, don't defer** — Do not assume the user is always right. When you see a counterargument, trade-off, or missed case in a spec or design decision, raise it before agreeing. No passive "yes" — push back, verify, or propose alternatives as a peer engineer would.
+- **design.md 교차 검증 필수** — UI 컴포넌트를 신규 구현하거나 수정할 때, 해당 컴포넌트에 관련된 `design.md` 섹션(§5 Components, §7 Layout, §10 CSS Reference 등)을 반드시 Read한 뒤 수치·토큰·형태를 대조 확인하고 구현한다. "그럴듯해 보이는 값" 추정 금지.
 
 ## graphify
 

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -18,10 +18,10 @@ const STATUS_CONFIG: Record<string, { bg: string; border: string; color: string;
     dot: 'var(--status-green)',
   },
   완료: {
-    bg: 'var(--status-green-bg)',
-    border: 'var(--status-green-border)',
-    color: 'var(--status-green)',
-    dot: 'var(--status-green)',
+    bg: 'var(--status-emerald-bg)',
+    border: 'var(--status-emerald-border)',
+    color: 'var(--status-emerald)',
+    dot: 'var(--status-emerald)',
   },
   드랍: {
     bg: 'var(--status-amber-bg)',
@@ -43,10 +43,9 @@ export function StatusBadge({ status }: { status: string }) {
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: '4px',
-        minHeight: '19px',
-        padding: '1px 7px',
-        borderRadius: '9999px',
+        gap: '5px',
+        padding: '2px 8px',
+        borderRadius: '4px',
         fontSize: '11.5px',
         fontWeight: 600,
         backgroundColor: cfg.bg,
@@ -57,8 +56,8 @@ export function StatusBadge({ status }: { status: string }) {
     >
       <span
         style={{
-          width: '5px',
-          height: '5px',
+          width: '6px',
+          height: '6px',
           borderRadius: '50%',
           backgroundColor: cfg.dot,
           flexShrink: 0,

--- a/frontend/src/components/voc/VocRow.tsx
+++ b/frontend/src/components/voc/VocRow.tsx
@@ -249,7 +249,7 @@ export function VocRow({
               className="truncate"
               style={{
                 color: titleColor,
-                fontSize: '14px',
+                fontSize: '13px',
                 fontWeight: isChild ? 500 : 600,
                 lineHeight: 1.45,
                 minWidth: 0,

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -77,8 +77,15 @@
     oklch(5% 0.01 265 / 0.55) 0 4px 16px
   );
 
-  --font-ui: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-code: 'D2Coding', monospace;
+  --font-ui:
+    'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo',
+    sans-serif;
+  --font-mono: 'D2Coding', 'SF Mono', 'Menlo', ui-monospace, monospace;
+  --font-code: var(--font-mono); /* backward-compat alias */
+
+  /* Priority indicator colors */
+  --priority-urgent: oklch(58% 0.22 25);
+  --priority-high: oklch(60% 0.18 45);
 }
 
 [data-theme='light'] {

--- a/frontend/src/tokens.ts
+++ b/frontend/src/tokens.ts
@@ -3,16 +3,20 @@
 // Full values populated in Phase 6-9 (Prototype → Components).
 // Never import hex values elsewhere — always go through this file.
 export const tokens = {
-  brand: 'oklch(56.5% 0.196 261.3)',
-  accent: 'oklch(60% 0.15 200)',
-  bgApp: 'oklch(14% 0.01 264)',
-  bgPanel: 'oklch(17% 0.01 264)',
-  textPrimary: 'oklch(95% 0.003 264.5)',
-  textSecondary: 'oklch(65% 0.012 264)',
-  textTertiary: 'oklch(45% 0.01 264)',
-  borderDefault: 'oklch(28% 0.012 264)',
-  overlayBg: 'oklch(0% 0 0 / 0.5)',
-  defaultTypeColor: 'oklch(38% 0.01 264)',
+  // Dark-mode resolved values for JS/canvas usage (light-dark() not available in JS)
+  brand: 'oklch(63% 0.19 258)',
+  accent: 'oklch(70% 0.21 255)',
+  bgApp: 'oklch(11% 0.016 264)',
+  bgPanel: 'oklch(14.5% 0.019 262)',
+  bgSurface: 'oklch(18.5% 0.021 260)',
+  bgElevated: 'oklch(23% 0.022 258)',
+  textPrimary: 'oklch(95.5% 0.007 252)',
+  textSecondary: 'oklch(79% 0.014 255)',
+  textTertiary: 'oklch(59% 0.012 258)',
+  textQuaternary: 'oklch(43% 0.01 260)',
+  borderDefault: 'oklch(27% 0.02 259 / 0.85)',
+  overlayBg: 'oklch(8% 0.012 265 / 0.88)',
+  defaultTypeColor: 'oklch(43% 0.01 260)',
   // Chart series — mirrors --chart-* CSS vars in index.css
   chartBlue: 'oklch(63% 0.19 258)',
   chartSky: 'oklch(72% 0.14 235)',


### PR DESCRIPTION
## Summary

- `index.css`: `--font-mono` 추가(--font-code는 alias 유지), `--font-ui` 폴백 보완, `--priority-urgent/high` 토큰 신규 정의
- `tokens.ts`: `accent` hue 200→255(삼성 블루 계열), `brand/bg/text` 값 design.md §10 기준 전면 정렬
- `StatusBadge`: `borderRadius` 9999px→4px, `padding` 1px 7px→2px 8px, dot 5px→6px, `완료` 색상 --status-green→--status-emerald
- `VocRow`: 제목 `fontSize` 14px→13px (§7 Tier 1 Content 스펙)
- `CLAUDE.md`: UI 컴포넌트 구현·수정 시 design.md 교차 검증 필수 규칙 추가

## Test plan

- [ ] TypeScript typecheck 통과 (pre-commit hook 확인)
- [ ] StatusBadge 사각형 배지 + 완료 emerald 색상 시각 확인
- [ ] VOC 목록 제목 13px 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)