### PR TITLE
feat: 대시보드 기간 필터 1달/3달/1년/전체 + 커스텀 피커 + 스크롤 + null guard 수정

### DIFF
--- a/frontend/src/components/dashboard/AssigneeTable.tsx
+++ b/frontend/src/components/dashboard/AssigneeTable.tsx
@@ -31,7 +31,7 @@ export function AssigneeTable({ filter, buildQueryParams }: AssigneeTableProps) 
     staleTime: 5 * 60 * 1000,
   });
 
-  const allValues = data?.rows.flatMap((row) => row.values) ?? [];
+  const allValues = data?.rows.flatMap((row) => row.values ?? []) ?? [];
   const maxValue = Math.max(...allValues, 1);
 
   return (
@@ -78,7 +78,7 @@ export function AssigneeTable({ filter, buildQueryParams }: AssigneeTableProps) 
                 <td className={`rl${!row.assigneeName ? ' unassigned' : ''}`}>
                   {row.assigneeName || '미지정'}
                 </td>
-                {row.values.map((val, idx) => {
+                {(row.values ?? []).map((val, idx) => {
                   const header = data?.headers[idx] ?? '';
                   if (val === 0) {
                     return (

--- a/frontend/src/components/dashboard/DashboardHeader.css
+++ b/frontend/src/components/dashboard/DashboardHeader.css
@@ -66,6 +66,10 @@
   font-weight: 600;
 }
 
+.date-range-wrap {
+  position: relative;
+}
+
 .date-range-btn,
 .edit-layout-btn {
   display: flex;
@@ -78,4 +82,56 @@
   color: var(--text-secondary);
   border-radius: 4px;
   cursor: pointer;
+}
+
+.date-range-btn.custom-active {
+  border-color: var(--brand-border);
+  color: var(--brand);
+}
+
+.date-picker-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px color-mix(in oklch, var(--text-primary) 10%, transparent);
+  z-index: 100;
+  white-space: nowrap;
+}
+
+.date-picker-input {
+  padding: 4px 6px;
+  font-size: 12px;
+  border: 1px solid var(--border-standard);
+  border-radius: 5px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.date-picker-sep {
+  color: var(--text-quaternary);
+  font-size: 12px;
+}
+
+.date-picker-apply {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  border: none;
+  border-radius: 5px;
+  background: var(--brand);
+  color: var(--text-on-brand);
+  cursor: pointer;
+}
+
+.date-picker-apply:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }

--- a/frontend/src/components/dashboard/DashboardHeader.tsx
+++ b/frontend/src/components/dashboard/DashboardHeader.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { Calendar, LayoutPanelLeft } from 'lucide-react';
 import { DashboardFilterState } from '../../hooks/useDashboardFilter';
 import './DashboardHeader.css';
@@ -6,7 +7,7 @@ interface DashboardHeaderProps {
   filter: DashboardFilterState;
   menus: { id: string; name: string }[];
   assignees: { id: string; name: string }[];
-  onSetDatePreset: (preset: '7d' | '30d' | '90d' | 'custom') => void;
+  onSetDatePreset: (preset: '1m' | '3m' | '1y' | 'all' | 'custom') => void;
   onSetDateRange: (start: string, end: string) => void;
   onSetActiveMenu: (menuId: string | null) => void;
   onSetActiveAssignee: (assigneeId: string | null) => void;
@@ -20,9 +21,10 @@ function formatDateRange(start: string, end: string): string {
 }
 
 const DATE_PRESETS = [
-  { label: '7일', value: '7d' as const },
-  { label: '30일', value: '30d' as const },
-  { label: '90일', value: '90d' as const },
+  { label: '1달', value: '1m' as const },
+  { label: '3달', value: '3m' as const },
+  { label: '1년', value: '1y' as const },
+  { label: '전체', value: 'all' as const },
   { label: '커스텀', value: 'custom' as const },
 ];
 
@@ -31,10 +33,53 @@ export function DashboardHeader({
   menus,
   assignees,
   onSetDatePreset,
+  onSetDateRange,
   onSetActiveMenu,
   onSetActiveAssignee,
   onEditLayout,
 }: DashboardHeaderProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [draftStart, setDraftStart] = useState(filter.dateRange.startDate);
+  const [draftEnd, setDraftEnd] = useState(filter.dateRange.endDate);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [pickerOpen]);
+
+  function handlePresetClick(preset: '1m' | '3m' | '1y' | 'all' | 'custom') {
+    if (preset === 'custom') {
+      setDraftStart(filter.dateRange.startDate);
+      setDraftEnd(filter.dateRange.endDate);
+      setPickerOpen(true);
+      onSetDatePreset('custom');
+    } else {
+      setPickerOpen(false);
+      onSetDatePreset(preset);
+    }
+  }
+
+  function handleCalendarBtnClick() {
+    if (filter.datePreset === 'custom') {
+      setDraftStart(filter.dateRange.startDate);
+      setDraftEnd(filter.dateRange.endDate);
+      setPickerOpen((v) => !v);
+    }
+  }
+
+  function handleApply() {
+    if (!draftStart || !draftEnd || draftStart > draftEnd) return;
+    onSetDateRange(draftStart, draftEnd);
+    setPickerOpen(false);
+  }
+
   return (
     <header className="dashboard-header">
       <span className="dashboard-header-title">대시보드</span>
@@ -75,17 +120,49 @@ export function DashboardHeader({
             <button
               key={p.value}
               className={filter.datePreset === p.value ? 'active' : ''}
-              onClick={() => onSetDatePreset(p.value)}
+              onClick={() => handlePresetClick(p.value)}
             >
               {p.label}
             </button>
           ))}
         </div>
 
-        <button className="date-range-btn">
-          <Calendar size={13} />
-          {formatDateRange(filter.dateRange.startDate, filter.dateRange.endDate)}
-        </button>
+        <div className="date-range-wrap" ref={pickerRef}>
+          <button
+            className={`date-range-btn${filter.datePreset === 'custom' ? ' custom-active' : ''}`}
+            onClick={handleCalendarBtnClick}
+          >
+            <Calendar size={13} />
+            {formatDateRange(filter.dateRange.startDate, filter.dateRange.endDate)}
+          </button>
+
+          {pickerOpen && (
+            <div className="date-picker-popover">
+              <input
+                type="date"
+                className="date-picker-input"
+                value={draftStart}
+                max={draftEnd || undefined}
+                onChange={(e) => setDraftStart(e.target.value)}
+              />
+              <span className="date-picker-sep">–</span>
+              <input
+                type="date"
+                className="date-picker-input"
+                value={draftEnd}
+                min={draftStart || undefined}
+                onChange={(e) => setDraftEnd(e.target.value)}
+              />
+              <button
+                className="date-picker-apply"
+                disabled={!draftStart || !draftEnd || draftStart > draftEnd}
+                onClick={handleApply}
+              >
+                적용
+              </button>
+            </div>
+          )}
+        </div>
 
         <button className="edit-layout-btn" onClick={onEditLayout}>
           <LayoutPanelLeft size={13} />

--- a/frontend/src/components/dashboard/DistributionWidget.tsx
+++ b/frontend/src/components/dashboard/DistributionWidget.tsx
@@ -51,8 +51,9 @@ function buildConicGradient(items: { color: string; pct: number }[]): string {
     'conic-gradient(' +
     items
       .map((item, i) => {
+        const pct = item.pct ?? 0;
         const start = acc;
-        acc += item.pct;
+        acc += pct;
         const end = i === items.length - 1 ? 100 : acc;
         return `${item.color} ${start.toFixed(1)}% ${end.toFixed(1)}%`;
       })
@@ -148,7 +149,7 @@ export function DistributionWidget({ filter, buildQueryParams }: DistributionWid
               <span className="legend-dot" style={{ background: item.resolvedColor }} />
               <span className="legend-name">{item.name}</span>
               <span className="legend-count">{item.count}</span>
-              <span className="legend-pct">{item.pct.toFixed(0)}%</span>
+              <span className="legend-pct">{(item.pct ?? 0).toFixed(0)}%</span>
               <span className="legend-bar-wrap">
                 <span
                   className="legend-bar-fill"

--- a/frontend/src/components/dashboard/DrilldownHeatmap.tsx
+++ b/frontend/src/components/dashboard/DrilldownHeatmap.tsx
@@ -45,7 +45,7 @@ export function DrilldownHeatmap({
     if (!data) return 0;
     let max = 0;
     for (const row of data.rows) {
-      for (const v of row.values) {
+      for (const v of row.values ?? []) {
         if (v > max) max = v;
       }
     }
@@ -180,7 +180,7 @@ export function DrilldownHeatmap({
                     {isAllTab ? '▶ ' : ''}
                     {row.name}
                   </td>
-                  {row.values.map((v, i) => (
+                  {(row.values ?? []).map((v, i) => (
                     <td
                       key={i}
                       className={v === 0 ? 'empty' : ''}

--- a/frontend/src/components/dashboard/PriorityStatusMatrix.tsx
+++ b/frontend/src/components/dashboard/PriorityStatusMatrix.tsx
@@ -67,8 +67,8 @@ export function PriorityStatusMatrix({ filter, buildQueryParams }: PriorityStatu
           </tr>
         </thead>
         <tbody>
-          {(data?.rows ?? []).map((row) => (
-            <tr key={row.priority}>
+          {(data?.rows ?? []).map((row, idx) => (
+            <tr key={`${row.priority}-${idx}`}>
               <td
                 className="rh"
                 style={{ color: PRIORITY_COLORS[row.priority] ?? 'var(--text-secondary)' }}

--- a/frontend/src/components/dashboard/ProcessingSpeedWidget.tsx
+++ b/frontend/src/components/dashboard/ProcessingSpeedWidget.tsx
@@ -52,7 +52,7 @@ export function ProcessingSpeedWidget({ filter, buildQueryParams }: ProcessingSp
       {(data?.rows ?? []).map((row) => (
         <div className="sla-row" key={row.id}>
           <span className="sla-name">{row.name}</span>
-          <span className="sla-avg">{row.avgDays.toFixed(1)}일</span>
+          <span className="sla-avg">{(row.avgDays ?? 0).toFixed(1)}일</span>
           <span className={slaRateClass(row.slaRate)}>{row.slaRate}%</span>
         </div>
       ))}

--- a/frontend/src/hooks/useDashboardFilter.ts
+++ b/frontend/src/hooks/useDashboardFilter.ts
@@ -3,7 +3,7 @@ import { DashboardQueryParams } from '../api/dashboard';
 
 export interface DashboardFilterState {
   dateRange: { startDate: string; endDate: string };
-  datePreset: '7d' | '30d' | '90d' | 'custom';
+  datePreset: '1m' | '3m' | '1y' | 'all' | 'custom';
   globalTab: 'all' | string;
   activeMenu: string | null;
   activeAssignee: string | null;
@@ -11,7 +11,7 @@ export interface DashboardFilterState {
 
 export interface UseDashboardFilter {
   filter: DashboardFilterState;
-  setDatePreset: (preset: '7d' | '30d' | '90d' | 'custom') => void;
+  setDatePreset: (preset: '1m' | '3m' | '1y' | 'all' | 'custom') => void;
   setDateRange: (startDate: string, endDate: string) => void;
   setGlobalTab: (tab: string) => void;
   setActiveMenu: (menuId: string | null) => void;
@@ -23,19 +23,22 @@ function toISODate(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-function calcDateRange(preset: '7d' | '30d' | '90d'): { startDate: string; endDate: string } {
+function calcDateRange(preset: '1m' | '3m' | '1y' | 'all'): { startDate: string; endDate: string } {
   const today = new Date();
-  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
-  const start = new Date(today);
-  start.setDate(today.getDate() - days);
-  return { startDate: toISODate(start), endDate: toISODate(today) };
+  const end = toISODate(today);
+  if (preset === 'all') return { startDate: '2020-01-01', endDate: end };
+  const start = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  if (preset === '1m') start.setMonth(start.getMonth() - 1);
+  else if (preset === '3m') start.setMonth(start.getMonth() - 3);
+  else if (preset === '1y') start.setFullYear(start.getFullYear() - 1);
+  return { startDate: toISODate(start), endDate: end };
 }
 
-const initial30d = calcDateRange('30d');
+const initial1m = calcDateRange('1m');
 
 const initialState: DashboardFilterState = {
-  dateRange: initial30d,
-  datePreset: '30d',
+  dateRange: initial1m,
+  datePreset: '1m',
   globalTab: 'all',
   activeMenu: null,
   activeAssignee: null,
@@ -44,7 +47,7 @@ const initialState: DashboardFilterState = {
 export function useDashboardFilter(): UseDashboardFilter {
   const [filter, setFilter] = useState<DashboardFilterState>(initialState);
 
-  function setDatePreset(preset: '7d' | '30d' | '90d' | 'custom') {
+  function setDatePreset(preset: '1m' | '3m' | '1y' | 'all' | 'custom') {
     setFilter((prev) => {
       const dateRange = preset === 'custom' ? prev.dateRange : calcDateRange(preset);
       return { ...prev, datePreset: preset, dateRange };

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -1,6 +1,8 @@
 #page-dashboard {
   position: relative;
-  min-height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   background: var(--bg-app);
 }
 


### PR DESCRIPTION
## Summary

- 기간 프리셋 변경: 7일/30일/90일 → **1달 / 3달 / 1년 / 전체 / 커스텀**
- 달/년 단위 정확한 날짜 계산 (`setMonth`, `setFullYear`)
- 커스텀 선택 시 시작일/종료일 날짜 피커 팝오버 UI (외부 클릭 닫힘, 잘못된 범위 비활성화)
- `#page-dashboard`에 `flex:1; overflow-y:auto` 추가 → 스크롤 활성화
- null guard 5건: `avgDays`, `pct`, `row.values` (DrilldownHeatmap, AssigneeTable), `PriorityStatusMatrix` duplicate key

## Test plan

- [x] typecheck clean
- [x] vitest 25/25 pass
- [x] Playwright: 1달/3달/1년/전체/커스텀 버튼 클릭 — TypeError 크래시 없음
- [x] 커스텀 피커 팝오버 표시/닫힘 확인
- [x] 스크롤로 하단 위젯 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)