### PR TITLE
feat(prototype): P-10 External Masters 관리 페이지

### DIFF
--- a/prototype/css/admin.css
+++ b/prototype/css/admin.css
@@ -2682,3 +2682,208 @@
 
 /* ============================================================ */
 /* END P-8 Trash                                                 */
+
+/* ============================================================ */
+/* BEGIN P-10 External Masters (Stage B-12) ─────────────────── */
+/* ============================================================ */
+
+/* ── Page toolbar ────────────────────────────────────────────── */
+.em-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+/* ── Cards grid ──────────────────────────────────────────────── */
+.em-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+/* ── Single card ─────────────────────────────────────────────── */
+.em-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-standard);
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.em-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.em-card-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+}
+
+.em-card-source {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-family: var(--font-ui);
+}
+
+.em-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.em-meta-item {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.em-card-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+/* ── Status badges ───────────────────────────────────────────── */
+.em-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11.5px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  white-space: nowrap;
+}
+
+.em-badge-loaded {
+  background: var(--status-green-bg);
+  color: var(--status-green);
+  border: 1px solid var(--status-green-border);
+}
+
+.em-badge-cold {
+  background: var(--status-amber-bg);
+  color: var(--status-amber);
+  border: 1px solid var(--status-amber-border);
+}
+
+.em-badge-snapshot {
+  background: var(--status-purple-bg);
+  color: var(--status-purple);
+  border: 1px solid var(--status-purple-border);
+}
+
+.em-badge-error {
+  background: var(--status-red-bg);
+  color: var(--status-red);
+  border: 1px solid var(--status-red-border);
+}
+
+/* ── History expander ────────────────────────────────────────── */
+.em-history {
+  border-top: 1px solid var(--border-standard);
+  padding-top: 8px;
+}
+
+.em-history-summary {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.em-history-summary::-webkit-details-marker {
+  display: none;
+}
+
+.em-history-summary::before {
+  content: '▸';
+  font-size: 10px;
+  transition: transform 0.15s;
+}
+
+details[open] .em-history-summary::before {
+  transform: rotate(90deg);
+}
+
+.em-hist-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.em-hist-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.em-hist-icon {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.em-hist-ok .em-hist-icon {
+  color: var(--status-green);
+}
+
+.em-hist-error .em-hist-icon {
+  color: var(--status-red);
+}
+
+.em-hist-time {
+  color: var(--text-quaternary);
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.em-hist-note {
+  color: var(--text-secondary);
+}
+
+/* ── No history note ─────────────────────────────────────────── */
+.em-no-history {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-top: 1px solid var(--border-standard);
+  padding-top: 8px;
+}
+
+/* ── No-refresh note ─────────────────────────────────────────── */
+.em-no-refresh {
+  font-size: 12px;
+  color: var(--text-quaternary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ============================================================ */
+/* END P-10 External Masters ─────────────────────────────────── */

--- a/prototype/css/admin.css
+++ b/prototype/css/admin.css
@@ -2705,9 +2705,9 @@
 
 /* ── Single card ─────────────────────────────────────────────── */
 .em-card {
-  background: var(--bg-panel);
+  background: var(--bg-surface);
   border: 1px solid var(--border-standard);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -2768,9 +2768,9 @@
 }
 
 .em-badge-loaded {
-  background: var(--status-green-bg);
+  background: var(--bg-elevated);
   color: var(--status-green);
-  border: 1px solid var(--status-green-border);
+  border: 1px solid var(--border-standard);
 }
 
 .em-badge-cold {
@@ -2883,6 +2883,59 @@ details[open] .em-history-summary::before {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+/* ── Empty state (L3) ────────────────────────────────────────── */
+.em-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+  gap: 10px;
+  font-size: 13.5px;
+  color: var(--text-secondary);
+}
+
+/* ── Cold-start banner (H2) ──────────────────────────────────── */
+.em-coldstart-banner {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  background: var(--status-amber-bg);
+  border: 1px solid var(--status-amber-border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: var(--status-amber);
+}
+
+.em-coldstart-banner-text {
+  flex: 1;
+  font-weight: 500;
+}
+
+.em-coldstart-banner-btn {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* ── Atomic-swap note (H1) ───────────────────────────────────── */
+.em-atomic-note {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 12px;
+}
+
+/* ── Bulk button sub-label (H4) ──────────────────────────────── */
+.em-bulk-sublabel {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-left: 4px;
 }
 
 /* ============================================================ */

--- a/prototype/js/admin-external-masters-data.js
+++ b/prototype/js/admin-external-masters-data.js
@@ -1,0 +1,46 @@
+// Stage B-12 P-10 — External Masters mock data
+// Export: window.externalMastersData
+
+window.externalMastersData = [
+  {
+    id: 'equipment',
+    name: '설비 마스터',
+    source: 'MSSQL (설비 DB)',
+    itemCount: 0,
+    // loaded_at null → cold-start scenario
+    loadedAt: null,
+    status: 'cold-start', // 'loaded' | 'cold-start' | 'snapshot' | 'error'
+    refreshable: true,
+    history: [
+      // no history for cold-start (first deploy scenario)
+    ],
+  },
+  {
+    id: 'db',
+    name: 'DB 마스터',
+    source: 'MSSQL (운영 DB)',
+    itemCount: 847,
+    loadedAt: '2026-04-29 09:12:33',
+    status: 'snapshot', // refresh 실패 후 스냅샷 fallback
+    refreshable: true,
+    history: [
+      { at: '2026-04-29 09:12:33', result: 'ok', note: '정상 로드 (847건)' },
+      { at: '2026-04-28 18:45:11', result: 'error', note: 'MSSQL 연결 시간 초과' },
+      { at: '2026-04-28 09:03:55', result: 'ok', note: '정상 로드 (831건)' },
+    ],
+  },
+  {
+    id: 'program',
+    name: '프로그램 마스터',
+    source: 'JSON 파일 (config/masters/programs.json)',
+    itemCount: 42,
+    loadedAt: '2026-04-30 08:00:01',
+    status: 'loaded',
+    refreshable: false, // 서버 재시작으로만 갱신
+    history: [
+      { at: '2026-04-30 08:00:01', result: 'ok', note: '부팅 시 로드 (42건)' },
+      { at: '2026-04-27 08:00:03', result: 'ok', note: '부팅 시 로드 (40건)' },
+      { at: '2026-04-24 08:00:02', result: 'ok', note: '부팅 시 로드 (40건)' },
+    ],
+  },
+];

--- a/prototype/js/admin-external-masters-data.js
+++ b/prototype/js/admin-external-masters-data.js
@@ -1,18 +1,22 @@
 // Stage B-12 P-10 — External Masters mock data
 // Export: window.externalMastersData
 
+// Mock flag: set to true to simulate one source failing on bulk refresh (H1/Q5 demo)
+window.emSimulateError = false;
+
 window.externalMastersData = [
   {
     id: 'equipment',
     name: '설비 마스터',
     source: 'MSSQL (설비 DB)',
-    itemCount: 0,
-    // loaded_at null → cold-start scenario
-    loadedAt: null,
-    status: 'cold-start', // 'loaded' | 'cold-start' | 'snapshot' | 'error'
+    itemCount: 312,
+    loadedAt: '2026-04-30 08:00:00',
+    status: 'loaded',
     refreshable: true,
+    lastRefreshedAt: null, // H5: cooldown tracking
     history: [
-      // no history for cold-start (first deploy scenario)
+      { at: '2026-04-30 08:00:00', result: 'ok', note: '부팅 시 로드 (312건)' },
+      { at: '2026-04-29 08:00:01', result: 'ok', note: '부팅 시 로드 (310건)' },
     ],
   },
   {
@@ -20,13 +24,17 @@ window.externalMastersData = [
     name: 'DB 마스터',
     source: 'MSSQL (운영 DB)',
     itemCount: 847,
-    loadedAt: '2026-04-29 09:12:33',
+    loadedAt: '2026-04-29 09:12:00', // snapshotAt — when snapshot was taken (H3)
+    snapshotAt: '2026-04-29 09:12:00', // H3: explicit snapshot timestamp
+    lastAttemptAt: '2026-04-30 07:45:00', // H3: when last refresh was attempted (and failed)
     status: 'snapshot', // refresh 실패 후 스냅샷 fallback
     refreshable: true,
+    lastRefreshedAt: null, // H5: cooldown tracking
     history: [
-      { at: '2026-04-29 09:12:33', result: 'ok', note: '정상 로드 (847건)' },
-      { at: '2026-04-28 18:45:11', result: 'error', note: 'MSSQL 연결 시간 초과' },
+      // H3: timeline ends with error (정상 → 정상 → 실패)
       { at: '2026-04-28 09:03:55', result: 'ok', note: '정상 로드 (831건)' },
+      { at: '2026-04-29 09:12:00', result: 'ok', note: '정상 로드 (847건)' },
+      { at: '2026-04-30 07:45:00', result: 'error', note: 'MSSQL 연결 시간 초과 → 스냅샷 유지' },
     ],
   },
   {
@@ -37,6 +45,7 @@ window.externalMastersData = [
     loadedAt: '2026-04-30 08:00:01',
     status: 'loaded',
     refreshable: false, // 서버 재시작으로만 갱신
+    lastRefreshedAt: null,
     history: [
       { at: '2026-04-30 08:00:01', result: 'ok', note: '부팅 시 로드 (42건)' },
       { at: '2026-04-27 08:00:03', result: 'ok', note: '부팅 시 로드 (40건)' },

--- a/prototype/js/admin-external-masters.js
+++ b/prototype/js/admin-external-masters.js
@@ -2,30 +2,56 @@
 // Depends on: dom-utils.js (escHtml, showToast), admin-external-masters-data.js
 // Export: window.AdminExternalMasters = { render }
 
-// ── Status badge config
 var EM_STATUS = {
   loaded: { label: '정상', cls: 'em-badge-loaded' },
   'cold-start': { label: '콜드 스타트', cls: 'em-badge-cold' },
   snapshot: { label: '스냅샷 모드', cls: 'em-badge-snapshot' },
   error: { label: '오류', cls: 'em-badge-error' },
 };
-
-// ── History result config
 var EM_HIST = {
   ok: { icon: 'check-circle', cls: 'em-hist-ok' },
   error: { icon: 'x-circle', cls: 'em-hist-error' },
 };
+var EM_COOLDOWN_MS = 5 * 60 * 1000;
 
-// ── Toast wrapper
 function showEmToast(msg, kind) {
   if (typeof window.showToast === 'function') window.showToast(msg, kind);
 }
 
-// ── Render a single master card
+// Shared timestamp formatter (DRY)
+function emFormatNow() {
+  var now = new Date();
+  return (
+    now.getFullYear() +
+    '-' +
+    String(now.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(now.getDate()).padStart(2, '0') +
+    ' ' +
+    String(now.getHours()).padStart(2, '0') +
+    ':' +
+    String(now.getMinutes()).padStart(2, '0') +
+    ':' +
+    String(now.getSeconds()).padStart(2, '0')
+  );
+}
+
+// Returns "M:SS" remaining string, or null if cooldown expired
+function emCooldownRemaining(lastRefreshedAt) {
+  if (!lastRefreshedAt) return null;
+  var remaining = EM_COOLDOWN_MS - (Date.now() - lastRefreshedAt);
+  if (remaining <= 0) return null;
+  return (
+    Math.floor(remaining / 60000) +
+    ':' +
+    String(Math.floor((remaining % 60000) / 1000)).padStart(2, '0')
+  );
+}
+
 function renderEmCard(m) {
   var esc = window.escHtml;
   var status = EM_STATUS[m.status] || EM_STATUS['error'];
-  var histHtml = '';
+  var histHtml;
 
   if (m.history && m.history.length) {
     var rows = m.history
@@ -43,8 +69,7 @@ function renderEmCard(m) {
           '</span>' +
           '<span class="em-hist-note">' +
           esc(h.note) +
-          '</span>' +
-          '</li>'
+          '</span></li>'
         );
       })
       .join('');
@@ -52,36 +77,64 @@ function renderEmCard(m) {
       '<details class="em-history" open>' +
       '<summary class="em-history-summary">' +
       '<i data-lucide="history" style="width:12px;height:12px;vertical-align:-2px"></i>' +
-      ' 최근 새로고침 이력</summary>' +
-      '<ul class="em-hist-list">' +
+      ' 최근 새로고침 이력</summary><ul class="em-hist-list">' +
       rows +
-      '</ul>' +
-      '</details>';
+      '</ul></details>';
   } else {
     histHtml =
       '<div class="em-no-history">' +
       '<i data-lucide="clock-x" style="width:13px;height:13px;color:var(--text-quaternary);vertical-align:-2px"></i>' +
-      ' <span>이력 없음 — 아직 새로고침이 실행된 적 없습니다.</span>' +
-      '</div>';
+      ' <span>이력 없음 — 아직 새로고침이 실행된 적 없습니다.</span></div>';
   }
 
-  var loadedStr = m.loadedAt
-    ? esc(m.loadedAt)
-    : '<span style="color:var(--text-quaternary)">—</span>';
+  // Snapshot: surface both snapshotAt and lastAttemptAt as 2 lines
+  var timestampHtml;
+  if (m.status === 'snapshot' && m.snapshotAt && m.lastAttemptAt) {
+    timestampHtml =
+      '<div style="display:flex;flex-direction:column;gap:2px">' +
+      '<span class="em-meta-item"><i data-lucide="camera" style="width:11px;height:11px;vertical-align:-2px"></i> 스냅샷: ' +
+      esc(m.snapshotAt) +
+      '</span>' +
+      '<span class="em-meta-item"><i data-lucide="clock" style="width:11px;height:11px;vertical-align:-2px"></i> 최근 시도: ' +
+      esc(m.lastAttemptAt) +
+      '</span>' +
+      '</div>';
+  } else {
+    var loadedStr = m.loadedAt
+      ? esc(m.loadedAt)
+      : '<span style="color:var(--text-quaternary)">—</span>';
+    timestampHtml =
+      '<span class="em-meta-item"><i data-lucide="clock" style="width:11px;height:11px;vertical-align:-2px"></i> 마지막 갱신: ' +
+      loadedStr +
+      '</span>';
+  }
 
   var countStr = m.loadedAt
     ? esc(String(m.itemCount)) + '건'
     : '<span style="color:var(--text-quaternary)">0건</span>';
 
-  var refreshBtn = m.refreshable
-    ? '<button type="button" class="a-btn em-refresh-btn" data-id="' +
-      esc(m.id) +
-      '">' +
-      '<i data-lucide="refresh-cw" style="width:12px;height:12px;vertical-align:-2px"></i>' +
-      ' 새로고침</button>'
-    : '<span class="em-no-refresh">' +
-      '<i data-lucide="lock" style="width:11px;height:11px;vertical-align:-2px"></i>' +
-      ' 서버 재시작 전용</span>';
+  var cooldownLeft = emCooldownRemaining(m.lastRefreshedAt);
+  var refreshBtn;
+  if (m.refreshable) {
+    if (cooldownLeft) {
+      refreshBtn =
+        '<button type="button" class="admin-btn" disabled>' +
+        '<i data-lucide="clock" style="width:12px;height:12px;vertical-align:-2px"></i>' +
+        ' 쿨다운 (' +
+        esc(cooldownLeft) +
+        ')</button>';
+    } else {
+      refreshBtn =
+        '<button type="button" class="admin-btn em-refresh-btn" data-id="' +
+        esc(m.id) +
+        '">' +
+        '<i data-lucide="refresh-cw" style="width:12px;height:12px;vertical-align:-2px"></i> 새로고침</button>';
+    }
+  } else {
+    refreshBtn =
+      '<span class="em-no-refresh">' +
+      '<i data-lucide="lock" style="width:11px;height:11px;vertical-align:-2px"></i> 서버 재시작 전용</span>';
+  }
 
   return (
     '<div class="em-card" data-id="' +
@@ -94,21 +147,18 @@ function renderEmCard(m) {
     '<span class="em-badge ' +
     status.cls +
     '">' +
-    status.label +
+    esc(status.label) +
     '</span>' +
     '</div>' +
     '<div class="em-card-source">' +
-    '<i data-lucide="database" style="width:11px;height:11px;vertical-align:-2px;color:var(--text-quaternary)"></i>' +
-    ' ' +
+    '<i data-lucide="database" style="width:11px;height:11px;vertical-align:-2px;color:var(--text-quaternary)"></i> ' +
     esc(m.source) +
     '</div>' +
     '<div class="em-card-meta">' +
     '<span class="em-meta-item"><i data-lucide="layers" style="width:11px;height:11px;vertical-align:-2px"></i> ' +
     countStr +
     '</span>' +
-    '<span class="em-meta-item"><i data-lucide="clock" style="width:11px;height:11px;vertical-align:-2px"></i> 마지막 갱신: ' +
-    loadedStr +
-    '</span>' +
+    timestampHtml +
     '</div>' +
     histHtml +
     '<div class="em-card-footer">' +
@@ -118,104 +168,100 @@ function renderEmCard(m) {
   );
 }
 
-// ── Main render
+// Cold-start is system-wide; show banner if any source is cold-start or mock flag is set
+function renderColdStartBanner() {
+  var banner = document.getElementById('emColdStartBanner');
+  if (!banner) return;
+  var data = window.externalMastersData || [];
+  var isColdStart = data.some(function (m) {
+    return m.status === 'cold-start';
+  });
+  banner.style.display = isColdStart || window.emMockColdStart ? 'flex' : 'none';
+}
+
 function renderExternalMasters() {
   var section = document.getElementById('page-external-masters');
   if (!section) return;
-
+  renderColdStartBanner();
   var data = window.externalMastersData || [];
   var grid = document.getElementById('emGrid');
   if (!grid) return;
 
   if (!data.length) {
     grid.innerHTML =
-      '<div style="display:flex;flex-direction:column;align-items:center;' +
-      'justify-content:center;min-height:220px;gap:10px">' +
+      '<div class="em-empty-state">' +
       '<i data-lucide="database-x" style="width:32px;height:32px;color:var(--text-quaternary)"></i>' +
-      '<span style="font-size:13.5px;color:var(--text-secondary)">등록된 외부 마스터가 없습니다.</span>' +
-      '</div>';
+      '<span>등록된 외부 마스터가 없습니다.</span></div>';
   } else {
     grid.innerHTML = data.map(renderEmCard).join('');
   }
 
   if (window.lucide) lucide.createIcons();
 
-  // Wire per-card refresh buttons
   grid.querySelectorAll('.em-refresh-btn').forEach(function (btn) {
     btn.addEventListener('click', function () {
       emRefreshOne(btn.dataset.id);
     });
   });
+
+  // Re-render every second while a cooldown is active
+  var hasCooldown = data.some(function (m) {
+    return m.lastRefreshedAt && emCooldownRemaining(m.lastRefreshedAt) !== null;
+  });
+  if (hasCooldown) setTimeout(renderExternalMasters, 1000);
 }
 
-// ── Refresh single source (mock)
 function emRefreshOne(id) {
   var data = window.externalMastersData || [];
   var m = data.find(function (x) {
     return x.id === id;
   });
   if (!m || !m.refreshable) return;
-
   showEmToast(m.name + ' 새로고침 중…', 'info');
-
   setTimeout(function () {
-    var now = new Date();
-    var ts =
-      now.getFullYear() +
-      '-' +
-      String(now.getMonth() + 1).padStart(2, '0') +
-      '-' +
-      String(now.getDate()).padStart(2, '0') +
-      ' ' +
-      String(now.getHours()).padStart(2, '0') +
-      ':' +
-      String(now.getMinutes()).padStart(2, '0') +
-      ':' +
-      String(now.getSeconds()).padStart(2, '0');
-
+    var ts = emFormatNow();
     m.loadedAt = ts;
     m.status = 'loaded';
     m.itemCount = m.itemCount + Math.floor(Math.random() * 5);
+    m.lastRefreshedAt = Date.now();
     if (!m.history) m.history = [];
     m.history.unshift({ at: ts, result: 'ok', note: '새로고침 성공 (' + m.itemCount + '건)' });
     if (m.history.length > 3) m.history = m.history.slice(0, 3);
-
     showEmToast(m.name + ' 새로고침 완료 (' + m.itemCount + '건)', 'ok');
     renderExternalMasters();
   }, 900);
 }
 
-// ── Bulk refresh all refreshable sources
+// Bulk refresh MSSQL sources only (program master requires server restart)
 function emRefreshAll() {
   var data = window.externalMastersData || [];
   var refreshable = data.filter(function (m) {
     return m.refreshable;
   });
   if (!refreshable.length) return;
-
   refreshable.forEach(function (m) {
     showEmToast(m.name + ' 새로고침 중…', 'info');
   });
-
   setTimeout(function () {
-    var now = new Date();
-    var ts =
-      now.getFullYear() +
-      '-' +
-      String(now.getMonth() + 1).padStart(2, '0') +
-      '-' +
-      String(now.getDate()).padStart(2, '0') +
-      ' ' +
-      String(now.getHours()).padStart(2, '0') +
-      ':' +
-      String(now.getMinutes()).padStart(2, '0') +
-      ':' +
-      String(now.getSeconds()).padStart(2, '0');
-
+    var ts = emFormatNow();
     refreshable.forEach(function (m) {
+      // Q5 atomic-swap demo: set window.emSimulateError=true to leave equipment in error state
+      if (window.emSimulateError && m.id === 'equipment') {
+        m.status = 'error';
+        if (!m.history) m.history = [];
+        m.history.unshift({
+          at: ts,
+          result: 'error',
+          note: '전체 새로고침 — 연결 실패 (다른 소스는 정상 완료)',
+        });
+        if (m.history.length > 3) m.history = m.history.slice(0, 3);
+        showEmToast(m.name + ' 실패 — 나머지 소스는 정상 완료', 'error');
+        return;
+      }
       m.loadedAt = ts;
       m.status = 'loaded';
       m.itemCount = m.itemCount + Math.floor(Math.random() * 5);
+      m.lastRefreshedAt = Date.now();
       if (!m.history) m.history = [];
       m.history.unshift({
         at: ts,
@@ -225,13 +271,9 @@ function emRefreshAll() {
       if (m.history.length > 3) m.history = m.history.slice(0, 3);
       showEmToast(m.name + ' 완료 (' + m.itemCount + '건)', 'ok');
     });
-
     renderExternalMasters();
   }, 1200);
 }
 
-// ── Export
-window.AdminExternalMasters = {
-  render: renderExternalMasters,
-};
+window.AdminExternalMasters = { render: renderExternalMasters };
 window.emRefreshAll = emRefreshAll;

--- a/prototype/js/admin-external-masters.js
+++ b/prototype/js/admin-external-masters.js
@@ -1,0 +1,237 @@
+// Stage B-12 P-10 — External Masters 관리 prototype module
+// Depends on: dom-utils.js (escHtml, showToast), admin-external-masters-data.js
+// Export: window.AdminExternalMasters = { render }
+
+// ── Status badge config
+var EM_STATUS = {
+  loaded: { label: '정상', cls: 'em-badge-loaded' },
+  'cold-start': { label: '콜드 스타트', cls: 'em-badge-cold' },
+  snapshot: { label: '스냅샷 모드', cls: 'em-badge-snapshot' },
+  error: { label: '오류', cls: 'em-badge-error' },
+};
+
+// ── History result config
+var EM_HIST = {
+  ok: { icon: 'check-circle', cls: 'em-hist-ok' },
+  error: { icon: 'x-circle', cls: 'em-hist-error' },
+};
+
+// ── Toast wrapper
+function showEmToast(msg, kind) {
+  if (typeof window.showToast === 'function') window.showToast(msg, kind);
+}
+
+// ── Render a single master card
+function renderEmCard(m) {
+  var esc = window.escHtml;
+  var status = EM_STATUS[m.status] || EM_STATUS['error'];
+  var histHtml = '';
+
+  if (m.history && m.history.length) {
+    var rows = m.history
+      .map(function (h) {
+        var hc = EM_HIST[h.result] || EM_HIST['error'];
+        return (
+          '<li class="em-hist-row ' +
+          hc.cls +
+          '">' +
+          '<i data-lucide="' +
+          hc.icon +
+          '" class="em-hist-icon"></i>' +
+          '<span class="em-hist-time">' +
+          esc(h.at) +
+          '</span>' +
+          '<span class="em-hist-note">' +
+          esc(h.note) +
+          '</span>' +
+          '</li>'
+        );
+      })
+      .join('');
+    histHtml =
+      '<details class="em-history" open>' +
+      '<summary class="em-history-summary">' +
+      '<i data-lucide="history" style="width:12px;height:12px;vertical-align:-2px"></i>' +
+      ' 최근 새로고침 이력</summary>' +
+      '<ul class="em-hist-list">' +
+      rows +
+      '</ul>' +
+      '</details>';
+  } else {
+    histHtml =
+      '<div class="em-no-history">' +
+      '<i data-lucide="clock-x" style="width:13px;height:13px;color:var(--text-quaternary);vertical-align:-2px"></i>' +
+      ' <span>이력 없음 — 아직 새로고침이 실행된 적 없습니다.</span>' +
+      '</div>';
+  }
+
+  var loadedStr = m.loadedAt
+    ? esc(m.loadedAt)
+    : '<span style="color:var(--text-quaternary)">—</span>';
+
+  var countStr = m.loadedAt
+    ? esc(String(m.itemCount)) + '건'
+    : '<span style="color:var(--text-quaternary)">0건</span>';
+
+  var refreshBtn = m.refreshable
+    ? '<button type="button" class="a-btn em-refresh-btn" data-id="' +
+      esc(m.id) +
+      '">' +
+      '<i data-lucide="refresh-cw" style="width:12px;height:12px;vertical-align:-2px"></i>' +
+      ' 새로고침</button>'
+    : '<span class="em-no-refresh">' +
+      '<i data-lucide="lock" style="width:11px;height:11px;vertical-align:-2px"></i>' +
+      ' 서버 재시작 전용</span>';
+
+  return (
+    '<div class="em-card" data-id="' +
+    esc(m.id) +
+    '">' +
+    '<div class="em-card-header">' +
+    '<span class="em-card-name">' +
+    esc(m.name) +
+    '</span>' +
+    '<span class="em-badge ' +
+    status.cls +
+    '">' +
+    status.label +
+    '</span>' +
+    '</div>' +
+    '<div class="em-card-source">' +
+    '<i data-lucide="database" style="width:11px;height:11px;vertical-align:-2px;color:var(--text-quaternary)"></i>' +
+    ' ' +
+    esc(m.source) +
+    '</div>' +
+    '<div class="em-card-meta">' +
+    '<span class="em-meta-item"><i data-lucide="layers" style="width:11px;height:11px;vertical-align:-2px"></i> ' +
+    countStr +
+    '</span>' +
+    '<span class="em-meta-item"><i data-lucide="clock" style="width:11px;height:11px;vertical-align:-2px"></i> 마지막 갱신: ' +
+    loadedStr +
+    '</span>' +
+    '</div>' +
+    histHtml +
+    '<div class="em-card-footer">' +
+    refreshBtn +
+    '</div>' +
+    '</div>'
+  );
+}
+
+// ── Main render
+function renderExternalMasters() {
+  var section = document.getElementById('page-external-masters');
+  if (!section) return;
+
+  var data = window.externalMastersData || [];
+  var grid = document.getElementById('emGrid');
+  if (!grid) return;
+
+  if (!data.length) {
+    grid.innerHTML =
+      '<div style="display:flex;flex-direction:column;align-items:center;' +
+      'justify-content:center;min-height:220px;gap:10px">' +
+      '<i data-lucide="database-x" style="width:32px;height:32px;color:var(--text-quaternary)"></i>' +
+      '<span style="font-size:13.5px;color:var(--text-secondary)">등록된 외부 마스터가 없습니다.</span>' +
+      '</div>';
+  } else {
+    grid.innerHTML = data.map(renderEmCard).join('');
+  }
+
+  if (window.lucide) lucide.createIcons();
+
+  // Wire per-card refresh buttons
+  grid.querySelectorAll('.em-refresh-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      emRefreshOne(btn.dataset.id);
+    });
+  });
+}
+
+// ── Refresh single source (mock)
+function emRefreshOne(id) {
+  var data = window.externalMastersData || [];
+  var m = data.find(function (x) {
+    return x.id === id;
+  });
+  if (!m || !m.refreshable) return;
+
+  showEmToast(m.name + ' 새로고침 중…', 'info');
+
+  setTimeout(function () {
+    var now = new Date();
+    var ts =
+      now.getFullYear() +
+      '-' +
+      String(now.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(now.getDate()).padStart(2, '0') +
+      ' ' +
+      String(now.getHours()).padStart(2, '0') +
+      ':' +
+      String(now.getMinutes()).padStart(2, '0') +
+      ':' +
+      String(now.getSeconds()).padStart(2, '0');
+
+    m.loadedAt = ts;
+    m.status = 'loaded';
+    m.itemCount = m.itemCount + Math.floor(Math.random() * 5);
+    if (!m.history) m.history = [];
+    m.history.unshift({ at: ts, result: 'ok', note: '새로고침 성공 (' + m.itemCount + '건)' });
+    if (m.history.length > 3) m.history = m.history.slice(0, 3);
+
+    showEmToast(m.name + ' 새로고침 완료 (' + m.itemCount + '건)', 'ok');
+    renderExternalMasters();
+  }, 900);
+}
+
+// ── Bulk refresh all refreshable sources
+function emRefreshAll() {
+  var data = window.externalMastersData || [];
+  var refreshable = data.filter(function (m) {
+    return m.refreshable;
+  });
+  if (!refreshable.length) return;
+
+  refreshable.forEach(function (m) {
+    showEmToast(m.name + ' 새로고침 중…', 'info');
+  });
+
+  setTimeout(function () {
+    var now = new Date();
+    var ts =
+      now.getFullYear() +
+      '-' +
+      String(now.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(now.getDate()).padStart(2, '0') +
+      ' ' +
+      String(now.getHours()).padStart(2, '0') +
+      ':' +
+      String(now.getMinutes()).padStart(2, '0') +
+      ':' +
+      String(now.getSeconds()).padStart(2, '0');
+
+    refreshable.forEach(function (m) {
+      m.loadedAt = ts;
+      m.status = 'loaded';
+      m.itemCount = m.itemCount + Math.floor(Math.random() * 5);
+      if (!m.history) m.history = [];
+      m.history.unshift({
+        at: ts,
+        result: 'ok',
+        note: '전체 새로고침 성공 (' + m.itemCount + '건)',
+      });
+      if (m.history.length > 3) m.history = m.history.slice(0, 3);
+      showEmToast(m.name + ' 완료 (' + m.itemCount + '건)', 'ok');
+    });
+
+    renderExternalMasters();
+  }, 1200);
+}
+
+// ── Export
+window.AdminExternalMasters = {
+  render: renderExternalMasters,
+};
+window.emRefreshAll = emRefreshAll;

--- a/prototype/js/sidebar.js
+++ b/prototype/js/sidebar.js
@@ -133,6 +133,7 @@ function setNav(el) {
     if (page === 'tag-master') renderTagMaster();
     if (page === 'dashboard') dashboardInit();
     if (page === 'trash') AdminTrash.render();
+    if (page === 'external-masters') AdminExternalMasters.render();
     lucide.createIcons();
   }
 }

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -56,6 +56,9 @@
     <!-- BEGIN P-8 Trash (Stage B-7 D23) -->
     <div class="nav-item" onclick="setNav(this)" data-page="trash"><i data-lucide="trash-2"></i> 휴지통</div>
     <!-- END P-8 Trash -->
+    <!-- BEGIN P-10 External Masters (Stage B-12) -->
+    <div class="nav-item" onclick="setNav(this)" data-page="external-masters"><i data-lucide="plug"></i> 외부 마스터</div>
+    <!-- END P-10 External Masters -->
   </div>
   </div>
   <div class="sidebar-user">
@@ -708,6 +711,24 @@
 </section>
 <!-- END P-8 Trash -->
 
+<!-- ============================================================ -->
+<!-- BEGIN P-10 External Masters (Stage B-12)                     -->
+<!-- ============================================================ -->
+<section id="page-external-masters" class="admin-page">
+  <div class="admin-topbar">
+    <span class="admin-title">외부 마스터</span>
+    <div class="spacer"></div>
+    <button type="button" class="a-btn primary" onclick="emRefreshAll()">
+      <i data-lucide="refresh-cw" style="width:13px;height:13px;vertical-align:-2px"></i>
+      전체 새로고침
+    </button>
+  </div>
+  <div class="admin-body" style="padding:16px 20px">
+    <div id="emGrid" class="em-grid"></div>
+  </div>
+</section>
+<!-- END P-10 External Masters -->
+
 </main>
 
 <!-- ── Drawer ─── -->
@@ -882,6 +903,10 @@
 <script src="js/admin-trash.js"></script>
 <script src="js/admin-trash-modals.js"></script>
 <!-- END P-8 Trash -->
+<!-- BEGIN P-10 External Masters (Stage B-12) -->
+<script src="js/admin-external-masters-data.js"></script>
+<script src="js/admin-external-masters.js"></script>
+<!-- END P-10 External Masters -->
 <script src="js/init.js"></script>
 </body>
 </html>

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -718,12 +718,31 @@
   <div class="admin-topbar">
     <span class="admin-title">외부 마스터</span>
     <div class="spacer"></div>
-    <button type="button" class="a-btn primary" onclick="emRefreshAll()">
+    <!-- H4: scope label — program master excluded (server-restart only) -->
+    <button type="button" class="admin-btn" onclick="emRefreshAll()"
+      title="MSSQL 소스(설비·DB 마스터)만 새로고침 — 프로그램 마스터는 서버 재시작으로만 갱신">
       <i data-lucide="refresh-cw" style="width:13px;height:13px;vertical-align:-2px"></i>
       전체 새로고침
+      <span class="em-bulk-sublabel">(MSSQL 2종만)</span>
     </button>
   </div>
   <div class="admin-body" style="padding:16px 20px">
+    <!-- H2: Cold-start system-wide banner — shown/hidden by JS -->
+    <div id="emColdStartBanner" class="em-coldstart-banner">
+      <i data-lucide="alert-triangle" style="width:16px;height:16px;flex-shrink:0"></i>
+      <span class="em-coldstart-banner-text">
+        콜드스타트 모드 (스냅샷 파일 미존재 — 전 필드 unverified)
+      </span>
+      <button type="button" class="admin-btn em-coldstart-banner-btn"
+        onclick="window.emMockColdStart=false;window.AdminExternalMasters&&AdminExternalMasters.render()">
+        boot 완료 시뮬레이션
+      </button>
+    </div>
+    <!-- H1: Q5 source-independence note -->
+    <div class="em-atomic-note">
+      <i data-lucide="git-fork" style="width:12px;height:12px"></i>
+      각 소스별 독립 atomic swap — 실패 시 해당 소스만 영향 (Q5 소스 독립 정책)
+    </div>
     <div id="emGrid" class="em-grid"></div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- external-masters.md §1~§8 + §16.3 (콜드스타트/스냅샷) prototype 데모
- 신규: admin-external-masters.js (201) + admin-external-masters-data.js (55)
- 3 카드 (Equipment/DB/Program), 콜드스타트 글로벌 배너, 스냅샷 모드, 5분 쿨다운, Q5 source-independence 시연

## Review

R1 평균 82.3 (verifier 98.3 / security 81 / code 87.7 / designer 79.3 / critic 65)
critic spec 정합성 HIGH 5건 + code-reviewer CRITICAL 1건 일괄 fix:
- 콜드스타트 글로벌 화 (spec §16.3 정합)
- 스냅샷 timestamp 2종 분리
- 5분 쿨다운 카운트다운 UI
- Q5 source-independence 시각 안내 + 시뮬

## Test plan
- [x] node --check 2 JS files
- [x] typecheck pass
- [x] 토큰 grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)