### PR TITLE
feat(prototype): P-12 알림 유형별 + Urgent 뱃지

### DIFF
--- a/prototype/css/admin.css
+++ b/prototype/css/admin.css
@@ -2940,3 +2940,187 @@ details[open] .em-history-summary::before {
 
 /* ============================================================ */
 /* END P-10 External Masters ─────────────────────────────────── */
+
+/* ============================================================ */
+/* BEGIN P-12 Notifications (Stage B-14) ─────────────────────── */
+
+/* ── Filter chips ─────────────────────────────────────────── */
+.nf-chips {
+  display: flex;
+  gap: 6px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.nf-chips::-webkit-scrollbar {
+  display: none;
+}
+
+.nf-chip {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 20px;
+  border: 1px solid var(--border-standard);
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
+}
+.nf-chip:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+.nf-chip--active {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: var(--bg-app);
+}
+
+/* ── Type-coloured icons ──────────────────────────────────── */
+.nf-icon--brand {
+  background: var(--brand-bg) !important;
+}
+.nf-icon--brand svg {
+  color: var(--brand) !important;
+}
+.nf-icon--blue {
+  background: var(--status-blue-bg, var(--bg-elevated)) !important;
+}
+.nf-icon--blue svg {
+  color: var(--status-blue) !important;
+}
+.nf-icon--green {
+  background: var(--status-green-bg, var(--bg-elevated)) !important;
+}
+.nf-icon--green svg {
+  color: var(--status-green) !important;
+}
+.nf-icon--red {
+  background: var(--status-red-bg) !important;
+}
+.nf-icon--red svg {
+  color: var(--status-red) !important;
+}
+.nf-icon--amber {
+  background: var(--status-amber-bg) !important;
+}
+.nf-icon--amber svg {
+  color: var(--status-amber) !important;
+}
+.nf-icon--purple {
+  background: var(--status-purple-bg) !important;
+}
+.nf-icon--purple svg {
+  color: var(--status-purple) !important;
+}
+
+/* Unread overrides type colour with brand (existing pattern) */
+.notif-item.unread .notif-icon[class*='nf-icon--'] {
+  background: var(--brand) !important;
+}
+.notif-item.unread .notif-icon[class*='nf-icon--'] svg {
+  color: var(--bg-app) !important;
+}
+
+/* ── Urgent row highlight ─────────────────────────────────── */
+.notif-item.nf-urgent-row {
+  background: var(--status-red-bg);
+}
+.notif-item.nf-urgent-row:hover {
+  background: var(--status-red-bg);
+  filter: brightness(0.97);
+}
+
+/* ── Urgent inline badge (inside notification text) ─────── */
+.nf-urgent-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+.nf-urgent-badge svg {
+  width: 12px;
+  height: 12px;
+  color: var(--status-red);
+}
+
+/* ── Bell button — count badge ────────────────────────────── */
+.nf-count-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--status-red);
+  color: var(--bg-app);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  pointer-events: none;
+}
+
+/* ── Bell button — urgent exclamation badge ───────────────── */
+.nf-bell-urgent {
+  position: absolute;
+  bottom: -4px;
+  right: -2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--status-red);
+  color: var(--bg-app);
+  font-size: 10px;
+  font-weight: 900;
+  line-height: 14px;
+  text-align: center;
+  pointer-events: none;
+}
+
+/* Ensure notifBtn is position relative for badge positioning */
+#notifBtn {
+  position: relative;
+}
+
+/* ── Unread count label in header ─────────────────────────── */
+#nfUnreadLabel {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+/* ── List container scroll ────────────────────────────────── */
+#nfList {
+  max-height: 380px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-standard) transparent;
+}
+
+/* ── Empty state §13.11 ───────────────────────────────────── */
+.nf-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 16px;
+  color: var(--text-secondary);
+  font-size: 13.5px;
+}
+.nf-empty svg {
+  width: 28px;
+  height: 28px;
+  color: var(--text-secondary);
+  opacity: 0.5;
+}
+
+/* ============================================================ */
+/* END P-12 Notifications ─────────────────────────────────────── */

--- a/prototype/css/admin.css
+++ b/prototype/css/admin.css
@@ -2983,58 +2983,68 @@ details[open] .em-history-summary::before {
 }
 
 /* ── Type-coloured icons ──────────────────────────────────── */
-.nf-icon--brand {
-  background: var(--brand-bg) !important;
+/* M1: !important removed — .nf-list .notif-icon specificity handles cascade */
+.nf-list .notif-icon.nf-icon--brand {
+  background: var(--brand-bg);
 }
-.nf-icon--brand svg {
-  color: var(--brand) !important;
+.nf-list .notif-icon.nf-icon--brand svg {
+  color: var(--brand);
 }
-.nf-icon--blue {
-  background: var(--status-blue-bg, var(--bg-elevated)) !important;
+.nf-list .notif-icon.nf-icon--blue {
+  background: var(--status-blue-bg, var(--bg-elevated));
 }
-.nf-icon--blue svg {
-  color: var(--status-blue) !important;
+.nf-list .notif-icon.nf-icon--blue svg {
+  color: var(--status-blue);
 }
-.nf-icon--green {
-  background: var(--status-green-bg, var(--bg-elevated)) !important;
+.nf-list .notif-icon.nf-icon--green {
+  background: var(--status-green-bg, var(--bg-elevated));
 }
-.nf-icon--green svg {
-  color: var(--status-green) !important;
+.nf-list .notif-icon.nf-icon--green svg {
+  color: var(--status-green);
 }
-.nf-icon--red {
-  background: var(--status-red-bg) !important;
+.nf-list .notif-icon.nf-icon--red {
+  background: var(--status-red-bg);
 }
-.nf-icon--red svg {
-  color: var(--status-red) !important;
+.nf-list .notif-icon.nf-icon--red svg {
+  color: var(--status-red);
 }
-.nf-icon--amber {
-  background: var(--status-amber-bg) !important;
+.nf-list .notif-icon.nf-icon--amber {
+  background: var(--status-amber-bg);
 }
-.nf-icon--amber svg {
-  color: var(--status-amber) !important;
+.nf-list .notif-icon.nf-icon--amber svg {
+  color: var(--status-amber);
 }
-.nf-icon--purple {
-  background: var(--status-purple-bg) !important;
+.nf-list .notif-icon.nf-icon--purple {
+  background: var(--status-purple-bg);
 }
-.nf-icon--purple svg {
-  color: var(--status-purple) !important;
+.nf-list .notif-icon.nf-icon--purple svg {
+  color: var(--status-purple);
 }
 
 /* Unread overrides type colour with brand (existing pattern) */
-.notif-item.unread .notif-icon[class*='nf-icon--'] {
-  background: var(--brand) !important;
+.nf-list .notif-item.unread .notif-icon[class*='nf-icon--'] {
+  background: var(--brand);
 }
-.notif-item.unread .notif-icon[class*='nf-icon--'] svg {
-  color: var(--bg-app) !important;
+.nf-list .notif-item.unread .notif-icon[class*='nf-icon--'] svg {
+  color: var(--bg-app);
+}
+
+/* M2: Unread urgent stays red (exempt from brand override) */
+.nf-list .notif-item.unread .notif-icon.nf-icon--red {
+  background: var(--status-red-bg);
+  color: var(--status-red);
+}
+.nf-list .notif-item.unread .notif-icon.nf-icon--red svg {
+  color: var(--status-red);
 }
 
 /* ── Urgent row highlight ─────────────────────────────────── */
 .notif-item.nf-urgent-row {
   background: var(--status-red-bg);
 }
+/* M4: replace filter: brightness() with proper token-based overlay */
 .notif-item.nf-urgent-row:hover {
-  background: var(--status-red-bg);
-  filter: brightness(0.97);
+  background: var(--bg-elevated);
 }
 
 /* ── Urgent inline badge (inside notification text) ─────── */

--- a/prototype/js/notif.js
+++ b/prototype/js/notif.js
@@ -1,28 +1,239 @@
-// ── Notifications
-function toggleNotif() {
-  document.getElementById('notifPanel').classList.toggle('open');
+// ── P-12 Notifications ───────────────────────────────────────────────────────
+
+const NOTIF_TYPES = {
+  COMMENT: { key: 'comment', icon: 'message-circle', label: '댓글', color: 'brand' },
+  STATUS: { key: 'status', icon: 'refresh-cw', label: '상태', color: 'blue' },
+  ASSIGNEE: { key: 'assignee', icon: 'user-check', label: '담당자', color: 'green' },
+  URGENT: { key: 'urgent', icon: 'alert-triangle', label: 'Urgent', color: 'red' },
+  NOTICE: { key: 'notice', icon: 'megaphone', label: '공지', color: 'amber' },
+  FAQ: { key: 'faq', icon: 'help-circle', label: 'FAQ', color: 'purple' },
+};
+
+const MOCK_NOTIFS = [
+  {
+    id: 1,
+    type: 'urgent',
+    unread: true,
+    urgent: true,
+    voc: '분석-2025-0009',
+    text: '<strong>분석-2025-0009</strong> Urgent VOC 담당자로 배정됐습니다.',
+    time: '방금 전',
+  },
+  {
+    id: 2,
+    type: 'comment',
+    unread: true,
+    urgent: false,
+    voc: '분석-2025-0001',
+    text: '<strong>박개발</strong>님이 <strong>분석-2025-0001</strong>에 댓글을 달았습니다.',
+    time: '5분 전',
+  },
+  {
+    id: 3,
+    type: 'status',
+    unread: true,
+    urgent: false,
+    voc: '분석-2025-0001',
+    text: '<strong>분석-2025-0001</strong> 상태가 <strong>처리중</strong>으로 변경됐습니다.',
+    time: '어제 14:23',
+  },
+  {
+    id: 4,
+    type: 'urgent',
+    unread: true,
+    urgent: true,
+    voc: '파이프-2025-0007',
+    text: '<strong>파이프-2025-0007</strong> Urgent VOC 상태가 <strong>긴급검토</strong>로 변경됐습니다.',
+    time: '어제 11:40',
+  },
+  {
+    id: 5,
+    type: 'assignee',
+    unread: false,
+    urgent: false,
+    voc: '분석-2025-0047',
+    text: '<strong>분석-2025-0047</strong>의 담당자로 배정됐습니다.',
+    time: '어제 10:05',
+  },
+  {
+    id: 6,
+    type: 'comment',
+    unread: false,
+    urgent: false,
+    voc: '파이프-2025-0002',
+    text: '<strong>이분석</strong>님이 <strong>파이프라인-2025-0002</strong>에 댓글을 달았습니다.',
+    time: '2025.06.11',
+  },
+  {
+    id: 7,
+    type: 'notice',
+    unread: false,
+    urgent: false,
+    voc: null,
+    text: '서비스 점검 공지: 6월 15일(일) 02:00–04:00 시스템 점검 예정입니다.',
+    time: '2025.06.10',
+  },
+  {
+    id: 8,
+    type: 'faq',
+    unread: false,
+    urgent: false,
+    voc: null,
+    text: 'FAQ <strong>결재 프로세스 안내</strong> 항목이 업데이트됐습니다.',
+    time: '2025.06.09',
+  },
+  {
+    id: 9,
+    type: 'status',
+    unread: false,
+    urgent: false,
+    voc: '분석-2025-0033',
+    text: '<strong>분석-2025-0033</strong> 상태가 <strong>완료</strong>로 변경됐습니다.',
+    time: '2025.06.08',
+  },
+];
+
+// Active filter key ('all' or a NOTIF_TYPES key)
+let _activeFilter = 'all';
+
+// ── Render ────────────────────────────────────────────────────────────────────
+function renderNotifPanel() {
+  const list = document.getElementById('nfList');
+  if (!list) return;
+
+  const filtered =
+    _activeFilter === 'all' ? MOCK_NOTIFS : MOCK_NOTIFS.filter((n) => n.type === _activeFilter);
+
+  if (filtered.length === 0) {
+    list.innerHTML = `<div class="nf-empty"><i data-lucide="bell-off"></i><span>알림이 없습니다.</span></div>`;
+    lucide.createIcons({ nodes: [list] });
+    return;
+  }
+
+  list.innerHTML = filtered
+    .map((n) => {
+      const typeInfo =
+        Object.values(NOTIF_TYPES).find((t) => t.key === n.type) || NOTIF_TYPES.COMMENT;
+      const urgentBadge = n.urgent
+        ? `<span class="nf-urgent-badge" aria-label="Urgent"><i data-lucide="alert-octagon"></i></span>`
+        : '';
+      const unreadDot = n.unread ? `<div class="notif-dot-unread"></div>` : '';
+      return `
+      <div class="notif-item${n.unread ? ' unread' : ''}${n.urgent ? ' nf-urgent-row' : ''}"
+           data-nf-id="${n.id}" onclick="markReadById(${n.id})">
+        <div class="notif-icon nf-icon--${typeInfo.color}">
+          <i data-lucide="${typeInfo.icon}"></i>
+        </div>
+        <div class="notif-content">
+          <p>${n.text}${urgentBadge}</p>
+          <div class="notif-time">${n.time}</div>
+        </div>
+        ${unreadDot}
+      </div>`;
+    })
+    .join('');
+
+  lucide.createIcons({ nodes: [list] });
 }
+
+// ── Filter ────────────────────────────────────────────────────────────────────
+function filterByType(key) {
+  _activeFilter = key;
+  // Update chip active state
+  document.querySelectorAll('.nf-chip').forEach((chip) => {
+    chip.classList.toggle('nf-chip--active', chip.dataset.filter === key);
+  });
+  renderNotifPanel();
+}
+
+// ── Mark read ─────────────────────────────────────────────────────────────────
+function markReadById(id) {
+  const notif = MOCK_NOTIFS.find((n) => n.id === id);
+  if (!notif || !notif.unread) return;
+  notif.unread = false;
+  if (notif.urgent) notif.urgent = false; // clear urgent badge when read
+  renderNotifPanel();
+  syncBadge();
+}
+
 function markRead(item) {
+  // Legacy DOM-based handler (kept for backward compat)
+  const id = parseInt(item.dataset.nfId, 10);
+  if (id) {
+    markReadById(id);
+    return;
+  }
   item.classList.remove('unread');
   const dot = item.querySelector('.notif-dot-unread');
   if (dot) dot.remove();
-  const icon = item.querySelector('.notif-icon');
-  if (icon) {
-    icon.style.background = '';
-    const svg = icon.querySelector('svg');
-    if (svg) svg.style.color = '';
-  }
-  syncNotifDot();
-}
-function markAllRead() {
-  document.querySelectorAll('.notif-item.unread').forEach(markRead);
-}
-function syncNotifDot() {
-  const dot = document.querySelector('.notif-dot');
-  if (dot) dot.style.display = document.querySelectorAll('.notif-item.unread').length ? '' : 'none';
+  syncBadge();
 }
 
-// ── Global close handlers
+function markAllRead() {
+  MOCK_NOTIFS.forEach((n) => {
+    n.unread = false;
+    n.urgent = false;
+  });
+  renderNotifPanel();
+  syncBadge();
+}
+
+// ── Badge sync ────────────────────────────────────────────────────────────────
+function syncBadge() {
+  const unreadCount = MOCK_NOTIFS.filter((n) => n.unread).length;
+  const hasUrgent = MOCK_NOTIFS.some((n) => n.unread && n.urgent);
+
+  // Dot (legacy)
+  const dot = document.querySelector('.notif-dot');
+  if (dot) dot.style.display = unreadCount ? '' : 'none';
+
+  // Count badge
+  let countBadge = document.querySelector('.nf-count-badge');
+  if (unreadCount > 0) {
+    if (!countBadge) {
+      countBadge = document.createElement('span');
+      countBadge.className = 'nf-count-badge';
+      document.getElementById('notifBtn')?.appendChild(countBadge);
+    }
+    countBadge.textContent = unreadCount > 99 ? '99+' : unreadCount;
+  } else {
+    countBadge?.remove();
+  }
+
+  // Urgent exclamation badge
+  let urgentBadge = document.querySelector('.nf-bell-urgent');
+  if (hasUrgent) {
+    if (!urgentBadge) {
+      urgentBadge = document.createElement('span');
+      urgentBadge.className = 'nf-bell-urgent';
+      urgentBadge.setAttribute('aria-label', 'Urgent 알림');
+      urgentBadge.textContent = '!';
+      document.getElementById('notifBtn')?.appendChild(urgentBadge);
+    }
+  } else {
+    urgentBadge?.remove();
+  }
+
+  // Update header unread count label
+  const countLabel = document.getElementById('nfUnreadLabel');
+  if (countLabel) countLabel.textContent = unreadCount ? ` (${unreadCount})` : '';
+}
+
+// ── Panel toggle ──────────────────────────────────────────────────────────────
+function toggleNotif() {
+  const panel = document.getElementById('notifPanel');
+  const isOpen = panel.classList.toggle('open');
+  if (isOpen) {
+    renderNotifPanel();
+  }
+}
+
+// ── Legacy syncNotifDot (kept for backward compat) ───────────────────────────
+function syncNotifDot() {
+  syncBadge();
+}
+
+// ── Global close handlers ─────────────────────────────────────────────────────
 document.addEventListener('click', (e) => {
   const panel = document.getElementById('notifPanel');
   const notBtn = document.getElementById('notifBtn');
@@ -42,7 +253,7 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-// ── Notice popup helpers (overlay element is built by init.js initNoticePopup IIFE)
+// ── Notice popup helpers ──────────────────────────────────────────────────────
 function handleHideToday(id, checked) {
   const today = new Date().toISOString().slice(0, 10);
   if (checked) localStorage.setItem('notice_hide_' + id, today);
@@ -57,3 +268,8 @@ function closeNoticePopup() {
   const el = document.getElementById('noticePopupOverlay');
   if (el) el.remove();
 }
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+  syncBadge();
+});

--- a/prototype/js/notif.js
+++ b/prototype/js/notif.js
@@ -4,19 +4,21 @@ const NOTIF_TYPES = {
   COMMENT: { key: 'comment', icon: 'message-circle', label: '댓글', color: 'brand' },
   STATUS: { key: 'status', icon: 'refresh-cw', label: '상태', color: 'blue' },
   ASSIGNEE: { key: 'assignee', icon: 'user-check', label: '담당자', color: 'green' },
-  URGENT: { key: 'urgent', icon: 'alert-triangle', label: 'Urgent', color: 'red' },
   NOTICE: { key: 'notice', icon: 'megaphone', label: '공지', color: 'amber' },
   FAQ: { key: 'faq', icon: 'help-circle', label: 'FAQ', color: 'purple' },
+  DEFAULT: { key: 'default', icon: 'bell', label: '기타', color: 'brand' },
 };
 
+// urgent is a flag on assignee/status items (not a type); actor/vocId/action avoids raw HTML.
 const MOCK_NOTIFS = [
   {
     id: 1,
-    type: 'urgent',
+    type: 'assignee',
     unread: true,
     urgent: true,
-    voc: '분석-2025-0009',
-    text: '<strong>분석-2025-0009</strong> Urgent VOC 담당자로 배정됐습니다.',
+    actor: '',
+    vocId: '분석-2025-0009',
+    action: 'Urgent VOC 담당자로 배정됐습니다.',
     time: '방금 전',
   },
   {
@@ -24,8 +26,9 @@ const MOCK_NOTIFS = [
     type: 'comment',
     unread: true,
     urgent: false,
-    voc: '분석-2025-0001',
-    text: '<strong>박개발</strong>님이 <strong>분석-2025-0001</strong>에 댓글을 달았습니다.',
+    actor: '박개발',
+    vocId: '분석-2025-0001',
+    action: '님이 댓글을 달았습니다.',
     time: '5분 전',
   },
   {
@@ -33,17 +36,19 @@ const MOCK_NOTIFS = [
     type: 'status',
     unread: true,
     urgent: false,
-    voc: '분석-2025-0001',
-    text: '<strong>분석-2025-0001</strong> 상태가 <strong>처리중</strong>으로 변경됐습니다.',
+    actor: '',
+    vocId: '분석-2025-0001',
+    action: '상태가 처리중으로 변경됐습니다.',
     time: '어제 14:23',
   },
   {
     id: 4,
-    type: 'urgent',
+    type: 'status',
     unread: true,
     urgent: true,
-    voc: '파이프-2025-0007',
-    text: '<strong>파이프-2025-0007</strong> Urgent VOC 상태가 <strong>긴급검토</strong>로 변경됐습니다.',
+    actor: '',
+    vocId: '파이프-2025-0007',
+    action: 'Urgent VOC 상태가 긴급검토로 변경됐습니다.',
     time: '어제 11:40',
   },
   {
@@ -51,8 +56,9 @@ const MOCK_NOTIFS = [
     type: 'assignee',
     unread: false,
     urgent: false,
-    voc: '분석-2025-0047',
-    text: '<strong>분석-2025-0047</strong>의 담당자로 배정됐습니다.',
+    actor: '',
+    vocId: '분석-2025-0047',
+    action: '담당자로 배정됐습니다.',
     time: '어제 10:05',
   },
   {
@@ -60,8 +66,9 @@ const MOCK_NOTIFS = [
     type: 'comment',
     unread: false,
     urgent: false,
-    voc: '파이프-2025-0002',
-    text: '<strong>이분석</strong>님이 <strong>파이프라인-2025-0002</strong>에 댓글을 달았습니다.',
+    actor: '이분석',
+    vocId: '파이프-2025-0002',
+    action: '님이 댓글을 달았습니다.',
     time: '2025.06.11',
   },
   {
@@ -69,8 +76,9 @@ const MOCK_NOTIFS = [
     type: 'notice',
     unread: false,
     urgent: false,
-    voc: null,
-    text: '서비스 점검 공지: 6월 15일(일) 02:00–04:00 시스템 점검 예정입니다.',
+    actor: '',
+    vocId: null,
+    action: '서비스 점검 공지: 6월 15일(일) 02:00–04:00 점검 예정.',
     time: '2025.06.10',
   },
   {
@@ -78,8 +86,9 @@ const MOCK_NOTIFS = [
     type: 'faq',
     unread: false,
     urgent: false,
-    voc: null,
-    text: 'FAQ <strong>결재 프로세스 안내</strong> 항목이 업데이트됐습니다.',
+    actor: '',
+    vocId: null,
+    action: 'FAQ 결재 프로세스 안내 항목이 업데이트됐습니다.',
     time: '2025.06.09',
   },
   {
@@ -87,22 +96,52 @@ const MOCK_NOTIFS = [
     type: 'status',
     unread: false,
     urgent: false,
-    voc: '분석-2025-0033',
-    text: '<strong>분석-2025-0033</strong> 상태가 <strong>완료</strong>로 변경됐습니다.',
+    actor: '',
+    vocId: '분석-2025-0033',
+    action: '상태가 완료로 변경됐습니다.',
     time: '2025.06.08',
   },
 ];
 
-// Active filter key ('all' or a NOTIF_TYPES key)
+// Active filter key ('all', a NOTIF_TYPES key, or 'urgent')
 let _activeFilter = 'all';
+
+// CR2: module flag to ensure delegated listener is set up only once
+let _nfListInited = false;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const esc = window.escHtml;
+
+// Builds escaped notification text; actor/vocId wrapped with <strong> after escaping.
+function buildNotifText(n) {
+  const urgentBadge = n.urgent
+    ? `<span class="nf-urgent-badge" aria-label="Urgent"><i data-lucide="alert-octagon"></i></span>`
+    : '';
+  // M5: notice items get an importance badge prefix (class defined in components.css; TODO if missing)
+  const noticeBadge = n.type === 'notice' ? `<span class="notice-badge-important">중요</span>` : '';
+  if (n.actor) {
+    return `${noticeBadge}<strong>${esc(n.actor)}</strong>(${esc(n.vocId || '')})${esc(n.action)}${urgentBadge}`;
+  }
+  if (n.vocId) {
+    return `${noticeBadge}(<strong>${esc(n.vocId)}</strong>)${esc(n.action)}${urgentBadge}`;
+  }
+  return `${noticeBadge}${esc(n.action)}${urgentBadge}`;
+}
 
 // ── Render ────────────────────────────────────────────────────────────────────
 function renderNotifPanel() {
   const list = document.getElementById('nfList');
   if (!list) return;
 
-  const filtered =
-    _activeFilter === 'all' ? MOCK_NOTIFS : MOCK_NOTIFS.filter((n) => n.type === _activeFilter);
+  // "Urgent" filter is orthogonal to type — filters by flag
+  let filtered;
+  if (_activeFilter === 'all') {
+    filtered = MOCK_NOTIFS;
+  } else if (_activeFilter === 'urgent') {
+    filtered = MOCK_NOTIFS.filter((n) => n.urgent === true);
+  } else {
+    filtered = MOCK_NOTIFS.filter((n) => n.type === _activeFilter);
+  }
 
   if (filtered.length === 0) {
     list.innerHTML = `<div class="nf-empty"><i data-lucide="bell-off"></i><span>알림이 없습니다.</span></div>`;
@@ -112,21 +151,20 @@ function renderNotifPanel() {
 
   list.innerHTML = filtered
     .map((n) => {
-      const typeInfo =
-        Object.values(NOTIF_TYPES).find((t) => t.key === n.type) || NOTIF_TYPES.COMMENT;
-      const urgentBadge = n.urgent
-        ? `<span class="nf-urgent-badge" aria-label="Urgent"><i data-lucide="alert-octagon"></i></span>`
-        : '';
+      const typeInfo = Object.values(NOTIF_TYPES).find((t) => t.key === n.type);
+      if (!typeInfo) console.warn('[notif] unknown type:', n.type, '— falling back to DEFAULT');
+      const info = typeInfo || NOTIF_TYPES.DEFAULT;
+
       const unreadDot = n.unread ? `<div class="notif-dot-unread"></div>` : '';
       return `
       <div class="notif-item${n.unread ? ' unread' : ''}${n.urgent ? ' nf-urgent-row' : ''}"
-           data-nf-id="${n.id}" onclick="markReadById(${n.id})">
-        <div class="notif-icon nf-icon--${typeInfo.color}">
-          <i data-lucide="${typeInfo.icon}"></i>
+           data-nf-id="${esc(String(n.id))}">
+        <div class="notif-icon nf-icon--${info.color}">
+          <i data-lucide="${info.icon}"></i>
         </div>
         <div class="notif-content">
-          <p>${n.text}${urgentBadge}</p>
-          <div class="notif-time">${n.time}</div>
+          <p>${buildNotifText(n)}</p>
+          <div class="notif-time">${esc(n.time)}</div>
         </div>
         ${unreadDot}
       </div>`;
@@ -134,12 +172,22 @@ function renderNotifPanel() {
     .join('');
 
   lucide.createIcons({ nodes: [list] });
+
+  // CR2: attach delegated listener once after first render
+  if (!_nfListInited) {
+    list.addEventListener('click', (e) => {
+      const item = e.target.closest('[data-nf-id]');
+      if (!item) return;
+      const id = parseInt(item.dataset.nfId, 10);
+      if (id) markReadById(id);
+    });
+    _nfListInited = true;
+  }
 }
 
 // ── Filter ────────────────────────────────────────────────────────────────────
 function filterByType(key) {
   _activeFilter = key;
-  // Update chip active state
   document.querySelectorAll('.nf-chip').forEach((chip) => {
     chip.classList.toggle('nf-chip--active', chip.dataset.filter === key);
   });
@@ -150,8 +198,7 @@ function filterByType(key) {
 function markReadById(id) {
   const notif = MOCK_NOTIFS.find((n) => n.id === id);
   if (!notif || !notif.unread) return;
-  notif.unread = false;
-  if (notif.urgent) notif.urgent = false; // clear urgent badge when read
+  notif.unread = false; // only unread toggled; urgent preserved
   renderNotifPanel();
   syncBadge();
 }
@@ -172,8 +219,7 @@ function markRead(item) {
 function markAllRead() {
   MOCK_NOTIFS.forEach((n) => {
     n.unread = false;
-    n.urgent = false;
-  });
+  }); // urgent preserved
   renderNotifPanel();
   syncBadge();
 }
@@ -183,34 +229,36 @@ function syncBadge() {
   const unreadCount = MOCK_NOTIFS.filter((n) => n.unread).length;
   const hasUrgent = MOCK_NOTIFS.some((n) => n.unread && n.urgent);
 
-  // Dot (legacy)
   const dot = document.querySelector('.notif-dot');
   if (dot) dot.style.display = unreadCount ? '' : 'none';
 
-  // Count badge
+  // M3: badges are mutually exclusive — urgent takes priority over count
+  const notifBtn = document.getElementById('notifBtn');
   let countBadge = document.querySelector('.nf-count-badge');
-  if (unreadCount > 0) {
-    if (!countBadge) {
-      countBadge = document.createElement('span');
-      countBadge.className = 'nf-count-badge';
-      document.getElementById('notifBtn')?.appendChild(countBadge);
-    }
-    countBadge.textContent = unreadCount > 99 ? '99+' : unreadCount;
-  } else {
-    countBadge?.remove();
-  }
-
-  // Urgent exclamation badge
   let urgentBadge = document.querySelector('.nf-bell-urgent');
+
   if (hasUrgent) {
+    // Show ONLY urgent badge
+    countBadge?.remove();
     if (!urgentBadge) {
       urgentBadge = document.createElement('span');
       urgentBadge.className = 'nf-bell-urgent';
       urgentBadge.setAttribute('aria-label', 'Urgent 알림');
       urgentBadge.textContent = '!';
-      document.getElementById('notifBtn')?.appendChild(urgentBadge);
+      notifBtn?.appendChild(urgentBadge);
     }
+  } else if (unreadCount > 0) {
+    // Show ONLY count badge
+    urgentBadge?.remove();
+    if (!countBadge) {
+      countBadge = document.createElement('span');
+      countBadge.className = 'nf-count-badge';
+      notifBtn?.appendChild(countBadge);
+    }
+    countBadge.textContent = unreadCount > 99 ? '99+' : unreadCount;
   } else {
+    // No unread — remove both
+    countBadge?.remove();
     urgentBadge?.remove();
   }
 

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -865,29 +865,24 @@
 </div>
 
 <!-- ── Notification Panel ─── -->
+<!-- P-12: extended with type filter chips, dynamic list, urgent badge -->
 <div class="notif-panel" id="notifPanel">
   <div class="notif-header">
-    <span class="notif-title">알림</span>
+    <span class="notif-title">알림<span id="nfUnreadLabel"></span></span>
     <span class="notif-mark" onclick="markAllRead()">모두 읽음 처리</span>
   </div>
-  <div class="notif-item unread" onclick="markRead(this)">
-    <div class="notif-icon"><i data-lucide="message-circle"></i></div>
-    <div class="notif-content"><p><strong>박개발</strong>님이 <strong>분석-2025-0001</strong>에 댓글을 달았습니다.</p><div class="notif-time">방금 전</div></div>
-    <div class="notif-dot-unread"></div>
+  <!-- P-12: type filter chips -->
+  <div class="nf-chips" role="toolbar" aria-label="알림 유형 필터">
+    <button type="button" class="nf-chip nf-chip--active" data-filter="all"      onclick="filterByType('all')">전체</button>
+    <button type="button" class="nf-chip"                 data-filter="comment"  onclick="filterByType('comment')">댓글</button>
+    <button type="button" class="nf-chip"                 data-filter="status"   onclick="filterByType('status')">상태</button>
+    <button type="button" class="nf-chip"                 data-filter="assignee" onclick="filterByType('assignee')">담당자</button>
+    <button type="button" class="nf-chip"                 data-filter="urgent"   onclick="filterByType('urgent')">Urgent</button>
+    <button type="button" class="nf-chip"                 data-filter="notice"   onclick="filterByType('notice')">공지</button>
+    <button type="button" class="nf-chip"                 data-filter="faq"      onclick="filterByType('faq')">FAQ</button>
   </div>
-  <div class="notif-item unread" onclick="markRead(this)">
-    <div class="notif-icon"><i data-lucide="refresh-cw"></i></div>
-    <div class="notif-content"><p><strong>분석-2025-0001</strong> 상태가 <strong>처리중</strong>으로 변경됐습니다.</p><div class="notif-time">어제 14:23</div></div>
-    <div class="notif-dot-unread"></div>
-  </div>
-  <div class="notif-item" onclick="markRead(this)">
-    <div class="notif-icon"><i data-lucide="user-check"></i></div>
-    <div class="notif-content"><p><strong>분석-2025-0047</strong>의 담당자로 배정됐습니다.</p><div class="notif-time">어제 10:05</div></div>
-  </div>
-  <div class="notif-item" onclick="markRead(this)">
-    <div class="notif-icon"><i data-lucide="message-circle"></i></div>
-    <div class="notif-content"><p><strong>이분석</strong>님이 <strong>파이프라인-2025-0002</strong>에 댓글을 달았습니다.</p><div class="notif-time">2025.06.11</div></div>
-  </div>
+  <!-- P-12: dynamic list rendered by notif.js renderNotifPanel() -->
+  <div id="nfList"></div>
 </div>
 
 <!-- Load order matters: helpers → data → consumers → init.js (init MUST stay last) -->


### PR DESCRIPTION
## Summary

- feature-voc.md §8.6 알림 유형 + Urgent 뱃지 prototype 데모
- notif.js 59→240 확장. 5 유형 (댓글/상태/담당자/공지/FAQ) + Urgent flag (orthogonal)
- 9 mock + 유형 필터 chips + 미읽음 숫자 + Urgent 빨강 느낌표 뱃지 (mutually exclusive)

## Review

R1 평균 82.5 (verifier 100 / security 66.7 / code 84.7 / designer 85 / critic 76)
일괄 fix:
- security XSS HIGH 2건 (raw text, inline onclick)
- critic spec divergence (Urgent flag-not-type, urgent provenance preserve)
- !important 12건 제거, bell 뱃지 mutually exclusive

## Test plan
- [x] node --check
- [x] typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)