### PR TITLE
fix(prototype): enable scroll in result review list

### DIFF
--- a/prototype/css/admin/result-review.css
+++ b/prototype/css/admin/result-review.css
@@ -5,6 +5,7 @@
   padding: 0 24px;
   border-bottom: 1px solid var(--border-subtle);
   margin-top: 4px;
+  flex-shrink: 0;
 }
 .review-tab {
   padding: 5px 11px;
@@ -43,6 +44,9 @@
 
 .review-body {
   padding: 8px 0 32px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .review-card {


### PR DESCRIPTION
## Summary
- `.admin-page` is `flex: 1; overflow: hidden`, so the result review list was being clipped when content exceeded the viewport.
- Make `.review-body` a flex child with `overflow-y: auto`, and pin `.review-tabs` with `flex-shrink: 0` so tabs stay above the scroll area.

## Test plan
- [ ] Open prototype → 결과 검토 탭, ensure list scrolls when many cards are present and tabs stay fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)