### PR TITLE
fix(prototype): 공지/FAQ 관리 모드 인라인 액션 노출 + 토글 UX 개선

### DIFF
--- a/prototype/css/admin/notice-faq-admin.css
+++ b/prototype/css/admin/notice-faq-admin.css
@@ -70,8 +70,25 @@
 .nfa-row-actions {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   flex-shrink: 0;
+}
+/* 노출 토글 + 라벨은 액션 버튼과 시각적으로 분리 (왼쪽 클러스터) */
+.nfa-row-actions .nfa-visible-toggle {
+  flex-shrink: 0;
+}
+.nfa-visible-label {
+  font-size: 11.5px;
+  font-family: var(--font-ui);
+  min-width: 32px;
+  text-align: left;
+  margin-right: 4px;
+}
+.nfa-visible-label.on {
+  color: var(--status-green, var(--accent));
+}
+.nfa-visible-label.off {
+  color: var(--text-quaternary);
 }
 .nfa-action-btn {
   padding: 3px 9px;

--- a/prototype/css/admin/notice-faq-admin.css
+++ b/prototype/css/admin/notice-faq-admin.css
@@ -73,22 +73,10 @@
   gap: 8px;
   flex-shrink: 0;
 }
-/* 노출 토글 + 라벨은 액션 버튼과 시각적으로 분리 (왼쪽 클러스터) */
+/* 노출 토글 — 액션 버튼과 시각적으로 분리 (왼쪽 클러스터) */
 .nfa-row-actions .nfa-visible-toggle {
   flex-shrink: 0;
-}
-.nfa-visible-label {
-  font-size: 11.5px;
-  font-family: var(--font-ui);
-  min-width: 32px;
-  text-align: left;
   margin-right: 4px;
-}
-.nfa-visible-label.on {
-  color: var(--status-green, var(--accent));
-}
-.nfa-visible-label.off {
-  color: var(--text-quaternary);
 }
 .nfa-action-btn {
   padding: 3px 9px;

--- a/prototype/js/data.js
+++ b/prototype/js/data.js
@@ -468,6 +468,14 @@ const FAQ_CATEGORIES = [
   { id: 4, name: '기타', order: 4, visible: true },
 ];
 
+// `const` at script scope is not exposed on `window`, but notice-admin.js /
+// faq-admin.js / faq-admin-modals.js read these via `window.NOTICES` etc.
+// Without the explicit alias they fall back to `[]` and admin actions silently
+// no-op. Aliasing the same array reference keeps user-view and admin-view in sync.
+window.NOTICES = NOTICES;
+window.FAQS = FAQS;
+window.FAQ_CATEGORIES = FAQ_CATEGORIES;
+
 // ── State
 const CURRENT_USER = '홍길동';
 let currentView = 'all'; // 'all' | 'mine' | 'assigned'

--- a/prototype/js/faq-admin.js
+++ b/prototype/js/faq-admin.js
@@ -54,17 +54,14 @@
       div.innerHTML =
         '<label class="toggle-switch nfa-visible-toggle" data-action="toggle" data-id="' +
         id +
-        '" title="노출 여부">' +
+        '" title="' +
+        (faq.visible ? '노출 ON — 클릭하여 비노출' : '비노출 — 클릭하여 노출 ON') +
+        '">' +
         '<input type="checkbox" aria-label="노출 여부 토글"' +
         (faq.visible ? ' checked' : '') +
         '>' +
         '<span class="toggle-slider"></span>' +
         '</label>' +
-        '<span class="nfa-visible-label ' +
-        (faq.visible ? 'on' : 'off') +
-        '">' +
-        (faq.visible ? '노출' : '비노출') +
-        '</span>' +
         '<button type="button" class="nfa-action-btn" data-action="edit" data-id="' +
         id +
         '">편집</button>' +

--- a/prototype/js/faq-admin.js
+++ b/prototype/js/faq-admin.js
@@ -52,29 +52,44 @@
       var div = document.createElement('div');
       div.className = 'nfa-row-actions';
       div.innerHTML =
+        '<label class="toggle-switch nfa-visible-toggle" data-action="toggle" data-id="' +
+        id +
+        '" title="노출 여부">' +
+        '<input type="checkbox" aria-label="노출 여부 토글"' +
+        (faq.visible ? ' checked' : '') +
+        '>' +
+        '<span class="toggle-slider"></span>' +
+        '</label>' +
+        '<span class="nfa-visible-label ' +
+        (faq.visible ? 'on' : 'off') +
+        '">' +
+        (faq.visible ? '노출' : '비노출') +
+        '</span>' +
         '<button type="button" class="nfa-action-btn" data-action="edit" data-id="' +
         id +
         '">편집</button>' +
         '<button type="button" class="nfa-action-btn danger" data-action="delete" data-id="' +
         id +
-        '">삭제</button>' +
-        '<button type="button" class="nfa-action-btn ' +
-        (faq.visible ? 'toggle-on' : 'toggle-off') +
-        '" data-action="toggle" data-id="' +
-        id +
-        '">' +
-        (faq.visible ? '노출중' : '비노출') +
-        '</button>';
+        '">삭제</button>';
       div.addEventListener('click', function (e) {
         e.stopPropagation();
-        var btn = e.target.closest('[data-action]');
-        if (!btn) return;
-        var action = btn.getAttribute('data-action');
-        var fid = parseInt(btn.getAttribute('data-id'), 10);
+        var trg = e.target.closest('[data-action]');
+        if (!trg) return;
+        var action = trg.getAttribute('data-action');
+        var fid = parseInt(trg.getAttribute('data-id'), 10);
         if (action === 'edit') window.FaqAdminModals && window.FaqAdminModals.openEditFaqModal(fid);
         else if (action === 'delete') softDelete(fid);
-        else if (action === 'toggle') toggleVisibility(fid);
+        else if (action === 'toggle') {
+          if (e.target.tagName === 'INPUT') return;
+          toggleVisibility(fid);
+        }
       });
+      var chk = div.querySelector('.nfa-visible-toggle input');
+      if (chk)
+        chk.addEventListener('change', function (e) {
+          e.stopPropagation();
+          toggleVisibility(id);
+        });
       row.appendChild(div);
     });
   }
@@ -194,15 +209,14 @@
           }).length;
           // §10.4.4 표시 토글은 인라인 즉시 반영 (admin only). manager는 라벨만.
           var visibleCell = canEdit
-            ? '<button type="button" class="nfa-cat-toggle ' +
-              (c.visible ? 'on' : 'off') +
-              '" data-cat-toggle="' +
+            ? '<label class="toggle-switch nfa-cat-toggle" data-cat-toggle="' +
               c.id +
-              '" aria-pressed="' +
-              (c.visible ? 'true' : 'false') +
-              '">' +
-              (c.visible ? 'ON' : 'OFF') +
-              '</button>'
+              '" title="사용자 노출">' +
+              '<input type="checkbox"' +
+              (c.visible ? ' checked' : '') +
+              ' aria-label="카테고리 노출 토글">' +
+              '<span class="toggle-slider"></span>' +
+              '</label>'
             : '<span class="nfa-cat-label ' +
               (c.visible ? 'on' : 'off') +
               '">' +
@@ -237,6 +251,8 @@
     wrap.addEventListener('click', function (e) {
       var toggleBtn = e.target.closest('[data-cat-toggle]');
       if (toggleBtn) {
+        // label 클릭 시 브라우저가 input에 synthetic click을 발화시켜 두 번 토글되는 것을 방지.
+        if (e.target.tagName === 'INPUT') return;
         toggleCategoryVisible(parseInt(toggleBtn.getAttribute('data-cat-toggle'), 10));
         return;
       }

--- a/prototype/js/init.js
+++ b/prototype/js/init.js
@@ -16,6 +16,14 @@ if (window.AdminMode && typeof window.AdminMode.init === 'function') {
   window.AdminMode.init();
 }
 
+if (window.NoticeAdmin && typeof window.NoticeAdmin.init === 'function') {
+  window.NoticeAdmin.init();
+}
+
+if (window.FaqAdmin && typeof window.FaqAdmin.init === 'function') {
+  window.FaqAdmin.init();
+}
+
 lucide.createIcons();
 renderSidebar();
 renderVOCList();

--- a/prototype/js/notice-admin.js
+++ b/prototype/js/notice-admin.js
@@ -67,29 +67,47 @@
       var div = document.createElement('div');
       div.className = 'nfa-row-actions';
       div.innerHTML =
+        '<label class="toggle-switch nfa-visible-toggle" data-action="toggle" data-id="' +
+        id +
+        '" title="노출 여부">' +
+        '<input type="checkbox" aria-label="노출 여부 토글"' +
+        (notice.visible ? ' checked' : '') +
+        '>' +
+        '<span class="toggle-slider"></span>' +
+        '</label>' +
+        '<span class="nfa-visible-label ' +
+        (notice.visible ? 'on' : 'off') +
+        '">' +
+        (notice.visible ? '노출' : '비노출') +
+        '</span>' +
         '<button type="button" class="nfa-action-btn" data-action="edit" data-id="' +
         id +
         '">편집</button>' +
         '<button type="button" class="nfa-action-btn danger" data-action="delete" data-id="' +
         id +
-        '">삭제</button>' +
-        '<button type="button" class="nfa-action-btn ' +
-        (notice.visible ? 'toggle-on' : 'toggle-off') +
-        '" data-action="toggle" data-id="' +
-        id +
-        '">' +
-        (notice.visible ? '노출중' : '비노출') +
-        '</button>';
+        '">삭제</button>';
       div.addEventListener('click', function (e) {
         e.stopPropagation();
-        var btn = e.target.closest('[data-action]');
-        if (!btn) return;
-        var action = btn.getAttribute('data-action');
-        var nid = parseInt(btn.getAttribute('data-id'), 10);
+        var trg = e.target.closest('[data-action]');
+        if (!trg) return;
+        var action = trg.getAttribute('data-action');
+        var nid = parseInt(trg.getAttribute('data-id'), 10);
         if (action === 'edit') openEditModal(nid);
         else if (action === 'delete') softDelete(nid);
-        else if (action === 'toggle') toggleVisibility(nid);
+        else if (action === 'toggle') {
+          // label 클릭은 브라우저 기본 동작으로 input 상태가 토글되므로,
+          // 두 번 토글되지 않도록 input 클릭 시에는 핸들러 스킵.
+          if (e.target.tagName === 'INPUT') return;
+          toggleVisibility(nid);
+        }
       });
+      // input 직접 클릭(또는 키보드 Space)은 change 이벤트로 처리
+      var chk = div.querySelector('.nfa-visible-toggle input');
+      if (chk)
+        chk.addEventListener('change', function (e) {
+          e.stopPropagation();
+          toggleVisibility(id);
+        });
       row.appendChild(div);
     });
   }

--- a/prototype/js/notice-admin.js
+++ b/prototype/js/notice-admin.js
@@ -69,17 +69,14 @@
       div.innerHTML =
         '<label class="toggle-switch nfa-visible-toggle" data-action="toggle" data-id="' +
         id +
-        '" title="노출 여부">' +
+        '" title="' +
+        (notice.visible ? '노출 ON — 클릭하여 비노출' : '비노출 — 클릭하여 노출 ON') +
+        '">' +
         '<input type="checkbox" aria-label="노출 여부 토글"' +
         (notice.visible ? ' checked' : '') +
         '>' +
         '<span class="toggle-slider"></span>' +
         '</label>' +
-        '<span class="nfa-visible-label ' +
-        (notice.visible ? 'on' : 'off') +
-        '">' +
-        (notice.visible ? '노출' : '비노출') +
-        '</span>' +
         '<button type="button" class="nfa-action-btn" data-action="edit" data-id="' +
         id +
         '">편집</button>' +

--- a/prototype/js/notice-faq.js
+++ b/prototype/js/notice-faq.js
@@ -28,7 +28,13 @@ function _nfMountAdmin(slotId, bodyId) {
 function renderNotices() {
   const today = new Date().toISOString().slice(0, 10);
   const el = document.getElementById('page-notices');
-  const visible = NOTICES.filter((n) => n.visible && n.from <= today && n.to >= today);
+  const adminOn =
+    window.AdminMode && window.AdminMode.isAdminMode() && window.AdminMode.canEnterAdminMode();
+  // 관리 모드: soft-delete 제외 전체 노출 (비노출/기간 외 항목도 표시 — 토글 복원 가능해야 함, spec §10.3.4 "관리 목록에는 계속 표시")
+  // 사용자 모드: 노출 ON + 기간 내 항목만
+  const visible = adminOn
+    ? NOTICES.filter((n) => !n._deleted)
+    : NOTICES.filter((n) => n.visible && n.from <= today && n.to >= today);
   const levelLabel = { urgent: '긴급', important: '중요', normal: '일반' };
   el.innerHTML = `
     <div class="admin-topbar">
@@ -71,8 +77,12 @@ let faqCategory = '전체';
 function renderFaq() {
   const el = document.getElementById('page-faq');
   const categories = ['전체', ...new Set(FAQS.map((f) => f.category))];
+  const adminOn =
+    window.AdminMode && window.AdminMode.isAdminMode() && window.AdminMode.canEnterAdminMode();
   const filtered = FAQS.filter((f) => {
-    if (!f.visible) return false;
+    if (f._deleted) return false;
+    // 관리 모드는 비노출 항목도 표시 (토글 복원 가능). 사용자 모드는 노출 ON만.
+    if (!adminOn && !f.visible) return false;
     if (faqCategory !== '전체' && f.category !== faqCategory) return false;
     if (faqQuery) {
       const q = faqQuery.toLowerCase();


### PR DESCRIPTION
## Summary
관리 모드(`?mode=admin`)에서 인라인 관리 액션이 전혀 노출되지 않던 두 가지 근본 원인 수정 + 토글 UX 통일.

### 버그 1 — `NoticeAdmin.init()` / `FaqAdmin.init()` 미호출 (`c2dfa09`)
`prototype/js/init.js`가 두 모듈의 `init()`을 호출하지 않아 `admin-mode:change` 리스너 미등록 → MutationObserver/모달 DOM 부착 실패 → 인라인 액션 미주입.

### 버그 2 — `NOTICES`/`FAQS`/`FAQ_CATEGORIES` 미노출 (`627538b`)
`data.js`가 `const`로 선언만 하고 `window`에 alias하지 않아, `notice-admin.js` / `faq-admin.js` / `faq-admin-modals.js`의 `window.NOTICES` 접근이 항상 `undefined → []` fallback. `.find()`가 `undefined` 반환 → `if (!notice) return;`에서 조용히 early-return.

### 버그 3 — 비노출 토글 시 행이 사라짐 (`89ee363`)
관리 모드에서 '노출중'을 OFF로 바꾸면 사용자 필터(`!visible`)에서도 제외돼 admin이 다시 ON으로 되돌릴 방법이 없었음. spec §10.3.4 *"관리 목록에는 계속 표시"* 위반.

### UX 개선 — 스위치 토글 (`89ee363`, `0aa31e3`)
'노출중/비노출' 텍스트 버튼 → `dashboard-settings.css`의 `.toggle-switch` 재사용 (사용자 관리·대시보드 설정과 동일 스위치). 라벨 텍스트는 군더더기여서 제거하고 `title` (호버 안내) + `aria-label`로 접근성 유지. FAQ 카테고리 표 `표시` 컬럼도 동일 스위치로 통일.

## Test plan
- [x] 공지 페이지 `?mode=admin` 진입 → `+ 공지 등록` 바, 각 행 스위치/편집/삭제 노출
- [x] 공지 토글 OFF → 행 유지, 다시 ON 가능
- [x] FAQ 페이지 동일 동작 (6건)
- [x] FAQ 카테고리 관리 탭 토글 OFF→ON 더블 토글 없이 정상
- [ ] 머지 후 main에서 새로고침 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)