### PR TITLE
docs: sync sub-directory CLAUDE.md files with Phase 7 state

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -4,7 +4,7 @@ Express REST API for the VOC management system. Read root `CLAUDE.md` first for 
 
 ## Status
 
-Phase 6 implementation in progress. `src/` is scaffolded with `index.ts`, `auth/`, and `routes/`.
+Scaffolded — feature work deferred to Phase 8. Currently `src/` has `index.ts`, `auth/` (mockLogin only — `validateADSession` is a stub for Phase 9), `routes/`. Migrations 001-011 applied; 012 (dev role), 013 (tag master), 014 (trash) drafted in `docs/specs/plans/`.
 
 ## Commands
 
@@ -16,10 +16,13 @@ npm run test -- --testPathPattern=filename       # Single test
 
 ## Architecture
 
+Planned (Phase 8 implementation):
+
 - REST CRUD for VOCs, comments, attachments, tags.
-- `validateADSession` middleware for AD/LDAP authentication — runs before every protected route.
-- Auto-tagging service: matches keyword/regex rules from the `tag_rules` table → assigns tags on VOC creation.
-- Hierarchical queries via `parent_id` self-join on the `vocs` table (sub-task trees).
+- Auth: dev uses `POST /api/auth/mock-login` (4 roles: admin/manager/dev/user). `validateADSession` / OIDC = Phase 9.
+- Auto-tagging service: keyword/regex rules from `tag_rules` → assigns tags on VOC creation.
+- Hierarchical queries via `parent_id` self-join on `vocs` (sub-task trees).
+- `assertCanManageVoc(user, voc, action)` is the single permission helper — see `feature-voc.md §8.4-bis`.
 
 ## Database Schema
 
@@ -30,6 +33,10 @@ npm run test -- --testPathPattern=filename       # Single test
 - `users` — identity; linked to AD session on login.
 - `comments` — FK → `vocs.id`.
 - `attachments` — FK → `vocs.id`; file metadata only, blob in object storage.
+- `users.role` — enum `admin`/`manager`/`dev`/`user` (migration 012).
+- `notices` / `faqs` / `faq_categories` — content tables (migration 005).
+- `voc_internal_notes` — admin/manager-only annotations (User → 404 fail-closed).
+- `voc_payload_reviews` — Result Review flow with `review_status` enum.
 
 Full schema DDL and column-level spec: `docs/specs/requires/requirements.md` (data model section).
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,7 +4,7 @@ React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-c
 
 ## Status
 
-Phase 6 implementation in progress. `src/` is scaffolded with `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, and `api/`.
+Scaffolded — actual feature implementation deferred to Phase 8. Currently in Phase 7 (prototype-driven design freeze). `src/` contains: `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, `api/`, `contexts/`, `hooks/`, `styles/`, `test/`.
 
 ## Commands
 

--- a/prototype/CLAUDE.md
+++ b/prototype/CLAUDE.md
@@ -10,7 +10,24 @@ This directory is a **visual sandbox** for design reviews — dashboard mockups,
 
 - Prototype HTML is **not** production code. Do not wire it to backend APIs.
 - When a prototype graduates to implementation, the real version goes into `frontend/` — the prototype stays as a reference snapshot.
-- Do not add build tooling here. Plain HTML + `<style>` blocks + inline `<script>` only.
+- No bundler / no transpile. The prototype loads as static HTML with `<link>` to split CSS files under `css/` and classic `<script>` tags loading modules under `js/` (Stage A-2 / A-4 split, see `docs/specs/plans/prototype-phase7-wave3-plan.md`).
+- `package.json` exists only for Playwright-driven smoke verification (`scripts/`); no app-level build step.
+
+## Layout
+
+- `prototype.html` — single entry document (~929 lines, intentionally not split further).
+- `css/` — split modules (`admin/`, `components/`, `layout/`); each file ≤500 lines.
+- `js/` — 16+ modules; data exposed on `window` via explicit aliases in `data.js` (classic-script gotcha — `const NOTICES` etc. don't auto-attach).
+- `screenshots/` — captured reference snapshots.
+- `scripts/` — Playwright + tooling helpers.
+
+## Preview
+
+Open `prototype.html` directly in a browser, or serve the directory:
+
+```bash
+npx http-server prototype -p 8080
+```
 
 ## Design Tokens (authoritative — echoed here because this is a rendered visual surface)
 


### PR DESCRIPTION
## Summary
- `frontend/CLAUDE.md`: Phase 6 → Phase 7 status, complete `src/` listing (4 dirs added)
- `backend/CLAUDE.md`: clarify mockLogin vs Phase 9 OIDC, mark architecture Planned, extend schema list (role enum, notices/faqs, voc_internal_notes, voc_payload_reviews)
- `prototype/CLAUDE.md`: drop obsolete "inline scripts only" rule (Stage A-2/A-4 already split CSS/JS), add Layout section + data.js window-alias gotcha + preview command

## Test plan
- [x] No code changes — docs only
- [x] typecheck passes (lint-staged hook ran clean on commit)
- [x] No "Phase 6" stale references remain in sub-dir CLAUDE.md files