### PR TITLE
feat(prototype-w3b): Admin 공통 컴포넌트 4건 (C-10/C-11/C-14/M-05) + R2 fix

### DIFF
--- a/prototype/css/admin/external-masters.css
+++ b/prototype/css/admin/external-masters.css
@@ -253,5 +253,40 @@ details[open] .em-history-summary::before {
   margin-left: 4px;
 }
 
+/* ── M-05 필드 매핑 섹션 ────────────────────────────────────── */
+.em-field-map-section {
+  margin-bottom: 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.em-field-map-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.em-field-map-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.em-field-map-desc {
+  font-size: 12px;
+  color: var(--text-quaternary);
+  margin-left: 4px;
+}
+
+.em-field-map-table {
+  margin: 0;
+  border-radius: 0;
+  border: none;
+}
+
 /* ============================================================ */
 /* END P-10 External Masters ─────────────────────────────────── */

--- a/prototype/css/components/admin-states.css
+++ b/prototype/css/components/admin-states.css
@@ -1,0 +1,248 @@
+/* ============================================================
+   admin-states.css — Admin Non-data States (C-14)
+   Wave 3-B · spec: uidesign §13.11
+   3 variants: .admin-empty / .admin-loading / .admin-error
+   Hard rule: zero hex / zero raw OKLCH — only var(--token)
+   ============================================================ */
+
+/* ── Demo toggle bar ────────────────────────────────────────── */
+/*
+   Injected by admin-states-demo.js into each admin page's
+   admin-topbar. Floated right, does not affect layout.
+*/
+.admin-state-toggle-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+}
+
+.admin-state-toggle-label {
+  font-size: 11px;
+  color: var(--text-quaternary);
+  white-space: nowrap;
+}
+
+.admin-state-toggle {
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-standard);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  min-width: 80px;
+}
+
+.admin-state-toggle:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--brand-bg);
+}
+
+/* ── State container ────────────────────────────────────────── */
+/*
+   .admin-state-container wraps all three state variants.
+   JS shows/hides the active child; hides normal table/content.
+*/
+.admin-state-container {
+  display: none; /* hidden by default; JS activates */
+  padding: 0 0 24px;
+}
+
+.admin-state-container.is-active {
+  display: block;
+}
+
+/* ── C-14 Empty State (.admin-empty) ───────────────────────── */
+.admin-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  gap: 12px;
+  padding: 40px 24px;
+}
+
+.admin-empty-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--text-quaternary);
+  opacity: 0.7;
+}
+
+.admin-empty-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.admin-empty-desc {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  text-align: center;
+  max-width: 320px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.admin-empty-cta {
+  margin-top: 4px;
+  padding: 7px 18px;
+  border-radius: 7px;
+  border: 1px solid var(--brand-border);
+  background: var(--brand-bg);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: border-color 0.12s;
+}
+
+.admin-empty-cta:hover {
+  border-color: var(--accent-hover);
+  color: var(--accent-hover);
+}
+
+/* ── C-14 Loading State (.admin-loading) ───────────────────── */
+.admin-loading {
+  padding: 8px 0;
+}
+
+/* Shimmer animation */
+@keyframes admin-shimmer {
+  0% {
+    background-position: -400px 0;
+  }
+  100% {
+    background-position: 400px 0;
+  }
+}
+
+.admin-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.admin-skeleton-row:last-child {
+  border-bottom: none;
+}
+
+.admin-skeleton-cell {
+  border-radius: 5px;
+  height: 14px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-elevated) 0%,
+    var(--bg-panel) 50%,
+    var(--bg-elevated) 100%
+  );
+  background-size: 800px 100%;
+  animation: admin-shimmer 1.4s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+/* Varying widths for visual realism */
+.admin-skeleton-cell.w-8 {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.admin-skeleton-cell.w-32 {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.admin-skeleton-cell.w-120 {
+  width: 120px;
+}
+.admin-skeleton-cell.w-80 {
+  width: 80px;
+}
+.admin-skeleton-cell.w-60 {
+  width: 60px;
+}
+.admin-skeleton-cell.w-40 {
+  width: 40px;
+}
+.admin-skeleton-cell.flex-1 {
+  flex: 1;
+}
+
+/* ── C-14 Error State (.admin-error) ───────────────────────── */
+.admin-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  gap: 12px;
+  padding: 40px 24px;
+}
+
+.admin-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-radius: 8px;
+  background: var(--status-red-bg);
+  border: 1px solid var(--status-red-border);
+  color: var(--status-red);
+  font-size: 13.5px;
+  font-weight: 600;
+  max-width: 420px;
+  width: 100%;
+}
+
+.admin-error-banner-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.admin-error-desc {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  text-align: center;
+  max-width: 340px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.admin-error-retry {
+  margin-top: 4px;
+  padding: 7px 18px;
+  border-radius: 7px;
+  border: 1px solid var(--status-red-border);
+  background: var(--status-red-bg);
+  color: var(--status-red);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: opacity 0.12s;
+}
+
+.admin-error-retry:hover {
+  opacity: 0.8;
+}
+
+/* ── Reduced motion override ────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .admin-skeleton-cell {
+    animation: none;
+    background: var(--bg-elevated);
+  }
+}

--- a/prototype/css/components/badges.css
+++ b/prototype/css/components/badges.css
@@ -11,12 +11,16 @@
           <span class="status-dot archived"></span> → red (archived)
           <span class="status-dot pending"></span>  → amber (pending)
 
+   Scoped to .admin-page so admin tables get the spec 7×7 size
+   without colliding with list.css (6px row badges) or
+   dashboard-edit.css (7px — coincidentally same but separate scope).
+
    Pair with a sibling text label; the dot itself carries no text.
 */
-.status-dot {
+.admin-page .status-dot {
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
   vertical-align: middle;
@@ -24,36 +28,39 @@
 }
 
 /* active — green */
-.status-dot.on {
+.admin-page .status-dot.on {
   background: var(--status-green);
+  box-shadow: 0 0 5px color-mix(in oklch, var(--status-green) 50%, transparent);
 }
 
 /* inactive — quaternary gray */
-.status-dot.off {
+.admin-page .status-dot.off {
   background: var(--text-quaternary);
 }
 
 /* archived — red */
-.status-dot.archived {
+.admin-page .status-dot.archived {
   background: var(--status-red);
 }
 
 /* pending — amber */
-.status-dot.pending {
+.admin-page .status-dot.pending {
   background: var(--status-amber);
 }
 
 /* ── C-10 Type Badge Admin ──────────────────────────────────── */
 /*
-   Usage:
-     <span class="type-badge-admin type-system">system</span>
-     <span class="type-badge-admin type-menu">menu</span>
-     <span class="type-badge-admin type-issue-kind">issue-kind</span>
-     <span class="type-badge-admin type-external">external</span>
+   .type-badge-admin — used by spec §13.4 for the voc_types.color
+   swatch chip (color passed inline; legacy only — see note below).
 
-   Also supports legacy tag-rule variants (keyword / regex) used
-   in admin-master.js renderTagRules() for the type column.
+   .type-kind-badge — typeKind classifier badge (system / menu /
+   issue-kind / external). Renamed from .type-badge-admin.type-system
+   etc. to avoid collision with the §13.4 swatch-chip class.
+
+   Also supports legacy tag-rule variants (keyword / regex) under
+   .type-badge-admin, used in admin-master.js renderTagRules().
 */
+.type-kind-badge,
 .type-badge-admin {
   display: inline-flex;
   align-items: center;
@@ -68,6 +75,7 @@
 }
 
 /* dot inside badge — injected via ::before pseudo-element */
+.type-kind-badge::before,
 .type-badge-admin::before {
   content: '';
   display: inline-block;
@@ -77,43 +85,44 @@
   flex-shrink: 0;
 }
 
-/* system → brand (blue) */
-.type-badge-admin.type-system {
+/* ── .type-kind-badge variants (typeKind classifier) ─────────
+   system → brand (blue) */
+.type-kind-badge.type-system {
   background: var(--brand-bg);
   color: var(--accent);
   border-color: var(--brand-border);
 }
-.type-badge-admin.type-system::before {
+.type-kind-badge.type-system::before {
   background: var(--accent);
 }
 
-/* menu → status-blue (using reviewing tokens which are blue-toned) */
-.type-badge-admin.type-menu {
-  background: var(--status-reviewing-bg);
-  color: var(--status-reviewing-fg);
-  border-color: var(--status-reviewing-border);
+/* menu → brand accent (not status-reviewing which has "검토중" semantic) */
+.type-kind-badge.type-menu {
+  background: var(--brand-bg);
+  color: var(--accent);
+  border-color: var(--brand-border);
 }
-.type-badge-admin.type-menu::before {
-  background: var(--status-reviewing-fg);
+.type-kind-badge.type-menu::before {
+  background: var(--accent);
 }
 
 /* issue-kind → purple */
-.type-badge-admin.type-issue-kind {
+.type-kind-badge.type-issue-kind {
   background: var(--status-purple-bg);
   color: var(--status-purple);
   border-color: var(--status-purple-border);
 }
-.type-badge-admin.type-issue-kind::before {
+.type-kind-badge.type-issue-kind::before {
   background: var(--status-purple);
 }
 
 /* external → amber */
-.type-badge-admin.type-external {
+.type-kind-badge.type-external {
   background: var(--status-amber-bg);
   color: var(--status-amber);
   border-color: var(--status-amber-border);
 }
-.type-badge-admin.type-external::before {
+.type-kind-badge.type-external::before {
   background: var(--status-amber);
 }
 

--- a/prototype/css/components/badges.css
+++ b/prototype/css/components/badges.css
@@ -1,0 +1,145 @@
+/* ============================================================
+   badges.css — Status Dot (C-11) + Type Badge Admin (C-10)
+   Wave 3-B · spec: uidesign §13.4 (TypeBadge) §13.5 (StatusDot)
+   Hard rule: zero hex / zero raw OKLCH — only var(--token)
+   ============================================================ */
+
+/* ── C-11 Status Dot ────────────────────────────────────────── */
+/*
+   Usage: <span class="status-dot on"></span>   → green  (active)
+          <span class="status-dot off"></span>  → gray   (inactive)
+          <span class="status-dot archived"></span> → red (archived)
+          <span class="status-dot pending"></span>  → amber (pending)
+
+   Pair with a sibling text label; the dot itself carries no text.
+*/
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+/* active — green */
+.status-dot.on {
+  background: var(--status-green);
+}
+
+/* inactive — quaternary gray */
+.status-dot.off {
+  background: var(--text-quaternary);
+}
+
+/* archived — red */
+.status-dot.archived {
+  background: var(--status-red);
+}
+
+/* pending — amber */
+.status-dot.pending {
+  background: var(--status-amber);
+}
+
+/* ── C-10 Type Badge Admin ──────────────────────────────────── */
+/*
+   Usage:
+     <span class="type-badge-admin type-system">system</span>
+     <span class="type-badge-admin type-menu">menu</span>
+     <span class="type-badge-admin type-issue-kind">issue-kind</span>
+     <span class="type-badge-admin type-external">external</span>
+
+   Also supports legacy tag-rule variants (keyword / regex) used
+   in admin-master.js renderTagRules() for the type column.
+*/
+.type-badge-admin {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  letter-spacing: -0.01em;
+}
+
+/* dot inside badge — injected via ::before pseudo-element */
+.type-badge-admin::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* system → brand (blue) */
+.type-badge-admin.type-system {
+  background: var(--brand-bg);
+  color: var(--accent);
+  border-color: var(--brand-border);
+}
+.type-badge-admin.type-system::before {
+  background: var(--accent);
+}
+
+/* menu → status-blue */
+.type-badge-admin.type-menu {
+  background: var(--status-blue);
+  color: var(--bg-surface);
+  border-color: transparent;
+  opacity: 0.85;
+}
+.type-badge-admin.type-menu {
+  background: var(--status-reviewing-bg);
+  color: var(--status-reviewing-fg);
+  border-color: var(--status-reviewing-border);
+}
+.type-badge-admin.type-menu::before {
+  background: var(--status-reviewing-fg);
+}
+
+/* issue-kind → purple */
+.type-badge-admin.type-issue-kind {
+  background: var(--status-purple-bg);
+  color: var(--status-purple);
+  border-color: var(--status-purple-border);
+}
+.type-badge-admin.type-issue-kind::before {
+  background: var(--status-purple);
+}
+
+/* external → amber */
+.type-badge-admin.type-external {
+  background: var(--status-amber-bg);
+  color: var(--status-amber);
+  border-color: var(--status-amber-border);
+}
+.type-badge-admin.type-external::before {
+  background: var(--status-amber);
+}
+
+/* ── Legacy tag-rule type variants (keyword / regex) ─────────
+   Used in admin-master.js renderTagRules() type column.
+   Retained here so they continue to work after any refactor.    */
+.type-badge-admin.type-keyword {
+  background: var(--status-green-bg);
+  color: var(--status-green);
+  border-color: var(--status-green-border);
+}
+.type-badge-admin.type-keyword::before {
+  background: var(--status-green);
+}
+
+.type-badge-admin.type-regex {
+  background: var(--status-purple-bg);
+  color: var(--status-purple);
+  border-color: var(--status-purple-border);
+}
+.type-badge-admin.type-regex::before {
+  background: var(--status-purple);
+}

--- a/prototype/css/components/badges.css
+++ b/prototype/css/components/badges.css
@@ -87,13 +87,7 @@
   background: var(--accent);
 }
 
-/* menu → status-blue */
-.type-badge-admin.type-menu {
-  background: var(--status-blue);
-  color: var(--bg-surface);
-  border-color: transparent;
-  opacity: 0.85;
-}
+/* menu → status-blue (using reviewing tokens which are blue-toned) */
 .type-badge-admin.type-menu {
   background: var(--status-reviewing-bg);
   color: var(--status-reviewing-fg);

--- a/prototype/js/admin-master.js
+++ b/prototype/js/admin-master.js
@@ -280,7 +280,7 @@ function renderVocTypes() {
         <span class="td-primary" style="${t.archived ? 'opacity:.55' : ''}">${t.name}</span>
       </div></td>
       <td style="font-family:var(--font-mono);font-size:12px;color:var(--text-tertiary)">${t.slug}</td>
-      <td><span class="type-badge-admin ${kindCls}">${kindLabel}</span></td>
+      <td><span class="type-kind-badge ${kindCls}">${kindLabel}</span></td>
       <td style="font-size:12px;color:var(--text-tertiary);text-align:right">${cnt}</td>
       <td>${state}</td>
       <td style="text-align:right">

--- a/prototype/js/admin-master.js
+++ b/prototype/js/admin-master.js
@@ -258,6 +258,12 @@ function toggleArchiveMenu(id) {
   }
 }
 
+const TYPE_KIND_LABEL = {
+  system: 'system',
+  menu: 'menu',
+  'issue-kind': 'issue-kind',
+  external: 'external',
+};
 function renderVocTypes() {
   const el = document.getElementById('adminVocTypeContent');
   if (!el) return;
@@ -266,12 +272,15 @@ function renderVocTypes() {
     const state = t.archived
       ? `<span style="font-size:12px;color:var(--text-quaternary)"><span class="status-dot off"></span>아카이브</span>`
       : `<span style="font-size:12px;color:var(--status-green)"><span class="status-dot on"></span>활성</span>`;
+    const kindCls = t.typeKind ? `type-${t.typeKind}` : 'type-issue-kind';
+    const kindLabel = TYPE_KIND_LABEL[t.typeKind] || t.typeKind || '—';
     return `<tr>
       <td><div style="display:flex;align-items:center;gap:8px">
         <span class="color-swatch" style="background:${t.color};flex-shrink:0"></span>
         <span class="td-primary" style="${t.archived ? 'opacity:.55' : ''}">${t.name}</span>
       </div></td>
       <td style="font-family:var(--font-mono);font-size:12px;color:var(--text-tertiary)">${t.slug}</td>
+      <td><span class="type-badge-admin ${kindCls}">${kindLabel}</span></td>
       <td style="font-size:12px;color:var(--text-tertiary);text-align:right">${cnt}</td>
       <td>${state}</td>
       <td style="text-align:right">

--- a/prototype/js/admin-states-demo.js
+++ b/prototype/js/admin-states-demo.js
@@ -3,6 +3,7 @@
 // Wires a state-toggle <select> into each admin page's admin-topbar.
 // States: normal (정상) / empty (빈) / loading (로딩) / error (오류)
 // Depends on: lucide (global), dom-utils.js (optional showToast)
+// Demo toggle gated behind ?demo URL param — production builds will not show it
 
 (function () {
   'use strict';
@@ -11,7 +12,8 @@
   var STATE_LABELS = { normal: '정상', empty: '빈', loading: '로딩', error: '오류' };
 
   // Per-page config: which content selectors to hide/show per state
-  // Each entry: { pageId, contentSelectors[], emptyMsg, emptyCtaLabel }
+  // 7 pages with meaningful content selectors (pages with empty contentSelectors
+  // removed — they caused demo to show both content + state simultaneously)
   var PAGE_CONFIGS = [
     {
       pageId: 'page-users',
@@ -35,31 +37,18 @@
       pageId: 'page-trash',
       contentSelectors: ['.tr-toolbar', '.tr-table', '.tr-audit'],
       emptyMsg: '휴지통이 비어 있습니다.',
-      emptyCtaLabel: null,
+      emptyCtaLabel: '복원',
     },
     {
       pageId: 'page-external-masters',
-      contentSelectors: ['.em-atomic-note', '#emGrid', '.em-coldstart-banner'],
+      contentSelectors: [
+        '.em-atomic-note',
+        '#emGrid',
+        '.em-coldstart-banner',
+        '.em-field-map-section',
+      ],
       emptyMsg: '등록된 외부 마스터가 없습니다.',
       emptyCtaLabel: null,
-    },
-    {
-      pageId: 'page-result-review',
-      contentSelectors: [],
-      emptyMsg: '검토 대기 중인 항목이 없습니다.',
-      emptyCtaLabel: null,
-    },
-    {
-      pageId: 'page-notices',
-      contentSelectors: [],
-      emptyMsg: '등록된 공지사항이 없습니다.',
-      emptyCtaLabel: '공지 등록',
-    },
-    {
-      pageId: 'page-faq',
-      contentSelectors: [],
-      emptyMsg: '등록된 FAQ가 없습니다.',
-      emptyCtaLabel: 'FAQ 등록',
     },
     {
       pageId: 'page-tag-rules',
@@ -109,11 +98,11 @@
       : '';
 
     return (
-      '<div class="admin-state-container" id="' +
+      '<div class="admin-state-container" aria-live="polite" id="' +
       cfg.pageId +
       '-state-container">' +
       // Empty state
-      '<div class="admin-empty admin-state-panel" data-state="empty" style="display:none">' +
+      '<div class="admin-empty admin-state-panel" role="status" data-state="empty" style="display:none">' +
       '<svg class="admin-empty-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" ' +
       'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' +
       '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 01-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 011-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 011.52 0C14.51 3.81 17 5 19 5a1 1 0 011 1z"/>' +
@@ -125,11 +114,11 @@
       emptyCtaHtml +
       '</div>' +
       // Loading state
-      '<div class="admin-loading admin-state-panel" data-state="loading" style="display:none">' +
+      '<div class="admin-loading admin-state-panel" aria-busy="true" aria-live="polite" data-state="loading" style="display:none">' +
       buildSkeletonRows() +
       '</div>' +
       // Error state
-      '<div class="admin-error admin-state-panel" data-state="error" style="display:none">' +
+      '<div class="admin-error admin-state-panel" role="alert" data-state="error" style="display:none">' +
       '<div class="admin-error-banner">' +
       '<svg class="admin-error-banner-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" ' +
       'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
@@ -234,8 +223,9 @@
     }
   }
 
-  // Init: wire all configured pages
+  // Init: wire all configured pages — gated behind ?demo URL param
   function init() {
+    if (!new URLSearchParams(window.location.search).has('demo')) return;
     PAGE_CONFIGS.forEach(function (cfg) {
       wireToggle(cfg);
     });

--- a/prototype/js/admin-states-demo.js
+++ b/prototype/js/admin-states-demo.js
@@ -1,0 +1,252 @@
+// admin-states-demo.js — C-14 Admin Non-data States demo toggle
+// Wave 3-B · spec: uidesign §13.11
+// Wires a state-toggle <select> into each admin page's admin-topbar.
+// States: normal (정상) / empty (빈) / loading (로딩) / error (오류)
+// Depends on: lucide (global), dom-utils.js (optional showToast)
+
+(function () {
+  'use strict';
+
+  var STATES = ['normal', 'empty', 'loading', 'error'];
+  var STATE_LABELS = { normal: '정상', empty: '빈', loading: '로딩', error: '오류' };
+
+  // Per-page config: which content selectors to hide/show per state
+  // Each entry: { pageId, contentSelectors[], emptyMsg, emptyCtaLabel }
+  var PAGE_CONFIGS = [
+    {
+      pageId: 'page-users',
+      contentSelectors: ['.admin-add-form', '.admin-table'],
+      emptyMsg: '등록된 사용자가 없습니다.',
+      emptyCtaLabel: '사용자 초대',
+    },
+    {
+      pageId: 'page-tag-master',
+      contentSelectors: ['.tm-callout', '.admin-table'],
+      emptyMsg: '등록된 태그가 없습니다.',
+      emptyCtaLabel: '태그 추가',
+    },
+    {
+      pageId: 'page-voc-type',
+      contentSelectors: ['.admin-add-form', '.admin-table'],
+      emptyMsg: '등록된 유형이 없습니다.',
+      emptyCtaLabel: '유형 추가',
+    },
+    {
+      pageId: 'page-trash',
+      contentSelectors: ['.tr-toolbar', '.tr-table', '.tr-audit'],
+      emptyMsg: '휴지통이 비어 있습니다.',
+      emptyCtaLabel: null,
+    },
+    {
+      pageId: 'page-external-masters',
+      contentSelectors: ['.em-atomic-note', '#emGrid', '.em-coldstart-banner'],
+      emptyMsg: '등록된 외부 마스터가 없습니다.',
+      emptyCtaLabel: null,
+    },
+    {
+      pageId: 'page-result-review',
+      contentSelectors: [],
+      emptyMsg: '검토 대기 중인 항목이 없습니다.',
+      emptyCtaLabel: null,
+    },
+    {
+      pageId: 'page-notices',
+      contentSelectors: [],
+      emptyMsg: '등록된 공지사항이 없습니다.',
+      emptyCtaLabel: '공지 등록',
+    },
+    {
+      pageId: 'page-faq',
+      contentSelectors: [],
+      emptyMsg: '등록된 FAQ가 없습니다.',
+      emptyCtaLabel: 'FAQ 등록',
+    },
+    {
+      pageId: 'page-tag-rules',
+      contentSelectors: ['.admin-add-form', '.admin-table'],
+      emptyMsg: '등록된 태그 규칙이 없습니다.',
+      emptyCtaLabel: '규칙 추가',
+    },
+    {
+      pageId: 'page-system-menu',
+      contentSelectors: ['.admin-add-form', '.admin-table'],
+      emptyMsg: '등록된 시스템/메뉴가 없습니다.',
+      emptyCtaLabel: '시스템 추가',
+    },
+  ];
+
+  // Build skeleton rows HTML (5 rows, varying widths for realism)
+  function buildSkeletonRows() {
+    var widths = [
+      ['w-120', 'flex-1', 'w-80', 'w-60', 'w-40'],
+      ['w-80', 'flex-1', 'w-120', 'w-40', 'w-60'],
+      ['w-60', 'flex-1', 'w-40', 'w-80', 'w-60'],
+      ['w-120', 'flex-1', 'w-60', 'w-40', 'w-80'],
+      ['w-80', 'flex-1', 'w-80', 'w-60', 'w-40'],
+    ];
+    return widths
+      .map(function (row) {
+        return (
+          '<div class="admin-skeleton-row">' +
+          '<div class="admin-skeleton-cell w-8"></div>' +
+          row
+            .map(function (w) {
+              return '<div class="admin-skeleton-cell ' + w + '"></div>';
+            })
+            .join('') +
+          '</div>'
+        );
+      })
+      .join('');
+  }
+
+  // Build state container HTML for a page config
+  function buildStateContainer(cfg) {
+    var emptyCtaHtml = cfg.emptyCtaLabel
+      ? '<button type="button" class="admin-empty-cta" onclick="void(0)">' +
+        cfg.emptyCtaLabel +
+        '</button>'
+      : '';
+
+    return (
+      '<div class="admin-state-container" id="' +
+      cfg.pageId +
+      '-state-container">' +
+      // Empty state
+      '<div class="admin-empty admin-state-panel" data-state="empty" style="display:none">' +
+      '<svg class="admin-empty-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 01-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 011-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 011.52 0C14.51 3.81 17 5 19 5a1 1 0 011 1z"/>' +
+      '</svg>' +
+      '<p class="admin-empty-title">데이터가 없습니다</p>' +
+      '<p class="admin-empty-desc">' +
+      cfg.emptyMsg +
+      '</p>' +
+      emptyCtaHtml +
+      '</div>' +
+      // Loading state
+      '<div class="admin-loading admin-state-panel" data-state="loading" style="display:none">' +
+      buildSkeletonRows() +
+      '</div>' +
+      // Error state
+      '<div class="admin-error admin-state-panel" data-state="error" style="display:none">' +
+      '<div class="admin-error-banner">' +
+      '<svg class="admin-error-banner-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>' +
+      '</svg>' +
+      '데이터를 불러오지 못했습니다.' +
+      '</div>' +
+      '<p class="admin-error-desc">서버 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.</p>' +
+      '<button type="button" class="admin-error-retry">' +
+      '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>' +
+      '<path d="M3 3v5h5"/>' +
+      '</svg>' +
+      '재시도' +
+      '</button>' +
+      '</div>' +
+      '</div>'
+    );
+  }
+
+  // Apply a state to a page
+  function applyState(cfg, state) {
+    var page = document.getElementById(cfg.pageId);
+    if (!page) return;
+
+    var container = document.getElementById(cfg.pageId + '-state-container');
+    if (!container) return;
+
+    // Show/hide normal content selectors
+    var isNormal = state === 'normal';
+    cfg.contentSelectors.forEach(function (sel) {
+      var els = page.querySelectorAll(sel);
+      els.forEach(function (el) {
+        el.style.display = isNormal ? '' : 'none';
+      });
+    });
+
+    // Hide/show state container
+    if (isNormal) {
+      container.classList.remove('is-active');
+      container.querySelectorAll('.admin-state-panel').forEach(function (p) {
+        p.style.display = 'none';
+      });
+    } else {
+      container.classList.add('is-active');
+      container.querySelectorAll('.admin-state-panel').forEach(function (p) {
+        p.style.display = p.dataset.state === state ? '' : 'none';
+      });
+    }
+  }
+
+  // Wire a toggle select into a page's admin-topbar (or fallback container)
+  function wireToggle(cfg) {
+    var page = document.getElementById(cfg.pageId);
+    if (!page) return;
+
+    // Insert state container after admin-topbar or at start of admin-body
+    var insertTarget =
+      page.querySelector('.admin-body') || page.querySelector('.admin-topbar') || page;
+
+    // Build and inject state container
+    var tempDiv = document.createElement('div');
+    tempDiv.innerHTML = buildStateContainer(cfg);
+    var stateContainer = tempDiv.firstChild;
+
+    // Insert after admin-topbar if present, else prepend to page
+    var topbar = page.querySelector('.admin-topbar');
+    if (topbar && topbar.nextSibling) {
+      page.insertBefore(stateContainer, topbar.nextSibling);
+    } else if (insertTarget === page.querySelector('.admin-body')) {
+      insertTarget.insertBefore(stateContainer, insertTarget.firstChild);
+    } else {
+      page.appendChild(stateContainer);
+    }
+
+    // Build toggle select
+    var wrap = document.createElement('div');
+    wrap.className = 'admin-state-toggle-wrap';
+    wrap.innerHTML =
+      '<span class="admin-state-toggle-label">상태 데모</span>' +
+      '<select class="admin-state-toggle" aria-label="상태 데모 전환">' +
+      STATES.map(function (s) {
+        return '<option value="' + s + '">' + STATE_LABELS[s] + '</option>';
+      }).join('') +
+      '</select>';
+
+    var sel = wrap.querySelector('select');
+    sel.addEventListener('change', function () {
+      applyState(cfg, sel.value);
+    });
+
+    // Inject into topbar spacer area or at end of topbar
+    if (topbar) {
+      // Insert before last child if there's a spacer, otherwise append
+      var spacer = topbar.querySelector('.spacer');
+      if (spacer && spacer.nextSibling) {
+        topbar.insertBefore(wrap, spacer.nextSibling);
+      } else {
+        topbar.appendChild(wrap);
+      }
+    }
+  }
+
+  // Init: wire all configured pages
+  function init() {
+    PAGE_CONFIGS.forEach(function (cfg) {
+      wireToggle(cfg);
+    });
+  }
+
+  // Run after DOM is ready (scripts are at bottom, so DOM is ready)
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.AdminStatesDemo = { init: init, applyState: applyState };
+})();

--- a/prototype/js/data.js
+++ b/prototype/js/data.js
@@ -14,6 +14,10 @@ const MENUS = [
   { id: 'm10', systemId: 'sys4', name: 'KPI', archived: false },
   { id: 'm11', systemId: 'sys4', name: '알림 설정', archived: false },
 ];
+// typeKind: prototype-only mock for badge variant coverage.
+// spec §13.4 has no canonical typeKind taxonomy yet — values here are illustrative
+// (issue-kind for bug, system/menu/external for variant demo) and will be redefined
+// when the schema decision lands.
 const VOC_TYPES = [
   {
     id: 't1',

--- a/prototype/js/data.js
+++ b/prototype/js/data.js
@@ -15,10 +15,38 @@ const MENUS = [
   { id: 'm11', systemId: 'sys4', name: '알림 설정', archived: false },
 ];
 const VOC_TYPES = [
-  { id: 't1', name: '버그', slug: 'bug', color: '#e5534b', archived: false },
-  { id: 't2', name: '기능 요청', slug: 'feature', color: '#5e6ad2', archived: false },
-  { id: 't3', name: '개선 제안', slug: 'improvement', color: '#f5a623', archived: false },
-  { id: 't4', name: '문의', slug: 'inquiry', color: '#57ab5a', archived: false },
+  {
+    id: 't1',
+    name: '버그',
+    slug: 'bug',
+    color: '#e5534b',
+    archived: false,
+    typeKind: 'issue-kind',
+  },
+  {
+    id: 't2',
+    name: '기능 요청',
+    slug: 'feature',
+    color: '#5e6ad2',
+    archived: false,
+    typeKind: 'system',
+  },
+  {
+    id: 't3',
+    name: '개선 제안',
+    slug: 'improvement',
+    color: '#f5a623',
+    archived: false,
+    typeKind: 'menu',
+  },
+  {
+    id: 't4',
+    name: '문의',
+    slug: 'inquiry',
+    color: '#57ab5a',
+    archived: false,
+    typeKind: 'external',
+  },
 ];
 let sysNextSeq = 5,
   menuNextSeq = 12,

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -17,6 +17,7 @@
 <link rel="stylesheet" href="css/components/notification-panel.css">
 <link rel="stylesheet" href="css/components/misc.css">
 <link rel="stylesheet" href="css/components/badges.css">
+<link rel="stylesheet" href="css/components/admin-states.css">
 <link rel="stylesheet" href="css/components/notice-popup.css">
 <link rel="stylesheet" href="css/admin/dashboard-overview.css">
 <link rel="stylesheet" href="css/admin/dashboard-widgets.css">
@@ -993,6 +994,7 @@
 <script src="js/notice-admin.js"></script>
 <script src="js/faq-admin.js"></script>
 <script src="js/faq-admin-modals.js"></script>
+<script src="js/admin-states-demo.js"></script>
 <script src="js/init.js"></script>
 </body>
 </html>

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -778,30 +778,51 @@
       <table class="admin-table em-field-map-table">
         <thead>
           <tr>
-            <th>VOC 필드</th>
+            <th>VOC structured_payload 필드</th>
             <th>외부 마스터</th>
-            <th style="width:100px;font-family:var(--font-mono)">source key</th>
-            <th style="width:80px;text-align:right">갱신 주기</th>
+            <th style="width:90px;text-align:center">검증 여부</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">equipment_id</code></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">equipment</code></td>
             <td><span style="font-size:13px">설비 마스터</span></td>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">EQUIP</code></td>
-            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
           </tr>
           <tr>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">program_code</code></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">maker</code></td>
+            <td><span style="font-size:13px">설비 마스터</span></td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">model</code></td>
+            <td><span style="font-size:13px">설비 마스터</span></td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">process</code></td>
+            <td><span style="font-size:13px">설비 마스터</span></td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">related_programs</code></td>
             <td><span style="font-size:13px">프로그램 마스터</span></td>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">PROG</code></td>
-            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
           </tr>
           <tr>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">db_code</code></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">related_db_tables</code></td>
             <td><span style="font-size:13px">DB 마스터</span></td>
-            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">DB</code></td>
-            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">related_jobs</code></td>
+            <td><span style="font-size:13px">DB 마스터</span></td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">related_sps</code></td>
+            <td><span style="font-size:13px">DB 마스터</span></td>
+            <td style="text-align:center;font-size:12px;color:var(--status-green)">O</td>
           </tr>
         </tbody>
       </table>

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -768,6 +768,44 @@
     </button>
   </div>
   <div class="admin-body" style="padding:16px 20px">
+    <!-- M-05 필드 매핑 섹션 — 읽기 전용, VOC 필드 ↔ 외부 마스터 source key 표 -->
+    <div class="em-field-map-section">
+      <div class="em-field-map-header">
+        <i data-lucide="table-2" style="width:14px;height:14px;vertical-align:-2px;color:var(--text-tertiary)"></i>
+        <span class="em-field-map-title">필드 매핑</span>
+        <span class="em-field-map-desc">VOC 필드가 참조하는 외부 마스터 소스 (읽기 전용)</span>
+      </div>
+      <table class="admin-table em-field-map-table">
+        <thead>
+          <tr>
+            <th>VOC 필드</th>
+            <th>외부 마스터</th>
+            <th style="width:100px;font-family:var(--font-mono)">source key</th>
+            <th style="width:80px;text-align:right">갱신 주기</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">equipment_id</code></td>
+            <td><span style="font-size:13px">설비 마스터</span></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">EQUIP</code></td>
+            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">program_code</code></td>
+            <td><span style="font-size:13px">프로그램 마스터</span></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">PROG</code></td>
+            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+          </tr>
+          <tr>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--text-secondary)">db_code</code></td>
+            <td><span style="font-size:13px">DB 마스터</span></td>
+            <td><code style="font-family:var(--font-mono);font-size:12px;color:var(--accent)">DB</code></td>
+            <td style="text-align:right;font-size:12px;color:var(--text-tertiary)">1h</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <!-- H2: Cold-start system-wide banner — shown/hidden by JS -->
     <div id="emColdStartBanner" class="em-coldstart-banner">
       <i data-lucide="alert-triangle" style="width:16px;height:16px;flex-shrink:0"></i>

--- a/prototype/prototype.html
+++ b/prototype/prototype.html
@@ -16,6 +16,7 @@
 <link rel="stylesheet" href="css/components/modal.css">
 <link rel="stylesheet" href="css/components/notification-panel.css">
 <link rel="stylesheet" href="css/components/misc.css">
+<link rel="stylesheet" href="css/components/badges.css">
 <link rel="stylesheet" href="css/components/notice-popup.css">
 <link rel="stylesheet" href="css/admin/dashboard-overview.css">
 <link rel="stylesheet" href="css/admin/dashboard-widgets.css">
@@ -588,6 +589,7 @@
         <thead><tr>
           <th>유형</th>
           <th style="width:120px">슬러그</th>
+          <th style="width:110px">분류</th>
           <th style="width:60px;text-align:right">VOC</th>
           <th style="width:90px">상태</th>
           <th style="width:70px"></th>


### PR DESCRIPTION
## Summary
Phase 7 Wave 3 Sub-wave B — Admin 공통 컴포넌트 4건 + 5인 자가-금지 리뷰 R2 fix.

### 구현 (commits 0928f16..ed705eb)
- **C-11** Status Dot — 7×7 (spec §13.5), 4 variants (on/off/archived/pending), `.admin-page` scope
- **C-10** Type Kind Badge — `.type-kind-badge` 4 variants (system/menu/issue-kind/external), §13.4의 색 스워치 의미 보존을 위해 신규 클래스명 사용
- **C-14** Admin Non-data States — empty/loading/error 3 variants + `?demo` URL gated 토글 (7 admin pages)
- **M-05** External Masters 필드 매핑 — `external-masters.md §2` canonical 8행 (equipment/maker/model/process/related_programs/related_db_tables/related_jobs/related_sps)

### R2 fix (commit 7dfde21 — 10건)
5인 전문가 (architect/code/security/verifier/critic) × 3관점 리뷰 후 일괄 fix:
- **Spec correctness (5)**: status-dot 7px+box-shadow+scope, type-badge-admin → type-kind-badge rename, M-05 8행 정정, type-menu --brand-* 토큰, typeKind mock 코멘트
- **Demo isolation (3)**: PAGE_CONFIGS no-op 페이지 제거, ?demo URL gate, em-field-map contentSelectors
- **a11y (1)**: aria-live/role=status/aria-busy/role=alert
- **Quality (1)**: trash empty CTA '복원'

### Verification
- R2 verifier: 10/10 fix, 4/4 AC, smoke 5/5 HTTP 200, 토큰 위반 0
- 신규 토큰 추가: 0

## Test plan
- [ ] prototype.html 콘솔 에러 0
- [ ] voc-type 페이지: 4종 .type-kind-badge 표시 + "분류" 컬럼
- [ ] users 페이지 비활성 행에 회색 7px status-dot (.admin-page scope)
- [ ] external-masters 상단 8행 필드 매핑 (canonical names)
- [ ] ?demo=1 URL → admin 페이지 우상단 토글 셀렉트 노출
- [ ] 토글 "비어있음/로딩/오류" 상태 정상 동작 + a11y 속성

🤖 Generated with [Claude Code](https://claude.com/claude-code)