### PR TITLE
docs: CLAUDE.md prototype-as-reference 원칙 추가 + 루트 압축

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,27 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repo.
 
 ## Project Status
 
-This is a **VOC (Voice of Customer) management system** currently in **Phase 6 implementation** — frontend and backend are scaffolded with working source code. See `docs/specs/requires/requirements.md` for the product spec and `docs/specs/requires/uidesign.md` for the complete design system.
+**VOC (Voice of Customer) management system**, currently **Phase 6 implementation** — frontend and backend are scaffolded with working source code. Product spec: `docs/specs/requires/requirements.md`. Design system: `docs/specs/requires/uidesign.md`.
 
-## Planned Tech Stack
+## Stack (summary — details in sub-dir CLAUDE.md)
 
-| Layer     | Technology                                                                     |
-| --------- | ------------------------------------------------------------------------------ |
-| Frontend  | React + TypeScript, Vite, Toast UI Editor                                      |
-| Backend   | Node.js + Express + TypeScript                                                 |
-| Database  | PostgreSQL                                                                     |
-| Testing   | Vitest (frontend), Jest + Supertest (backend)                                  |
-| Container | Docker + Docker Compose                                                        |
-| Styling   | Tailwind CSS v4 + CSS custom properties (mixed) — `tokens.ts` as single source |
+Three-tier app: React SPA → Express REST API → PostgreSQL.
 
-## Sub-directory Guides
-
-Each working directory has a focused `CLAUDE.md` with its own commands, architecture, and rules:
-
-- `frontend/CLAUDE.md` — React SPA, hooks, state, full design tokens
-- `backend/CLAUDE.md` — Express REST API, DB schema, middleware
-- `prototype/CLAUDE.md` — visual exploration HTML, full design tokens
+- Frontend: React + TypeScript + Vite + Tailwind v4 → `frontend/CLAUDE.md`
+- Backend: Node + Express + TypeScript + PostgreSQL/pgvector → `backend/CLAUDE.md`
+- Prototype: static HTML visual sandbox → `prototype/CLAUDE.md`
+- Container: Docker Compose (`docker compose up` starts FE + BE + Postgres)
 
 **Rule:** when working inside a sub-directory, read its `CLAUDE.md` first. This file covers cross-cutting governance only.
 
-## Docker
+**Prototype-as-reference (shared FE/BE principle):** the prototype is a visual + behavioral reference, **not** production architecture. FE preserves UX while rebuilding cleanly; BE infers real requirements and defines stable contracts. Never copy prototype code directly into production. Detail rules: `frontend/CLAUDE.md` and `backend/CLAUDE.md`.
 
-```bash
-docker compose up    # Start all services (FE + BE + Postgres)
-```
+## Design System (canonical hard rule)
 
-## Architecture Overview
-
-Three-tier app: React SPA → Express REST API → PostgreSQL. Detailed architecture lives in each sub-directory's `CLAUDE.md` and in `docs/specs/requires/`.
-
-## Design System (Pointer)
-
-Full spec: `docs/specs/requires/uidesign.md`. Full token reference: §10 CSS Reference.
-
-**Hard rule (echoed in `frontend/CLAUDE.md` and `prototype/CLAUDE.md`):**
+Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture).
 
 - Always use CSS custom properties — `var(--bg-app)`, `var(--brand)`, `var(--text-primary)`, etc.
 - **Never write hex values** (no `#5e6ad2`, no `#ffffff`). No raw OKLCH either — go through the token.
@@ -54,27 +34,19 @@ Full spec: `docs/specs/requires/uidesign.md`. Full token reference: §10 CSS Ref
 2. Read `docs/specs/plans/next-session-tasks.md` to find current Phase and pending tasks
 3. Read relevant spec in `docs/` (selectively — only what's needed)
 4. Continue from progress file — don't re-read what you already know
-5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete any entries whose work is already reflected in specs or git (delete file + remove from index; do not archive)
+5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete entries already reflected in specs or git (delete file + remove from index; do not archive)
 
 ## Core Rules
 
 - **Grep/Glob before Read** — search first, never read full files to find one function
 - **Parallel tool calls** — independent tool calls go in one message, not sequential
 - **No re-read** — never re-read a file already in session context (exception: modified files)
-- **Tail test output** — pipe test output through `| tail -20`; never print full traces
+- **Tail test output** — pipe through `| tail -20`; never print full traces
 - **No Read before delete** — files being deleted must never be Read first; just `rm`
 - **Broad grep first pass** — use `--all` and wide keywords on first `git log` grep; never retry with a narrower pattern
-- **Minimum context for decisions** — "문서 업데이트" and similar judgment tasks: use only the single most relevant file (e.g. `claude-progress.txt`); do not open supporting files (next-session-tasks, git log, etc.) unless the first file is insufficient
-- **Git workflow** — always create a feature branch first, commit and push there. Never commit or push directly to main. Branch naming: `docs/<topic>`, `feat/<topic>`, `fix/<topic>`.
-  - PRs are opened by the user, not by Claude
-  - Merge PRs with `gh pr merge <n> --merge --delete-branch` — `--squash` and `--rebase` are forbidden
-    - `--squash`: destroys commit history
-    - `--rebase`: replays commits directly onto main, erasing PR boundaries
-    - `--merge`: preserves both the merge commit (PR boundary) and individual commits ✓
-  - After merging, delete the local branch: `git branch -D <branch>`
-  - main changes only via PR — direct push and force push are forbidden
-  - These rules are enforced by hookify rules in `.claude/hookify.block-*.local.md`
-- Run tests before committing; follow existing code style (read 2-3 nearby files first)
+- **Minimum context for decisions** — judgment tasks (e.g. "문서 업데이트"): use only the single most relevant file; open supporting files only if the first is insufficient
+- **Git workflow** — feature branch only (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`); never commit or push to main directly. PRs are opened by the user. Merge with `gh pr merge <n> --merge --delete-branch` (`--squash` and `--rebase` forbidden). After merge: `git branch -D <branch>`. Enforced by hookify rules in `.claude/hookify.block-*.local.md`.
+- Run tests before committing; follow existing code style (read 2–3 nearby files first)
 - No features beyond what the task requires (YAGNI)
 - CLAUDE.md stays under 200 lines
 
@@ -84,51 +56,30 @@ Every design decision → written to spec or ADR before session ends.
 Every phase completion → update `claude-progress.txt` + git commit.
 No implementation without a written spec section covering it.
 
-## Document Structure
+## Documents (structure + coherence)
 
-All design, review, and implementation documents live under `docs/specs/`. No document files at the repo root.
+All design / review / implementation docs live under `docs/specs/`. No document files at the repo root. Tool scratch dirs (`.omc/plans/`, `.superpowers/`, etc.) are temporary — canonical docs always live in `docs/specs/`.
 
 ```
 docs/specs/
-├── requires/   # requirements and design specs (requirements.md, uidesign.md, etc.)
-├── plans/      # per-feature implementation plans
-└── reviews/    # review and brainstorming outputs
+├── requires/   # requirements.md (Korean), uidesign.md (English only)
+├── plans/      # per-feature implementation plans, <feature-name>.md
+└── reviews/    # review / brainstorming, <topic>.md
 ```
 
-### Document Roles
+| Decision made                                                     | Write to                                           | Then propagate to             |
+| ----------------------------------------------------------------- | -------------------------------------------------- | ----------------------------- |
+| Visual design (color, layout, spacing, component pattern)         | `requires/uidesign.md` (English)                   | implementation plan           |
+| Functional / behavioral (feature rule, API shape, business logic) | `requires/requirements.md` or relevant `feature-*` | implementation plan           |
+| Implementation plan (task added/removed)                          | `plans/<feature>.md`                               | spec section it implements    |
+| New rule in `CLAUDE.md`                                           | this file                                          | spec if rule affects behavior |
 
-| File                                  | Language         | Scope                                                                                                              |
-| ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `docs/specs/requires/uidesign.md`     | **English only** | Visual design system — color tokens, typography, component specs, layout rules, spacing, elevation, UI do's/don'ts |
-| `docs/specs/requires/requirements.md` | Korean           | Functional requirements — feature specs, behavioral rules, data model, API design, business logic                  |
-
-- New feature plan → `docs/specs/plans/<feature-name>.md`
-- Review / brainstorming → `docs/specs/reviews/<topic>.md`
-- **Never put functional/behavioral spec in `uidesign.md`**
-- **Never put visual design rules in `requirements.md`**
-- `uidesign.md` must always be written in English
-- **Tool scratch dirs (`.omc/plans/`, `.superpowers/`, etc.) are temporary — canonical docs always live in `docs/specs/`**
-
-## Document Coherence
-
-**Write decisions to the right file first:**
-
-| Decision made                                                          | Write to                                                         |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Visual design change (color, layout, spacing, component pattern)       | `docs/specs/requires/uidesign.md` (English)                      |
-| Functional/behavioral change (feature rule, API shape, business logic) | `docs/specs/requires/requirements.md` or relevant `feature-*.md` |
-
-**Then check propagation:**
-
-| Changed                                  | Must also check               |
-| ---------------------------------------- | ----------------------------- |
-| Spec (design decision, constraint)       | Implementation plan           |
-| Implementation plan (task added/removed) | Spec section it implements    |
-| CLAUDE.md (new rule)                     | Spec if rule affects behavior |
+- **Never put functional/behavioral spec in `uidesign.md`** and **never put visual rules in `requirements.md`**.
+- `uidesign.md` must always be English.
 
 ## Input Interpretation
 
-When you receive a development request, mentally normalize it into this frame before coding. Ask only about items that materially affect the result; otherwise state your assumption and proceed.
+Normalize a request into this frame before coding. Ask only about items that materially affect the result; otherwise state the assumption and proceed.
 
 - **Goal** — what + why (one line)
 - **Scope** — files/paths involved; what _not_ to touch
@@ -141,43 +92,25 @@ Skip the frame for trivial one-liners (rename, obvious typo, single-file change 
 
 - **No completion claims** — never mark a task done until the user explicitly says so
 - **No implementation without approval** — never write BE/FE code until the user says to start
-- **Debate, don't defer** — when you see a counterargument or missed case, raise it before agreeing; no passive "yes"
+- **Debate, don't defer** — raise counterarguments or missed cases before agreeing; no passive "yes"
 - **Think before coding** — state assumptions; if multiple interpretations exist, present them, don't pick silently
 - **Simplicity first** — minimum code; no speculative abstractions; if 200 lines could be 50, rewrite
-- **Surgical changes** — touch only what the request requires; match existing style; only remove orphans your changes made unused
+- **Surgical changes** — touch only what the request requires; match existing style; remove only orphans your changes made unused
 - **Goal-driven execution** — convert tasks into verifiable goals; for multi-step work, plan per-step verification and loop until verified
 
 ## Refactoring
 
-A refactor changes structure without changing observable behavior. Most refactor bugs are mechanical (stale references, partial migration) — catch them with checks, not cleverness.
+A refactor changes structure without changing observable behavior. Refactor and feature change must NOT land together — separate commits/PRs.
 
-**Before:**
-
-- State the symbols/files/paths you will change (in chat, before editing)
-- Confirm tests cover the affected behavior; if not, write tests first
-- Refactor and feature change must NOT land together — split into separate commits/PRs
-
-**During:**
-
-- Use `git mv` for file moves so history follows
-- One refactor at a time
-
-**After (mandatory, in order):**
-
-1. **Update all references** — imports, dynamic strings, route paths, config (`*.json`/`*.yml`/`.env`), `docs/specs/**`, plan files, README/CLAUDE.md mentions, comments. **Nothing pointing to the old name/path may remain.**
-2. `grep -rn "<old_name>"` and `grep -rn "<old/path>"` → 0 hits (exception: a deliberate changelog entry)
-3. Typecheck passes (`tsc --noEmit` or `npm run build`)
-4. Tests pass (`npm run test`)
-5. Run the app and exercise the touched surface (UI: browser; API: endpoint)
-
-**Escalate to `code-reviewer` agent only when:** public API surface changed, ≥3 modules touched, or DB schema/migration involved. Routine renames/extracts skip the agent.
+- **Before:** state symbols/files/paths to be changed in chat; ensure tests cover affected behavior (write tests first if not).
+- **During:** `git mv` for file moves; one refactor at a time.
+- **After (in order):** update all references (imports, dynamic strings, config, `docs/specs/**`, plan files, README/CLAUDE.md, comments) → `grep -rn "<old>"` returns 0 hits → typecheck passes → tests pass → exercise the touched surface (UI: browser; API: endpoint).
+- **Escalate to `code-reviewer`** only when public API surface changed, ≥3 modules touched, or DB schema/migration involved.
 
 ## graphify
 
-This project has a graphify knowledge graph at `graphify-out/`.
+Knowledge graph at `graphify-out/`.
 
-Rules:
-
-- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for god nodes and community structure
+- Before architecture/codebase questions, read `graphify-out/GRAPH_REPORT.md` for god nodes and community structure
 - If `graphify-out/wiki/index.md` exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- After modifying code files, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Express REST API for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
 
+**Stack:** Node.js + Express + TypeScript, PostgreSQL with pgvector extension (`pgvector/pgvector:pg16`), Jest + Supertest (test), tsx (dev runner).
+
 ## Status
 
 Scaffolded — feature work deferred to Phase 8. Currently `src/` has `index.ts`, `auth/` (mockLogin only — `validateADSession` is a stub for Phase 9), `routes/`. Migrations 001-011 applied; 012 (dev role), 013 (tag master), 014 (trash) drafted in `docs/specs/plans/`.
@@ -13,6 +15,28 @@ npm run dev                                      # tsx watch
 npm run test                                     # Jest
 npm run test -- --testPathPattern=filename       # Single test
 ```
+
+## Working from the Prototype
+
+The frontend prototype (`prototype/`) is a **product/UX reference**, not a backend spec. Treat it as evidence of real requirements — never as a DB schema or API blueprint.
+
+Infer backend needs from: pages, user actions, forms, displayed data, filters/sorting, status values, empty/error states, permission hints.
+
+Before coding an endpoint, define:
+
+- Domain entities + relationships, required/optional fields, enums/statuses
+- API contract (route, method, request/response shape, status codes, error shape)
+- Validation rules, auth/permission rules, error cases
+
+Rules:
+
+- Design APIs around **product behavior**, not UI layout — models reflect business concepts, not screen labels
+- Keep business logic out of route handlers (route → service → repository)
+- Validate all external input; use clear status codes and stable error shapes
+- Support FE states: pagination, filtering, sorting, loading-friendly responses, empty/error semantics
+- Avoid vague strings, generic models, and prototype-driven DB design (e.g., a column per UI badge)
+
+Flow: review prototype behavior → define entities/types → design API contract → service logic → persistence → validation/errors → confirm FE integration.
 
 ## Architecture
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -2,6 +2,8 @@
 
 React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
 
+**Stack:** React + TypeScript, Vite, Tailwind CSS v4, Toast UI Editor (rich text), Vitest (test).
+
 ## Status
 
 Scaffolded — actual feature implementation deferred to Phase 8. Currently in Phase 7 (prototype-driven design freeze). `src/` contains: `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, `api/`, `contexts/`, `hooks/`, `styles/`, `test/`.
@@ -14,6 +16,24 @@ npm run build                            # Production build
 npm run test                             # Vitest
 npm run test -- path/to/file.test.ts     # Single test file
 ```
+
+## Working from the Prototype
+
+The prototype (`prototype/`) is a **visual/UX reference**, not source code. **Never** copy its HTML/CSS/JS into React.
+
+Before coding a screen, extract from the prototype:
+
+- Pages and layout, reusable components, props/data shape, UI states, interactions, responsive behavior
+
+Implementation rules:
+
+- Rebuild with clean React structure — preserve the prototype's visual result, not its DOM
+- Reuse existing components first; extract a new component only when UI/logic repeats
+- Keep page components small; avoid duplicated Tailwind patterns (extract via `@apply` or a component)
+- Define TypeScript types **before** UI when data is involved; never use `any`
+- Always handle: loading, error, empty, hover, focus, and responsive states
+
+Flow: analyze prototype → map components → define types → build with dummy data → wire interactions → connect API → polish states/responsive → visual diff vs prototype.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- `frontend/CLAUDE.md`, `backend/CLAUDE.md`에 **Working from the Prototype** 섹션 추가 — 프로토타입은 시각/UX 참고만, 직접 코드 변환 금지. 컴포넌트 재사용·타입 우선·UI 상태 체크리스트·구현 흐름 명시
- 두 파일에 Stack 한 줄(Vite/Toast UI/Vitest, pgvector/Jest/Supertest) 추가 — 루트에서 빠진 정보 보전
- 루트 `CLAUDE.md` 185 → 116줄로 압축 (Tech Stack 표 축약, Git workflow 이유 제거, Document Structure+Coherence 통합 테이블, Refactoring Before/During/After 컴팩트화)
- 정보 유실 없음: 모든 규칙·hookify 포인터·refactor 체크리스트·디자인 토큰 hard rule 보존

## Test plan
- [x] typecheck (pre-commit hook 통과 확인)
- [x] line counts: 루트 116, frontend 65, backend 69, prototype 47

🤖 Generated with [Claude Code](https://claude.com/claude-code)