### PR TITLE
docs: Phase 8 계획 확정 반영 — progress + tasks + nextgen-backlog 갱신

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,20 +2,23 @@
 
 ## 다음 세션 시작점
 
-→ **Phase 8 재계획** — Phase 7 종료, 다음 Phase 정의 필요
+→ **Phase 8 Wave 0 시작** — Foundation PR 작성 (`feat/phase-8-foundation`)
 
-전체 Phase 계획: **`docs/specs/plans/next-session-tasks.md`**
-NextGen 백로그: **`docs/specs/plans/nextgen-backlog.md`**
+**Wave 0 첫 commit 강제**: 사내 npm 미러 사전 점검 (`npm config get registry` + `npm install zod --dry-run`). 미러 부재 시 §7 raw 벤더링 경로로 사용자 승인 후 진행.
+
+계획서 정본: **`docs/specs/plans/phase-8.md`** (PR #99, consensus 통과)
+전체 Phase 계획: **`docs/specs/plans/next-session-tasks.md`** (Phase 8 Wave 0~5 표)
+NextGen 백로그: **`docs/specs/plans/nextgen-backlog.md`** (§5 Phase 8 분리 항목 4건)
 누적 이력: **`docs/specs/plans/progress-archive.md`**
 
 ---
 
 ## 현재 위치 (2026-05-01 기준)
 
-- Phase 0~6 ✅ → Phase 7 Wave 1·2·3 ✅ → **Phase 7 close**
-- Wave 3 PR #93 #94 #95 머지 완료 (2026-05-01)
-- R-4 (tsx watch) 이미 완료 — backend `dev` 스크립트 `tsx watch` (commit 809e267)
-- 갭 재스캔 결론: Critical 0 / Major 0 / Minor 0 (N-03 알림 폴링은 OOS — BE/timer 의존)
+- Phase 0~6 ✅ → Phase 7 ✅ → **Phase 8 계획 확정** (PR #99 머지)
+- Phase 8 채택안: A′ Contract-first per-screen, 6 Wave (Wave 1만 vertical slice)
+- 스택 결정: shadcn/ui + TanStack Query/Table + RHF/Zod + MSW + Recharts (폐쇄망 self-host)
+- Architect 4 조건 + Critic 1 Critical + 5 Major 모두 반영 → APPROVED
 
 ## Phase 7 Wave 3 산출물
 
@@ -33,6 +36,7 @@ NextGen 백로그: **`docs/specs/plans/nextgen-backlog.md`**
 
 ## 가장 최근 산출물
 
+- 2026-05-01 — **Phase 8 계획 확정** (PR #99) — A′ Contract-first per-screen, 6 Wave + ADR §10
 - 2026-05-01 — **Phase 7 close** (Wave 3 W3-A/B/C 머지 #93/#94/#95 + 재스캔 0 잔여)
 - 2026-05-01 — Wave 2 전건 머지 + Wave 3 plan PR
 - 2026-05-01 — B-9 Playwright MCP 통합 검증 (S1~S6, 6/6 PASS, 콘솔 에러 0)

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -1,7 +1,7 @@
 # vocpage — 다음 세션 태스크 계획
 
-> 최종 업데이트: 2026-05-01 (**Phase 7 close** — Wave 3 W3-A/B/C 머지 완료, Phase 8 재계획 대기)
-> 현재 위치: **Phase 7 종료** — 다음 = **Phase 8 재계획** (NextGen 백로그 + 운영/배포 phase 후보 입력으로 새 phase 정의)
+> 최종 업데이트: 2026-05-01 (**Phase 8 계획 확정** — PR #99 머지, Wave 0 진입 대기)
+> 현재 위치: **Phase 8 Wave 0 진입 직전** — 계획서 `docs/specs/plans/phase-8.md` (consensus 통과, ADR §10)
 > Wave 3 결과: PR #93 W3-A / #94 W3-B / #95 W3-C 모두 머지 + 갭 재스캔 결론 0 잔여
 > R-4 (tsx watch) 이미 완료 — backend `dev` 스크립트 `tsx watch` (commit 809e267)
 
@@ -54,13 +54,29 @@
 
 ---
 
-## Phase 8 재계획 (대기 — 다음 세션 입력)
+## Phase 8: FE 실구현 (Contract-first per-screen, 6 Wave)
 
-Phase 8 이후 phase는 다음 세션에서 아래 입력을 토대로 재계획한다:
+> **계획서 정본**: `docs/specs/plans/phase-8.md` (PR #99, 2026-05-01 머지)
+> **방식**: A′ Contract-first per-screen — Wave 1만 vertical slice, Wave 2~5 분리 PR
+> **스택**: shadcn/ui + TanStack Query/Table + RHF/Zod + MSW + Recharts (폐쇄망 self-host)
 
-- 본 문서 "이연 갭" 섹션 (Phase F 후속 / 권한·스키마 인프라 / 명세 보강 / 운영·배포 후보)
-- `docs/specs/plans/nextgen-backlog.md`
-- 사용자 우선순위 조율
+| Wave | 범위                                                                                                                                                   | PR 수 | 상태       |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- | ---------- |
+| 0    | Foundation — shared/, shadcn 8종, TanStack Query, MSW, AppShell, RoleContext, BE Zod, ESLint(max-lines), CI 매트릭스, PR template, 폰트 self-host 점검 | 1     | 대기       |
+| 1    | **기준 화면** — VOC 리스트 + 검토 드로어 (vertical slice 1 PR) + `phase-8-pattern.md` 머지 (Wave 2 진입 게이트)                                        | 1     | Wave 0 후  |
+| 2    | Dashboard + 위젯 8종 (계약 → FE → BE)                                                                                                                  | 3     | Wave 1 후  |
+| 3    | Admin 4 화면 (Tag Master / Trash / External Masters / Users) — 계약 1 + FE/BE 묶음 4                                                                   | 5     | 병렬 가능  |
+| 4    | 공지/FAQ + Notice popup                                                                                                                                | 3     | 병렬 가능  |
+| 5    | 알림 + 셸 마감 + 시각 회귀 12 화면 — N-03 BE polling 필수                                                                                              | 3     | close gate |
+
+**Phase 8 close 조건** (계획서 §2 Wave 5 close 참조):
+
+- 빌드/테스트/lint clean (FE/BE) + fixture-seed parity check
+- Playwright 9 시나리오 PASS
+- 핵심 12 화면 시각 회귀 yes/no 통과 (사용자 결정자)
+- NextGen leger 갱신 (N-03-ETag, 시각 회귀 자동화, shadcn 라이선스 inventory, contract semver)
+
+**Wave 0 첫 commit 강제**: 사내 npm 미러 사전 점검 (`npm config get registry` + `npm install zod --dry-run`). 미러 부재 시 §7 raw 벤더링 절차로 우회 결정 (사용자 승인 필요).
 
 ---
 

--- a/docs/specs/plans/nextgen-backlog.md
+++ b/docs/specs/plans/nextgen-backlog.md
@@ -89,8 +89,22 @@
 
 ---
 
-## 5. 변경 이력
+## 5. Phase 8 분리 항목 (계획서 §10 ADR Follow-ups)
+
+> 출처: `docs/specs/plans/phase-8.md` ADR + Wave 5 close 조건 4번 leger.
+
+| ID        | 항목                                    | 분리 사유                                                                                              | 활성화 시점                      |
+| --------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| N-03-ETag | 알림 폴링 ETag 304 최적화               | MVP는 단순 GET polling으로 충분 (BE는 Wave 5 필수). ETag 헤더·캐시 매니지먼트는 운영 부하 측정 후 도입 | Phase 8 close 후 운영 1~2주 측정 |
+| VR-1      | 시각 회귀 자동화 (pixel-diff)           | Phase 8 close는 수동 12 화면 yes/no 체크. 자동화는 별도 phase                                          | Phase 9 검토                     |
+| OSS-1     | shadcn 카피본 라이선스 inventory 자동화 | 사내 OSS 정책 license inventory 자동 생성 스크립트. Phase 8 시점은 LICENSE 동봉 honor system           | NextGen                          |
+| CON-1     | contract semver / breaking-change 정책  | `shared/contracts/<domain>.ts` 변경 정책 (메이저 변경 시 dual-write, 마이그레이션 스크립트 등)         | NextGen                          |
+
+---
+
+## 6. 변경 이력
 
 | 일자       | 변경                                                                                         |
 | ---------- | -------------------------------------------------------------------------------------------- |
 | 2026-05-01 | 초기 분리 — `next-session-tasks.md` "미결" 섹션 + 8개 spec/review 파일에서 NextGen 언급 통합 |
+| 2026-05-01 | §5 추가 — Phase 8 ADR 분리 항목 4건 (N-03-ETag / VR-1 / OSS-1 / CON-1)                       |


### PR DESCRIPTION
## Summary
- claude-progress.txt: 다음 세션 시작점을 "Phase 8 Wave 0 시작"으로 갱신, npm 미러 사전 점검 강제
- next-session-tasks.md: "Phase 8 재계획 (대기)" → "Phase 8 FE 실구현" Wave 0~5 표 + close 조건
- nextgen-backlog.md §5 신설: Phase 8 ADR Follow-ups 4건 (N-03-ETag / VR-1 / OSS-1 / CON-1)

PR #99 (Phase 8 계획서) 머지 직후 follow-up. 다음 세션은 Wave 0 진입 직전 상태로 정렬됨.

## Test plan
- [ ] docs only — 코드 영향 없음
- [ ] 다음 세션 시작 시 progress 첫 30줄 → next-session-tasks → phase-8.md 순으로 진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)