### PR TITLE
docs: TDD 정본화 + Phase 8 OSS 스택 requirements/CLAUDE.md 동기화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Skip the frame for trivial one-liners (rename, obvious typo, single-file change 
 
 ## Working Style
 
+- **TDD only** — every implementation (FE/BE) goes test-first: write or update the test, confirm it fails for the right reason, write the minimal code to pass, then refactor. No "tests later" PRs. Bug fixes start with a failing regression test. Stack: Vitest (FE) / Jest+Supertest (BE) — see `requirements.md §3`.
 - **No completion claims** — never mark a task done until the user explicitly says so
 - **No implementation without approval** — never write BE/FE code until the user says to start
 - **Debate, don't defer** — raise counterarguments or missed cases before agreeing; no passive "yes"

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Express REST API for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
 
-**Stack:** Node.js + Express + TypeScript, PostgreSQL with pgvector extension (`pgvector/pgvector:pg16`), Jest + Supertest (test), tsx (dev runner).
+**Stack:** Node.js + Express + TypeScript, PostgreSQL with pgvector extension (`pgvector/pgvector:pg16`), zod v4 (shared/ 계약 — FE와 단일 schema 공유, 라우트 입력 검증), Jest + Supertest (test), tsx (dev runner). **TDD 필수** (root CLAUDE.md). 전체 OSS·버전: `docs/specs/requires/requirements.md §3`.
 
 ## Status
 

--- a/docs/specs/requires/requirements.md
+++ b/docs/specs/requires/requirements.md
@@ -55,16 +55,23 @@
 
 ## 3. 기술 스택 (Tech Stack)
 
-| 구분              | 기술 스택                                | 비고                                                                                                |
-| :---------------- | :--------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| **Frontend**      | Vite, React, TypeScript, Tailwind CSS v4 | `tokens.ts` → Tailwind config + CSS vars 단일 소스                                                  |
-| **Backend**       | Node.js 20 LTS (Express), TypeScript     | OIDC 인증 미들웨어                                                                                  |
-| **Database**      | PostgreSQL 16                            | Self-join 및 M:N 관계 설계                                                                          |
-| **Infra**         | Docker, Docker Compose                   | 환경 일치 및 배포 편의성                                                                            |
-| **Editor**        | Toast UI Editor                          | 오픈소스 리치 텍스트 에디터                                                                         |
-| **Testing**       | Vitest (FE), Jest/Supertest (BE)         | TDD 개발 수행                                                                                       |
-| **Data Fetching** | @tanstack/react-query                    | staleTime 페이지별 확정: 대시보드·관리자 5분, VOC 목록 30초, VOC 상세·댓글 0(항상 fresh), 알림 30초 |
-| **Charts**        | recharts                                 | 대시보드 LineChart / BarChart (lazy import)                                                         |
+| 구분               | 기술 스택                                         | 비고                                                                                                |
+| :----------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------- |
+| **Frontend**       | Vite, React, TypeScript, Tailwind CSS v4          | `tokens.ts` → Tailwind config + CSS vars 단일 소스                                                  |
+| **Backend**        | Node.js 20 LTS (Express), TypeScript              | OIDC 인증 미들웨어                                                                                  |
+| **Database**       | PostgreSQL 16                                     | Self-join 및 M:N 관계 설계                                                                          |
+| **Infra**          | Docker, Docker Compose                            | 환경 일치 및 배포 편의성                                                                            |
+| **Editor**         | Toast UI Editor                                   | 오픈소스 리치 텍스트 에디터                                                                         |
+| **Testing**        | Vitest (FE), Jest/Supertest (BE), MSW             | **TDD 필수** (CLAUDE.md Working Style). MSW v2로 FE 단위·통합 테스트에서 API 모킹                   |
+| **Data Fetching**  | @tanstack/react-query v5                          | staleTime 페이지별 확정: 대시보드·관리자 5분, VOC 목록 30초, VOC 상세·댓글 0(항상 fresh), 알림 30초 |
+| **Charts**         | recharts v2                                       | 대시보드 LineChart / BarChart (lazy import)                                                         |
+| **UI Primitives**  | shadcn/ui (Radix 기반 카피본) + Lucide            | `frontend/src/components/ui/` 에 raw 카피, npm 의존성 아님. 토큰 매핑 codemod로 색상 일괄 치환      |
+| **Tables**         | @tanstack/react-table v8                          | VOC 리스트·관리자 표 (가상 스크롤·정렬·필터·계층 행)                                                |
+| **Forms**          | react-hook-form v7 + @hookform/resolvers          | 드로어/모달 폼 상태. zod resolver 표준                                                              |
+| **Validation**     | zod v4 (FE+BE 공유)                               | `shared/contracts/` 단일 schema 소스 — FE 입력 검증·API 응답 parse + BE 핸들러 입력 검증 동시 사용  |
+| **Toast/Feedback** | sonner v2                                         | 전역 토스트, `<Toaster />` AppShell 마운트                                                          |
+| **Date utils**     | date-fns v3 + react-day-picker v9                 | 드로어 날짜 표기 + Dashboard 기간 필터                                                              |
+| **Tailwind utils** | class-variance-authority, clsx, tailwind-merge v3 | shadcn 카피본 peer. 컴포넌트 variant + 클래스 병합                                                  |
 
 ---
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -2,7 +2,7 @@
 
 React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
 
-**Stack:** React + TypeScript, Vite, Tailwind CSS v4, Toast UI Editor (rich text), Vitest (test).
+**Stack:** React + TypeScript, Vite, Tailwind CSS v4, Toast UI Editor (rich text), shadcn/ui (Radix 카피본) + Lucide, @tanstack/react-query v5, @tanstack/react-table v8, react-hook-form + zod (shared/), sonner, date-fns + react-day-picker, recharts (lazy), MSW v2, Vitest. **TDD 필수** (root CLAUDE.md). 전체 OSS·버전: `docs/specs/requires/requirements.md §3`.
 
 ## Status
 


### PR DESCRIPTION
## Summary

- root CLAUDE.md Working Style 에 **TDD only** 룰 추가 — test-first → fail for the right reason → minimal pass → refactor; 버그픽스는 회귀 테스트 선행; "tests later" PR 금지
- `requirements.md §3 Tech Stack` 에 Phase 8 OSS 7행 추가 (shadcn/ui + Lucide, react-table, RHF + resolvers, zod v4 shared, sonner, date-fns + day-picker, cva/clsx/tailwind-merge) + Testing 행에 MSW + TDD 필수 + react-query/recharts 버전 표기
- `frontend/CLAUDE.md` / `backend/CLAUDE.md` Stack 한 줄에 Phase 8 OSS + TDD 반영

## Why

Phase 8 OSS 결정이 `phase-8.md` / `phase-8-oss-vendoring.md` 에만 있어 정본 spec(`requirements.md`)·governance(`CLAUDE.md`)만 보는 리뷰어/신규 컨트리뷰터가 스택 전체를 파악할 수 없던 갭. TDD 또한 hookify·requirements 비고에만 산재 → governance 정본 부재.

## Test plan

- [x] FE typecheck PASS (lint-staged hook)
- [x] BE typecheck PASS (lint-staged hook)
- [x] root CLAUDE.md 200줄 룰 준수 (112줄)
- [x] 정본 link 정합 — frontend/backend CLAUDE.md → requirements.md §3 으로 단일 진실 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)