### PR TITLE
docs(claude-md): 90% certainty gate 룰 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Skip the frame for trivial one-liners (rename, obvious typo, single-file change 
 - **No implementation without approval** — never write BE/FE code until the user says to start
 - **Debate, don't defer** — raise counterarguments or missed cases before agreeing; no passive "yes"
 - **Think before coding** — state assumptions; if multiple interpretations exist, present them, don't pick silently
+- **90% certainty gate** — 진행 중 어떤 결정이든 90% 이상 확신이 없으면 임의 진행 금지. 해소될 때까지 사용자에게 질문한다 (양쪽 옵션·근거 명시 형식). 추측·기본값 채우기·"일단 이걸로" 모두 금지
 - **Simplicity first** — minimum code; no speculative abstractions; if 200 lines could be 50, rewrite
 - **Surgical changes** — touch only what the request requires; match existing style; remove only orphans your changes made unused
 - **Goal-driven execution** — convert tasks into verifiable goals; for multi-step work, plan per-step verification and loop until verified


### PR DESCRIPTION
## Summary

CLAUDE.md Working Style 섹션에 **90% certainty gate** 룰 추가.

진행 중 결정 시 90% 이상 확신이 없으면 임의 진행 금지, 해소될 때까지 사용자에게 양쪽 옵션·근거 명시 형식으로 질문. 추측·기본값 채우기·"일단 이걸로" 일괄 금지.

## Why

autopilot/ralph 같은 자율 모드에서 Claude가 모호한 결정을 임의로 채우고 진행해 doc drift / 잘못된 패턴 박제 사례가 발생하는 것을 차단.

## Test plan

- [x] CLAUDE.md 200 line 룰 (113 lines, 통과)
- [x] 본 PR 자체에서 룰 적용 검증 (Q1~Q5 결정 사용자 위임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)