### PR TITLE
feat(phase-8-wave1): VOC 리스트 + 검토 드로어 vertical slice

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/backend/src/index.js",
     "test": "jest --runInBand",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "db:migrate": "node-pg-migrate up -m migrations",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest --runInBand",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "db:migrate": "node-pg-migrate up -m migrations",
     "db:migrate:down": "node-pg-migrate down -m migrations",
     "db:seed": "psql $DATABASE_URL -f seeds/dev_seed.sql",

--- a/backend/src/__tests__/helpers/app.ts
+++ b/backend/src/__tests__/helpers/app.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import session from 'express-session';
 import { authRouter } from '../../routes/auth';
+import { vocRouter } from '../../routes/voc';
+import { errorHandler } from '../../middleware/errorHandler';
 import { setPool } from '../../db';
 import type { Pool } from 'pg';
 
@@ -31,6 +33,9 @@ export function createTestApp(pool?: Pool, authMode = 'mock') {
   });
 
   app.use('/api/auth', authRouter);
+  app.use('/api/vocs', vocRouter);
+
+  app.use(errorHandler);
 
   return app;
 }

--- a/backend/src/__tests__/voc-contract.test.ts
+++ b/backend/src/__tests__/voc-contract.test.ts
@@ -1,13 +1,20 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import yaml from 'js-yaml';
+import { ZodObject, ZodOptional, ZodDefault } from 'zod';
+import * as VocSchemas from '../../../shared/contracts/voc';
 
-// Contract guard: VocInput / Voc must keep voc_type_id, system_id, menu_id required
-// (DB columns are NOT NULL — see backend/migrations/003_vocs.sql).
-// If openapi.yaml drifts the required[] list, this jest test fails immediately.
+type AnyZodObject = ZodObject<Record<string, never>>;
+
+// U2 contract guard (Wave 1) — zod ↔ openapi 양방향 정합 가드.
+// required[] 뿐 아니라 enum 값과 nullable 분기까지 비교한다.
+// drift 가 생기면 본 jest 테스트가 즉시 실패하여 Source-of-Truth 분기를 막는다.
 
 interface SchemaShape {
   required?: string[];
+  properties?: Record<string, { enum?: readonly string[]; nullable?: boolean; $ref?: string }>;
+  enum?: readonly string[];
+  nullable?: boolean;
 }
 interface OpenApiShape {
   components?: { schemas?: Record<string, SchemaShape> };
@@ -16,17 +23,103 @@ interface OpenApiShape {
 const yamlPath = join(__dirname, '../../../shared/openapi.yaml');
 const doc = yaml.load(readFileSync(yamlPath, 'utf8')) as OpenApiShape;
 
+const schemas = doc.components?.schemas ?? {};
+
 describe('OpenAPI contract — VocInput/Voc required FK 컬럼 (DB NOT NULL 정합)', () => {
   const required = ['voc_type_id', 'system_id', 'menu_id'] as const;
 
   test.each(['Voc', 'VocInput'] as const)(
     '%s.required 에 voc_type_id+system_id+menu_id 포함',
     (name) => {
-      const schema = doc.components?.schemas?.[name];
+      const schema = schemas[name];
       expect(schema).toBeDefined();
       for (const key of required) {
         expect(schema!.required).toContain(key);
       }
     },
   );
+});
+
+describe('U2 guard — zod ↔ openapi voc 정합 (Wave 1)', () => {
+  function zodRequiredKeys(obj: AnyZodObject): Set<string> {
+    const out = new Set<string>();
+    const shape = (obj as unknown as { shape: Record<string, unknown> }).shape;
+    for (const [key, value] of Object.entries(shape)) {
+      if (value instanceof ZodOptional || value instanceof ZodDefault) continue;
+      out.add(key);
+    }
+    return out;
+  }
+
+  function zodNullableKeys(obj: AnyZodObject): Set<string> {
+    const out = new Set<string>();
+    const shape = (
+      obj as unknown as {
+        shape: Record<string, { safeParse(v: unknown): { success: boolean } }>;
+      }
+    ).shape;
+    for (const [key, value] of Object.entries(shape)) {
+      if (value.safeParse(null).success) out.add(key);
+    }
+    return out;
+  }
+
+  function enumOptions(schema: unknown): string[] {
+    return Object.values((schema as { options: Record<string, string> }).options ?? {});
+  }
+
+  test('Voc.required 매트릭스 (zod 의 비-옵셔널 키 ⊇ openapi.required)', () => {
+    const yamlVoc = schemas.Voc!;
+    const zodKeys = zodRequiredKeys(VocSchemas.Voc as unknown as AnyZodObject);
+    for (const k of yamlVoc.required ?? []) {
+      expect(zodKeys.has(k)).toBe(true);
+    }
+  });
+
+  test('Voc nullable 키 정합 (yaml.nullable=true ⊆ zod nullable)', () => {
+    const yamlVoc = schemas.Voc!;
+    const zodNullable = zodNullableKeys(VocSchemas.Voc as unknown as AnyZodObject);
+    const missing: string[] = [];
+    for (const [key, prop] of Object.entries(yamlVoc.properties ?? {})) {
+      if (prop.nullable && !zodNullable.has(key)) missing.push(key);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test('VocStatus enum 정합', () => {
+    const yamlEnum = (schemas.VocStatus?.enum ?? []) as string[];
+    const zodEnum = enumOptions(VocSchemas.VocStatus);
+    expect([...zodEnum].sort()).toEqual([...yamlEnum].sort());
+  });
+
+  test('VocPriority enum 정합', () => {
+    const yamlEnum = (schemas.VocPriority?.enum ?? []) as string[];
+    const zodEnum = enumOptions(VocSchemas.VocPriority);
+    expect([...zodEnum].sort()).toEqual([...yamlEnum].sort());
+  });
+
+  test('VocSource enum 정합', () => {
+    const yamlEnum = (schemas.VocSource?.enum ?? []) as string[];
+    const zodEnum = enumOptions(VocSchemas.VocSource);
+    expect([...zodEnum].sort()).toEqual([...yamlEnum].sort());
+  });
+
+  test('VocInput.required 매트릭스', () => {
+    const yamlInput = schemas.VocInput!;
+    const zodKeys = zodRequiredKeys(VocSchemas.VocCreate as unknown as AnyZodObject);
+    const expected = new Set(yamlInput.required ?? []);
+    expected.delete('status');
+    expected.delete('priority');
+    for (const k of expected) {
+      expect(zodKeys.has(k)).toBe(true);
+    }
+  });
+
+  test('fixture 50건 모두 Voc.parse 통과', async () => {
+    const { VOC_FIXTURES } = await import('../../../shared/fixtures/voc.fixtures');
+    expect(VOC_FIXTURES.length).toBeGreaterThanOrEqual(50);
+    for (const row of VOC_FIXTURES) {
+      expect(() => VocSchemas.Voc.parse(row)).not.toThrow();
+    }
+  });
 });

--- a/backend/src/__tests__/vocs.test.ts
+++ b/backend/src/__tests__/vocs.test.ts
@@ -29,6 +29,7 @@ jest.mock('../repository/voc', () => {
     listVocs: jest.fn(
       async (params: {
         status?: string[];
+        voc_type_id?: string[];
         limit?: number;
         page?: number;
         includeDeleted?: boolean;
@@ -38,6 +39,9 @@ jest.mock('../repository/voc', () => {
         let filtered = store.filter((r) => params.includeDeleted || r.deleted_at === null);
         if (params.status?.length) {
           filtered = filtered.filter((r) => params.status!.includes(r.status));
+        }
+        if (params.voc_type_id?.length) {
+          filtered = filtered.filter((r) => params.voc_type_id!.includes(r.voc_type_id));
         }
         const total = filtered.length;
         const start = (page - 1) * limit;
@@ -153,5 +157,27 @@ describe('VOC endpoints — Wave 1 회귀 매트릭스', () => {
     const agent = await loginAs('user');
     const res = await agent.get(`/api/vocs/${liveVoc.id}/notes`);
     expect(res.status).toBe(404);
+  });
+
+  test('B-T8 non-admin ?includeDeleted=true does not leak soft-deleted rows', async () => {
+    const agent = await loginAs('manager');
+    const res = await agent.get('/api/vocs?includeDeleted=true&limit=100');
+    expect(res.status).toBe(200);
+    const ids = (res.body.rows as Array<{ id: string }>).map((r) => r.id);
+    expect(ids).not.toContain(deletedVoc.id);
+  });
+
+  test('B-T9 ?voc_type_id filter is applied at repository (no silent drop)', async () => {
+    const targetType = liveVoc.voc_type_id;
+    const expectedIds = VOC_FIXTURES.filter(
+      (r) => r.deleted_at === null && r.voc_type_id === targetType,
+    ).map((r) => r.id);
+    const agent = await loginAs('manager');
+    const res = await agent.get(
+      `/api/vocs?voc_type_id=${encodeURIComponent(targetType)}&limit=100`,
+    );
+    expect(res.status).toBe(200);
+    const ids = (res.body.rows as Array<{ id: string }>).map((r) => r.id).sort();
+    expect(ids).toEqual([...expectedIds].sort());
   });
 });

--- a/backend/src/__tests__/vocs.test.ts
+++ b/backend/src/__tests__/vocs.test.ts
@@ -1,44 +1,157 @@
 import request from 'supertest';
 import { createTestApp } from './helpers/app';
+import { VocListResponse } from '../../../shared/contracts/voc';
+import { VOC_FIXTURES, FIXTURE_USERS } from '../../../shared/fixtures/voc.fixtures';
 
 /**
- * VOC CRUD + permission tests — TDD style.
- * Unimplemented routes are marked it.todo() and will be filled in when the route lands.
+ * Phase 8 Wave 1 BE 회귀 매트릭스 (plan §6-3 + adversarial review B-T7).
+ *
+ * U3=A: 테스트는 mock repository(jest.mock) 모듈 단위 mocking 으로 동작.
  */
-describe('VOC endpoints', () => {
-  describe('GET /api/vocs', () => {
-    it.todo('returns 401 when not authenticated');
-    it.todo('returns 200 with paginated list for authenticated user');
-    it.todo('filters by status query param');
-    it.todo('filters by systemId query param');
-  });
+jest.mock('../repository/voc', () => {
+  type Row = (typeof import('../../../shared/fixtures/voc.fixtures'))['VOC_FIXTURES'][number];
+  const fixtures = jest.requireActual('../../../shared/fixtures/voc.fixtures') as {
+    VOC_FIXTURES: Row[];
+    VOC_NOTES_FIXTURES: Array<{
+      id: string;
+      voc_id: string;
+      author_id: string;
+      body: string;
+      created_at: string;
+      updated_at: string;
+      deleted_at: string | null;
+    }>;
+  };
+  const store: Row[] = [...fixtures.VOC_FIXTURES];
+  const noteStore = [...fixtures.VOC_NOTES_FIXTURES];
 
-  describe('POST /api/vocs', () => {
-    it.todo('returns 401 when not authenticated');
-    it.todo('returns 201 with created VOC for valid body');
-    it.todo('returns 400 for missing required fields');
-  });
-
-  describe('PATCH /api/vocs/:id/status', () => {
-    it.todo('returns 401 when not authenticated');
-    it.todo('returns 403 when user role tries to change status (manager/admin only)');
-    it.todo('returns 200 when manager changes status following valid transition');
-    it.todo('returns 422 for invalid status transition');
-  });
-
-  describe('DELETE /api/vocs/:id', () => {
-    it.todo('returns 401 when not authenticated');
-    it.todo('returns 403 when manager tries to delete (admin-only soft delete)');
-    it.todo('returns 200 when admin soft-deletes');
-    it.todo('deleted VOC excluded from GET /api/vocs unless includeDeleted=true (admin only)');
-  });
+  return {
+    listVocs: jest.fn(
+      async (params: {
+        status?: string[];
+        limit?: number;
+        page?: number;
+        includeDeleted?: boolean;
+      }) => {
+        const limit = params.limit ?? 20;
+        const page = params.page ?? 1;
+        let filtered = store.filter((r) => params.includeDeleted || r.deleted_at === null);
+        if (params.status?.length) {
+          filtered = filtered.filter((r) => params.status!.includes(r.status));
+        }
+        const total = filtered.length;
+        const start = (page - 1) * limit;
+        return { rows: filtered.slice(start, start + limit), total };
+      },
+    ),
+    getVocById: jest.fn(async (id: string, opts: { includeDeleted?: boolean } = {}) => {
+      const row = store.find((r) => r.id === id);
+      if (!row) return null;
+      if (!opts.includeDeleted && row.deleted_at !== null) return null;
+      return row;
+    }),
+    updateVoc: jest.fn(async (id: string, patch: Partial<Row>) => {
+      const idx = store.findIndex((r) => r.id === id);
+      if (idx < 0) return null;
+      const next = { ...store[idx]!, ...patch, updated_at: new Date().toISOString() } as Row;
+      store[idx] = next;
+      return next;
+    }),
+    listNotes: jest.fn(async (vocId: string) => noteStore.filter((n) => n.voc_id === vocId)),
+    createNote: jest.fn(async (vocId: string, authorId: string, body: string) => {
+      const now = new Date().toISOString();
+      const row = {
+        id: `dddddddd-0000-4000-8000-${String(noteStore.length + 1).padStart(12, '0')}`,
+        voc_id: vocId,
+        author_id: authorId,
+        body,
+        created_at: now,
+        updated_at: now,
+        deleted_at: null,
+      };
+      noteStore.push(row);
+      return row;
+    }),
+    listHistory: jest.fn(async () => []),
+    __reset: () => {
+      store.length = 0;
+      store.push(...fixtures.VOC_FIXTURES);
+      noteStore.length = 0;
+      noteStore.push(...fixtures.VOC_NOTES_FIXTURES);
+    },
+  };
 });
 
-// Keep a concrete smoke test to ensure the test app + supertest wiring works
-describe('VOC route auth smoke', () => {
-  it('unknown VOC route returns 404 (sanity check)', async () => {
-    const app = createTestApp();
-    const res = await request(app).get('/api/vocs');
+const repoMock = jest.requireMock('../repository/voc') as {
+  __reset: () => void;
+};
+
+beforeEach(() => {
+  repoMock.__reset();
+  jest.clearAllMocks();
+});
+
+const liveVoc = VOC_FIXTURES.find(
+  (r) => r.deleted_at === null && r.assignee_id === FIXTURE_USERS.devSelf,
+)!;
+const otherDevVoc = VOC_FIXTURES.find(
+  (r) => r.deleted_at === null && r.assignee_id !== null && r.assignee_id !== FIXTURE_USERS.devSelf,
+)!;
+const deletedVoc = VOC_FIXTURES.find((r) => r.deleted_at !== null)!;
+
+async function loginAs(role: 'admin' | 'manager' | 'dev' | 'user') {
+  const app = createTestApp();
+  const agent = request.agent(app);
+  await agent.post('/api/auth/mock-login').send({ role });
+  return agent;
+}
+
+describe('VOC endpoints — Wave 1 회귀 매트릭스', () => {
+  test('B-T1 GET /api/vocs returns 200 + VocListResponse for manager', async () => {
+    const agent = await loginAs('manager');
+    const res = await agent.get('/api/vocs?status=%EC%A0%91%EC%88%98&limit=20');
+    expect(res.status).toBe(200);
+    expect(() => VocListResponse.parse(res.body)).not.toThrow();
+  });
+
+  test('B-T2 GET /api/vocs?limit=999 returns 400 VALIDATION_ERROR', async () => {
+    const agent = await loginAs('manager');
+    const res = await agent.get('/api/vocs?limit=999');
+    expect(res.status).toBe(400);
+    expect(res.body.error?.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('B-T3 dev PATCH on someone else’s VOC returns 403 FORBIDDEN action=changeStatus', async () => {
+    const agent = await loginAs('dev');
+    const res = await agent.patch(`/api/vocs/${otherDevVoc.id}`).send({ status: '검토중' });
+    expect(res.status).toBe(403);
+    expect(res.body.error?.code).toBe('FORBIDDEN');
+    expect(res.body.error?.details?.action).toBe('changeStatus');
+  });
+
+  test('B-T4 GET /api/vocs/:id returns 404 for soft-deleted VOC (manager)', async () => {
+    const agent = await loginAs('manager');
+    const res = await agent.get(`/api/vocs/${deletedVoc.id}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('B-T5 dev=self POST /api/vocs/:id/notes returns 200', async () => {
+    const agent = await loginAs('dev');
+    const res = await agent.post(`/api/vocs/${liveVoc.id}/notes`).send({ body: 'triage start' });
+    expect(res.status).toBe(200);
+    expect(res.body.body).toBe('triage start');
+  });
+
+  test('B-T6 dev=self priority change returns 200 (Q5=A regression)', async () => {
+    const agent = await loginAs('dev');
+    const res = await agent.patch(`/api/vocs/${liveVoc.id}`).send({ priority: 'urgent' });
+    expect(res.status).toBe(200);
+    expect(res.body.priority).toBe('urgent');
+  });
+
+  test('B-T7 user GET /api/vocs/:id/notes returns 404 fail-closed (architect 권고)', async () => {
+    const agent = await loginAs('user');
+    const res = await agent.get(`/api/vocs/${liveVoc.id}/notes`);
     expect(res.status).toBe(404);
   });
 });

--- a/backend/src/auth/mockUsers.ts
+++ b/backend/src/auth/mockUsers.ts
@@ -1,26 +1,30 @@
 import { AuthUser } from './types.js';
+import { FIXTURE_USERS } from '../../../shared/fixtures/voc.fixtures';
 
+// Mock users now reference the same UUID space as `shared/fixtures/voc.fixtures`
+// (v4-compliant). This unifies BE/FE auth ids with the fixture assignee_id used
+// for permission tests (Wave 1 §U3=A).
 export const MOCK_USERS: AuthUser[] = [
   {
-    id: '00000000-0000-0000-0000-000000000001',
+    id: FIXTURE_USERS.admin,
     email: 'admin@company.com',
     name: 'Mock Admin',
     role: 'admin',
   },
   {
-    id: '00000000-0000-0000-0000-000000000002',
+    id: FIXTURE_USERS.manager,
     email: 'manager@company.com',
     name: 'Mock Manager',
     role: 'manager',
   },
   {
-    id: '00000000-0000-0000-0000-000000000003',
+    id: FIXTURE_USERS.user,
     email: 'user@company.com',
     name: 'Mock User',
     role: 'user',
   },
   {
-    id: '00000000-0000-0000-0000-000000000004',
+    id: FIXTURE_USERS.devSelf,
     email: 'dev@company.com',
     name: 'Mock Dev',
     role: 'dev',

--- a/backend/src/auth/mockUsers.ts
+++ b/backend/src/auth/mockUsers.ts
@@ -1,9 +1,10 @@
 import { AuthUser } from './types.js';
-import { FIXTURE_USERS } from '../../../shared/fixtures/voc.fixtures';
+import { FIXTURE_USERS } from '../../../shared/contracts/voc/users';
 
-// Mock users now reference the same UUID space as `shared/fixtures/voc.fixtures`
+// Mock users share the UUID space declared in `shared/contracts/voc/users`
 // (v4-compliant). This unifies BE/FE auth ids with the fixture assignee_id used
-// for permission tests (Wave 1 §U3=A).
+// for permission tests (Wave 1 §U3=A). Imported from contracts/ — not
+// fixtures/ — so prod backend code does not pull in the 50-row fixture array.
 export const MOCK_USERS: AuthUser[] = [
   {
     id: FIXTURE_USERS.admin,

--- a/backend/src/controllers/voc.ts
+++ b/backend/src/controllers/voc.ts
@@ -8,7 +8,10 @@ function user(req: Request): AuthUser {
 
 export async function getList(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const result = await service.list(req.query as unknown as Parameters<typeof service.list>[0]);
+    const result = await service.list(
+      req.query as unknown as Parameters<typeof service.list>[0],
+      user(req),
+    );
     res.json(result);
   } catch (err) {
     next(err);

--- a/backend/src/controllers/voc.ts
+++ b/backend/src/controllers/voc.ts
@@ -1,0 +1,57 @@
+import type { Request, Response, NextFunction } from 'express';
+import * as service from '../services/voc';
+import type { AuthUser } from '../auth/types';
+
+function user(req: Request): AuthUser {
+  return req.user as AuthUser;
+}
+
+export async function getList(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const result = await service.list(req.query as unknown as Parameters<typeof service.list>[0]);
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const result = await service.detail(req.params.id as string, user(req));
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function patchVoc(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const result = await service.update(
+      req.params.id as string,
+      req.body as Parameters<typeof service.update>[1],
+      user(req),
+    );
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getNotes(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rows = await service.notes(req.params.id as string, user(req));
+    res.json({ rows });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function postNote(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { body } = req.body as { body: string };
+    const note = await service.addNote(req.params.id as string, body, user(req));
+    res.json(note);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import yaml from 'js-yaml';
 import { createAuthMiddleware } from './auth';
 import { authRouter } from './routes/auth';
+import { vocRouter } from './routes/voc';
 import { errorHandler } from './middleware/errorHandler';
 import logger from './logger';
 
@@ -57,6 +58,7 @@ app.get('/api/health', async (_req, res) => {
 });
 
 app.use('/api/auth', authRouter);
+app.use('/api/vocs', vocRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,8 +1,10 @@
 import pino from 'pino';
 
+const useDevTransport = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+
 const logger = pino({
-  level: process.env.LOG_LEVEL ?? 'info',
-  ...(process.env.NODE_ENV !== 'production' && {
+  level: process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'test' ? 'silent' : 'info'),
+  ...(useDevTransport && {
     transport: { target: 'pino-pretty', options: { colorize: true, ignore: 'pid,hostname' } },
   }),
 });

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,11 +1,12 @@
 import type { RequestHandler } from 'express';
-import { ZodSchema, ZodError } from 'zod';
+import { ZodError } from 'zod';
+import type { ZodType } from 'zod';
 import { errorEnvelope } from './errorEnvelope';
 
-export function validate<T>(opts: {
-  body?: ZodSchema<T>;
-  query?: ZodSchema<T>;
-  params?: ZodSchema<T>;
+export function validate<TBody = unknown, TQuery = unknown, TParams = unknown>(opts: {
+  body?: ZodType<TBody>;
+  query?: ZodType<TQuery>;
+  params?: ZodType<TParams>;
 }): RequestHandler {
   return (req, res, next) => {
     try {

--- a/backend/src/repository/voc.ts
+++ b/backend/src/repository/voc.ts
@@ -1,0 +1,118 @@
+/**
+ * VOC repository — DB access boundary. Service layer imports from here so tests
+ * can `jest.mock('../repository/voc')` for module-level mocking (Wave 1 §U3=A).
+ *
+ * Production wiring: this module talks to `getPool()` (pg). Wave 1 keeps the
+ * surface minimal — list / get / update / notes (list+create) / history.
+ */
+import { getPool } from '../db';
+import type { Voc, InternalNote, VocHistoryEntry } from '../../../shared/contracts/voc';
+
+export interface ListVocsParams {
+  status?: string[];
+  system_id?: string;
+  voc_type_id?: string[];
+  assignee_id?: string;
+  q?: string;
+  sort: 'created_at' | 'updated_at' | 'priority' | 'status' | 'due_date' | 'issue_code';
+  order: 'asc' | 'desc';
+  page: number;
+  limit: number;
+  includeDeleted?: boolean;
+}
+
+export interface ListVocsResult {
+  rows: Voc[];
+  total: number;
+}
+
+export async function listVocs(params: ListVocsParams): Promise<ListVocsResult> {
+  const pool = getPool();
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+  let i = 1;
+  if (!params.includeDeleted) conditions.push('deleted_at IS NULL');
+  if (params.status?.length) {
+    conditions.push(`status = ANY($${i++})`);
+    values.push(params.status);
+  }
+  if (params.system_id) {
+    conditions.push(`system_id = $${i++}`);
+    values.push(params.system_id);
+  }
+  if (params.assignee_id) {
+    conditions.push(`assignee_id = $${i++}`);
+    values.push(params.assignee_id);
+  }
+  if (params.q) {
+    conditions.push(`(title ILIKE $${i} OR issue_code ILIKE $${i})`);
+    values.push(`%${params.q}%`);
+    i += 1;
+  }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const offset = (params.page - 1) * params.limit;
+  const rows = (
+    await pool.query(
+      `SELECT * FROM vocs ${where} ORDER BY ${params.sort} ${params.order} LIMIT $${i++} OFFSET $${i++}`,
+      [...values, params.limit, offset],
+    )
+  ).rows as Voc[];
+  const totalRow = await pool.query(`SELECT count(*)::int AS n FROM vocs ${where}`, values);
+  return { rows, total: totalRow.rows[0]?.n ?? 0 };
+}
+
+export async function getVocById(
+  id: string,
+  opts: { includeDeleted?: boolean } = {},
+): Promise<Voc | null> {
+  const pool = getPool();
+  const r = await pool.query('SELECT * FROM vocs WHERE id = $1', [id]);
+  const row = r.rows[0] as Voc | undefined;
+  if (!row) return null;
+  if (!opts.includeDeleted && row.deleted_at !== null) return null;
+  return row;
+}
+
+export async function updateVoc(id: string, patch: Partial<Voc>): Promise<Voc | null> {
+  const pool = getPool();
+  const keys = Object.keys(patch);
+  if (!keys.length) return getVocById(id);
+  const setClause = keys.map((k, idx) => `${k} = $${idx + 2}`).join(', ');
+  const values = keys.map((k) => (patch as Record<string, unknown>)[k]);
+  const r = await pool.query(
+    `UPDATE vocs SET ${setClause}, updated_at = now() WHERE id = $1 RETURNING *`,
+    [id, ...values],
+  );
+  return (r.rows[0] as Voc | undefined) ?? null;
+}
+
+export async function listNotes(vocId: string): Promise<InternalNote[]> {
+  const pool = getPool();
+  const r = await pool.query(
+    'SELECT * FROM voc_internal_notes WHERE voc_id = $1 AND deleted_at IS NULL ORDER BY created_at ASC',
+    [vocId],
+  );
+  return r.rows as InternalNote[];
+}
+
+export async function createNote(
+  vocId: string,
+  authorId: string,
+  body: string,
+): Promise<InternalNote> {
+  const pool = getPool();
+  const r = await pool.query(
+    `INSERT INTO voc_internal_notes (voc_id, author_id, body) VALUES ($1, $2, $3) RETURNING *`,
+    [vocId, authorId, body],
+  );
+  return r.rows[0] as InternalNote;
+}
+
+export async function listHistory(vocId: string): Promise<VocHistoryEntry[]> {
+  const pool = getPool();
+  const r = await pool.query(
+    'SELECT * FROM voc_history WHERE voc_id = $1 ORDER BY changed_at DESC',
+    [vocId],
+  );
+  return r.rows as VocHistoryEntry[];
+}

--- a/backend/src/repository/voc.ts
+++ b/backend/src/repository/voc.ts
@@ -40,6 +40,10 @@ export async function listVocs(params: ListVocsParams): Promise<ListVocsResult> 
     conditions.push(`system_id = $${i++}`);
     values.push(params.system_id);
   }
+  if (params.voc_type_id?.length) {
+    conditions.push(`voc_type_id = ANY($${i++})`);
+    values.push(params.voc_type_id);
+  }
   if (params.assignee_id) {
     conditions.push(`assignee_id = $${i++}`);
     values.push(params.assignee_id);

--- a/backend/src/routes/__tests__/auth.test.ts
+++ b/backend/src/routes/__tests__/auth.test.ts
@@ -29,7 +29,7 @@ describe('POST /api/auth/mock-login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.user).toMatchObject({
-      id: '00000000-0000-0000-0000-000000000001',
+      id: '00000000-0000-4000-8000-0000000000a1',
       email: 'admin@company.com',
       name: 'Mock Admin',
       role: 'admin',
@@ -42,7 +42,7 @@ describe('POST /api/auth/mock-login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.user).toMatchObject({
-      id: '00000000-0000-0000-0000-000000000004',
+      id: '00000000-0000-4000-8000-0000000000c1',
       email: 'dev@company.com',
       name: 'Mock Dev',
       role: 'dev',

--- a/backend/src/routes/voc.ts
+++ b/backend/src/routes/voc.ts
@@ -1,0 +1,30 @@
+import { Router, type RequestHandler } from 'express';
+import { createAuthMiddleware } from '../auth';
+import { validate } from '../middleware/validate';
+import * as controller from '../controllers/voc';
+import {
+  vocListQuerySchema,
+  vocUpdateSchema,
+  vocIdParamSchema,
+  internalNoteCreateSchema,
+} from '../validators/voc';
+
+const auth: RequestHandler = (req, res, next) => createAuthMiddleware()(req, res, next);
+
+export const vocRouter = Router();
+
+vocRouter.use(auth);
+
+vocRouter.get('/', validate({ query: vocListQuerySchema }), controller.getList);
+vocRouter.get('/:id', validate({ params: vocIdParamSchema }), controller.getDetail);
+vocRouter.patch(
+  '/:id',
+  validate({ params: vocIdParamSchema, body: vocUpdateSchema }),
+  controller.patchVoc,
+);
+vocRouter.get('/:id/notes', validate({ params: vocIdParamSchema }), controller.getNotes);
+vocRouter.post(
+  '/:id/notes',
+  validate({ params: vocIdParamSchema, body: internalNoteCreateSchema }),
+  controller.postNote,
+);

--- a/backend/src/services/permissions/assertCanManageVoc.ts
+++ b/backend/src/services/permissions/assertCanManageVoc.ts
@@ -18,7 +18,7 @@ export type VocAction =
 export interface VocPermissionContext {
   id: string;
   assignee_id: string | null;
-  deleted_at: Date | null;
+  deleted_at: Date | string | null | undefined;
 }
 
 export function assertCanManageVoc(
@@ -33,5 +33,11 @@ export function assertCanManageVoc(
     throw new HttpError(403, 'FORBIDDEN', '담당자만 수행할 수 있는 작업입니다.', { action });
   }
 
+  // user role: internal-note read/write must look like a hidden endpoint (404)
+  // per requirements; other actions return 403. Helper centralises the role
+  // branch so route code never makes this decision (backend/CLAUDE.md rule).
+  if (action === 'readInternalNote' || action === 'writeInternalNote') {
+    throw new HttpError(404, 'NOT_FOUND', 'Not found.');
+  }
   throw new HttpError(403, 'FORBIDDEN', '접근 권한이 없습니다.', { action });
 }

--- a/backend/src/services/voc.ts
+++ b/backend/src/services/voc.ts
@@ -43,7 +43,7 @@ function toListItem(v: Voc) {
   };
 }
 
-export async function list(query: VocListQuery): Promise<VocListResponse> {
+export async function list(query: VocListQuery, user: AuthUser): Promise<VocListResponse> {
   const result = await repo.listVocs({
     status: query.status,
     system_id: query.system_id,
@@ -54,7 +54,7 @@ export async function list(query: VocListQuery): Promise<VocListResponse> {
     order: query.order,
     page: query.page,
     limit: query.limit,
-    includeDeleted: query.includeDeleted,
+    includeDeleted: query.includeDeleted && user.role === 'admin',
   });
   return {
     rows: result.rows.map(toListItem),

--- a/backend/src/services/voc.ts
+++ b/backend/src/services/voc.ts
@@ -1,0 +1,124 @@
+/**
+ * VOC service — business logic between routes and repository.
+ *
+ * Wave 1 §U3=A: routes import service, service imports repository. Tests use
+ * `jest.mock('../repository/voc')` for module-level isolation.
+ *
+ * Permission policy: every mutating call funnels through `assertCanManageVoc`
+ * (single source per backend/CLAUDE.md). Read-of-internal-notes uses the
+ * same helper with `readInternalNote` action — User → 404 fail-closed handled
+ * inside the helper to keep route code free of role branching.
+ */
+import { HttpError } from '../middleware/httpError';
+import { assertCanManageVoc, type VocAction } from './permissions/assertCanManageVoc';
+import * as repo from '../repository/voc';
+import type { AuthUser } from '../auth/types';
+import type {
+  Voc,
+  VocListQuery,
+  VocListResponse,
+  VocUpdate,
+  InternalNote,
+} from '../../../shared/contracts/voc';
+
+function toListItem(v: Voc) {
+  return {
+    id: v.id,
+    issue_code: v.issue_code,
+    title: v.title,
+    status: v.status,
+    priority: v.priority,
+    voc_type_id: v.voc_type_id,
+    system_id: v.system_id,
+    menu_id: v.menu_id,
+    assignee_id: v.assignee_id,
+    author_id: v.author_id,
+    parent_id: v.parent_id,
+    source: v.source,
+    due_date: v.due_date ?? null,
+    created_at: v.created_at,
+    updated_at: v.updated_at,
+    has_children: false,
+    notes_count: 0,
+  };
+}
+
+export async function list(query: VocListQuery): Promise<VocListResponse> {
+  const result = await repo.listVocs({
+    status: query.status,
+    system_id: query.system_id,
+    voc_type_id: query.voc_type_id,
+    assignee_id: query.assignee_id,
+    q: query.q,
+    sort: query.sort,
+    order: query.order,
+    page: query.page,
+    limit: query.limit,
+    includeDeleted: query.includeDeleted,
+  });
+  return {
+    rows: result.rows.map(toListItem),
+    page: query.page,
+    pageSize: query.limit,
+    total: result.total,
+  };
+}
+
+export async function detail(id: string, user: AuthUser): Promise<Voc> {
+  const includeDeleted = user.role === 'admin';
+  const row = await repo.getVocById(id, { includeDeleted });
+  if (!row) throw new HttpError(404, 'NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+  return row;
+}
+
+/** Patch picks the dominant action so the helper can deny precisely. */
+function inferAction(patch: VocUpdate): VocAction {
+  if ('status' in patch) return 'changeStatus';
+  if ('priority' in patch) return 'setPriority';
+  if ('due_date' in patch) return 'setDueDate';
+  if ('assignee_id' in patch) return 'changeStatus';
+  return 'changeStatus';
+}
+
+export async function update(id: string, patch: VocUpdate, user: AuthUser): Promise<Voc> {
+  const existing = await repo.getVocById(id);
+  if (!existing) throw new HttpError(404, 'NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+  const action = inferAction(patch);
+  assertCanManageVoc(user, existing, action);
+  const next = await repo.updateVoc(id, patch);
+  if (!next) throw new HttpError(404, 'NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+  return next;
+}
+
+/**
+ * For internal-note endpoints, evaluate the helper with a placeholder voc when
+ * the role would be denied regardless (User → 404). This short-circuits before
+ * any DB hit so unauthenticated requests can never leak existence via timing
+ * or 500 errors. The helper still owns the role decision (no role branching
+ * here) — see `assertCanManageVoc.ts:32-39`.
+ */
+function assertNoteAccessEarly(
+  user: AuthUser,
+  id: string,
+  action: 'readInternalNote' | 'writeInternalNote',
+) {
+  if (user.role === 'user') {
+    assertCanManageVoc(user, { id, assignee_id: null, deleted_at: null }, action);
+  }
+}
+
+export async function notes(id: string, user: AuthUser): Promise<InternalNote[]> {
+  assertNoteAccessEarly(user, id, 'readInternalNote');
+  const existing = await repo.getVocById(id);
+  if (!existing) throw new HttpError(404, 'NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+  assertCanManageVoc(user, existing, 'readInternalNote');
+  return repo.listNotes(id);
+}
+
+export async function addNote(id: string, body: string, user: AuthUser): Promise<InternalNote> {
+  assertNoteAccessEarly(user, id, 'writeInternalNote');
+  const existing = await repo.getVocById(id);
+  if (!existing) throw new HttpError(404, 'NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+  assertCanManageVoc(user, existing, 'writeInternalNote');
+  return repo.createNote(id, user.id, body);
+}

--- a/backend/src/validators/voc.ts
+++ b/backend/src/validators/voc.ts
@@ -1,0 +1,11 @@
+import {
+  VocListQuery,
+  VocUpdate,
+  VocIdParam,
+  InternalNoteCreate,
+} from '../../../shared/contracts/voc';
+
+export const vocListQuerySchema = VocListQuery;
+export const vocUpdateSchema = VocUpdate;
+export const vocIdParamSchema = VocIdParam;
+export const internalNoteCreateSchema = InternalNoteCreate;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,11 +5,11 @@
     "moduleResolution": "node",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "types": ["node", "jest"]
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "../shared/contracts", "../shared/fixtures"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts"]
 }

--- a/backend/tsconfig.typecheck.json
+++ b/backend/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true
+  },
+  "include": ["src", "../shared/contracts", "../shared/fixtures"]
+}

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,72 +2,38 @@
 
 ## 다음 세션 시작점
 
-→ **Phase 8 Wave 1 진입 직전** — 설계+계획+인프라 mini-PR 완료, 다음 세션 구현 진입.
+→ **Phase 8 Wave 1 PR #110 리뷰 대기** — 본 세션 vertical slice 4 commit 푸시 완료.
 
-**이번 세션 산출 (2026-05-01)**:
-- PR #106 머지 — CLAUDE.md 90% certainty gate 룰 (Working Style 섹션)
-- PR #107 머지 — `docs/specs/plans/phase-8-wave1-plan.md` 설계 메모 448 lines + Q1~Q5 결정 로그 §0
-- PR #108 머지 — shadcn 4종 카피본 (textarea/tooltip/alert/popover) + radix tooltip/popover 의존성
+**이번 세션 산출 (2026-05-01 cont.)**:
 
-**Q1~Q5 결정 (Wave 1 plan §0)**:
-- Q1=B contract 3분할 (entity/io/note + barrel) / Q2=A BE service 단일 / Q3=A 신규 마이그 0건 / Q4=B shadcn mini-PR 분리 (#108 완료) / Q5=A F12 setPriority Wave 1 포함
+- PR #110 (open) `feat/phase-8-wave1` — VOC 리스트 + 검토 드로어 vertical slice (~1500 LOC)
+  - `454c8ca` shared 계약 (entity/io/note 3분할) + 50 fixture + U2 zod↔openapi 가드 9건
+  - `20a6a73` BE vertical slice — repository/service/validators/routes + 회귀 매트릭스 7건
+  - `93ae273` FE api/voc + MSW handler 5건 + queryKey 보강
+  - `b7030dd` FE list + drawer 슬라이스 (RTL 3건) + /voc 라우트
 
-**다음 작업**: phase-8.md Wave 1 — VOC 리스트 + 검토 드로어 vertical slice (단일 PR ≤1500 LOC).
-- 시작 프롬프트: `docs/specs/plans/next-session-autopilot-prompt.md` (사용자가 다음 세션에 붙여넣기)
-- 계획 정본: `docs/specs/plans/phase-8-wave1-plan.md` §8 (10 commit 순서) + §9 (검증 게이트)
-- Wave 2 진입 게이트: `phase-8-pattern.md` (Wave 1 PR 머지 후 회고로 작성)
+**검증**: BE jest 42 PASS / FE vitest 30 PASS / 양쪽 typecheck clean.
 
-**이전 단계**: PR #102 (Wave 0 Foundation) + PR #103 (8-PR1 권한 인프라, codex round 3 APPROVE)
+**결정 로그 (4건 추가)**:
 
-**이전 단계**: Phase 8 Wave 0 ✅ (PR #102 머지 — 2026-05-01)
+- U1=B `/api/vocs` 복수형 (기존 코드 일관성)
+- U2=B lightweight zod ↔ openapi 양방향 가드 (dep 0)
+- U3=A jest.mock 모듈 단위 mocking
+- U4=B openapi.yaml 본 PR 미변경
 
-**Wave 0 산출 요약 (15 항목)**: 0-0 mirror-check.md / 0-1 shared/ tsconfig+ESLint+contracts / 0-2 shadcn 8 + token codemod / 0-3 TanStack Query + queryKeys / 0-4 MSW /health / 0-5 api/client + ErrorBoundary / 0-6 AppShell+Sidebar+TopBar+router / 0-7 RoleContext + useRole / 0-8 Toast+EmptyState/ErrorState/LoadingState / 0-9 BE zod + validate + errorEnvelope / 0-10 .github/ ci.yml + PR template + oss-vendoring.md / 0-11 ESLint max-lines / 0-12 no-raw-color 스캐너 / 0-13 폰트 self-host 점검 / 0-14 fixture-seed parity script
+**plan vs 실제 deviation**:
 
-**검증 (모두 PASS)**: FE typecheck/lint/build + BE typecheck/tests (19/19) + parity script (graceful skip)
+- C2/C3 결합, C5~C9 결합 (10 commit → 4 commit, TDD discipline 은 작성 순서 유지)
+- drawer 4분할 → 단일 파일 (180 LOC)
+- RTL 5건 → 3건 (empty/error/필터칩 핵심 시나리오)
 
-**머지 전 외부 액션**: 폰트 바이너리 (`Pretendard-Variable.woff2` + `D2Coding.woff2`) 사용자가 `frontend/public/fonts/` 에 직접 커밋 — 외부 GitHub release 다운로드 (closed-net 방침 검토 후). CI 의 `font-self-host` job 은 `continue-on-error: true` 로 임시 통과.
+**Wave 1 follow-up (별도 PR 또는 머지 후 commit)**:
 
-**Wave 1 진입 전제**: BE dev role 정합 (auth/types.ts, MOCK_USERS, routes/auth.ts, requireRole.ts, FE auth.ts) — `next-session-tasks.md` "Phase F 후속" F1~F6 (8-PR1 권한 인프라 PR) 우선 머지 필수.
+- `/codex:adversarial-review` 라운드 (사용자 트리거)
+- Playwright happy path (`frontend/e2e/voc-happy-path.spec.ts`)
+- `VITE_USE_MSW=false` 통합 verification + Lighthouse a11y ≥ 95
+- `phase-8-pattern.md` 회고 (Wave 2 진입 게이트, 머지 후)
+- RTL 5 매트릭스 보강 (F-T4 권한 차단 / F-T5 필터+드로어 + drawer dirty close)
+- `phase-8-wave1-plan.md` §6-3 표기 정정 (`VALIDATION_FAILED` → `VALIDATION_ERROR`)
 
-**운영 전제 (2026-05-01 갱신)**: Wave 0~5는 **개방망 표준 npm registry**로 진행 (사내 폐쇄망 검증 환경 미확보). 폐쇄망 빌드는 동일 lockfile + `phase-8.md` §7.2 우회 4경로(미러 / 오프라인 캐시 / Verdaccio / git tarball·`npm pack`)로 사후 재현. 사내 미러 점검은 Phase 8 종료 후 별도 phase.
-
-**Wave 0 첫 commit**: 레지스트리 환경 기록 (`npm config get registry` + `npm ci` 캡처) + 폐쇄망 사후 재현 4경로 우선순위 → `docs/specs/plans/phase-8-mirror-check.md`. 진행 중 강제 규칙: runtime fetch·CDN URL·telemetry zero / self-host / `package-lock.json` commit.
-
-계획서 정본: **`docs/specs/plans/phase-8.md`** (PR #99, consensus 통과)
-전체 Phase 계획: **`docs/specs/plans/next-session-tasks.md`** (Phase 8 Wave 0~5 표)
-NextGen 백로그: **`docs/specs/plans/nextgen-backlog.md`** (§5 Phase 8 분리 항목 4건)
-누적 이력: **`docs/specs/plans/progress-archive.md`**
-
----
-
-## 현재 위치 (2026-05-01 기준)
-
-- Phase 0~6 ✅ → Phase 7 ✅ → **Phase 8 계획 확정** (PR #99 머지)
-- Phase 8 채택안: A′ Contract-first per-screen, 6 Wave (Wave 1만 vertical slice)
-- 스택 결정: shadcn/ui + TanStack Query/Table + RHF/Zod + MSW + Recharts (폐쇄망 self-host)
-- Architect 4 조건 + Critic 1 Critical + 5 Major 모두 반영 → APPROVED
-
-## Phase 7 Wave 3 산출물
-
-| Sub-wave | 범위 | PR |
-| --- | --- | --- |
-| W3-A | VOC 본체 — C-02 / N-01 / N-02 / N-04 / N-06 / N-07 + R2 fix 14건 | #93 |
-| W3-B | Admin 공통 — C-10 / C-11 / C-14 / M-05 + R2 fix 10건 | #94 |
-| W3-C | Dashboard 빈 상태 / W7 스크롤 / drawer 권한 차단 / 갭 재스캔 + R2 fix 11건 | #95 |
-
-각 sub-wave는 5인 자가-금지 리뷰 (architect / code-reviewer / security / verifier / critic) × 3관점 후 R2 fix → verifier APPROVE.
-
-의도적 제외: N-03 알림 폴링 (BE/timer 의존), 풀 역할×상태 매트릭스, 신규 토큰.
-
----
-
-## 가장 최근 산출물
-
-- 2026-05-01 — **Documentation Hygiene 정책 도입** — `docs/specs/README.md`을 정본으로 채택 + `.claude/skills/doc-hygiene/SKILL.md` 등록 + `reviews/` 13건 → `reviews/done/` archive + dangling ref 4건 fix + Phase 8 운영 전제 (개방망 진행, 폐쇄망 사후 재현 4경로) 반영
-- 2026-05-01 — **Phase 8 계획 확정** (PR #99) — A′ Contract-first per-screen, 6 Wave + ADR §10
-- 2026-05-01 — **Phase 7 close** (Wave 3 W3-A/B/C 머지 #93/#94/#95 + 재스캔 0 잔여)
-- 2026-05-01 — Wave 2 전건 머지 + Wave 3 plan PR
-- 2026-05-01 — B-9 Playwright MCP 통합 검증 (S1~S6, 6/6 PASS, 콘솔 에러 0)
-- 2026-04-30 — Wave 1 P-7 / P-8 / P-10 / P-12 / P-5 / P-6 (PR #66~#70)
-
-상세 이력은 `docs/specs/plans/progress-archive.md` 참조 (grep 용도).
+**이전 단계**: Wave 0 PR #102 / 8-PR1 권한 인프라 PR #103 / shadcn mini-PR #108 / plan PR #107 / certainty gate PR #106 — 모두 머지.

--- a/docs/specs/plans/phase-8-contract-voc.md
+++ b/docs/specs/plans/phase-8-contract-voc.md
@@ -1,0 +1,37 @@
+# phase-8-contract-voc — Wave 1 contract memo
+
+> 산출 PR: feat/phase-8-wave1 (Wave 1 vertical slice).
+> 정본 plan: `docs/specs/plans/phase-8-wave1-plan.md`.
+> 본 문서: 계약 영역(C1) 의 의도/매핑/후속 영향만 기록한다.
+
+## 1. 의도
+
+VOC 도메인 Zod schema 를 `shared/contracts/voc/{entity,io,note}.ts` 3-분할 구조로 신설한다 (Wave 1 plan §0 Q1=B). FE/BE 가 동일 schema 를 import 하여 RHF resolver / validate middleware 에 그대로 사용한다.
+
+## 2. 파일 인벤토리
+
+| 파일                              | 책임                                                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `shared/contracts/voc/entity.ts`  | `Voc`, `VocListItem`, status/priority/source/review enum                                             |
+| `shared/contracts/voc/io.ts`      | `VocFilter`, `VocListQuery`, `VocListResponse`, `VocCreate`, `VocUpdate`, `VocSortColumn`, `SortDir` |
+| `shared/contracts/voc/note.ts`    | `InternalNote`, `InternalNoteCreate`, `VocHistoryEntry`                                              |
+| `shared/contracts/voc/index.ts`   | barrel — 외부 import 진입점                                                                          |
+| `shared/fixtures/voc.fixtures.ts` | 50 row fixture (3 시스템 × 5 상태 × 3 priority + edge 5건)                                           |
+
+## 3. openapi.yaml 정합
+
+본 PR 은 `shared/openapi.yaml` 의 voc 섹션을 **수정하지 않는다** (Wave 1 §U4=B). zod 가 Wave 1 부터 implementation SoT, openapi.yaml 은 read-only legacy SoT 로 유지. drift 는 `backend/src/__tests__/voc-contract.test.ts` 의 양방향 mirror 가드(U2)가 검출한다 — `required[]` + enum + nullable 모두 비교.
+
+## 4. 표기 정정
+
+- plan §6-3 B-T2 의 `code: 'VALIDATION_FAILED'` 는 표기 오류. 실제 구현은 `backend/src/middleware/validate.ts:25` 가 `VALIDATION_ERROR` 발행. 후속 commit 의 BE 테스트는 **`VALIDATION_ERROR`** 를 기대한다. `phase-8-wave1-plan.md` §6-3 의 표기는 별도 doc-fix commit 에서 정정한다.
+
+## 5. URL 규약
+
+- 라우트 prefix 는 `/api/vocs` (복수형). plan §1 Scope 의 단수형 표기는 오타로 확정 (Wave 1 §U1=B). 기존 `permission.test.ts:21`, openapi.yaml `/vocs` 와 일관.
+
+## 6. 후속 영향
+
+- C2/C3 BE 테스트·구현은 본 schema 를 그대로 import.
+- C4 FE `vocApi` 는 `vocApi.list/get/create/update/addNote` 5개 fetcher 가 zod parse 1회씩 통과.
+- Wave 2 dashboard 도 동일 3분할 패턴(`shared/contracts/dashboard/{entity,io,...}`) 채택을 강제. `phase-8-pattern.md` 회고에 한 줄 기록.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -94,3 +94,21 @@ export function apiPost<T>(
     opts,
   );
 }
+
+export function apiPatch<T>(
+  url: string,
+  body: unknown,
+  schema: ZodSchema<T>,
+  opts?: ApiClientOptions,
+): Promise<T> {
+  return request(
+    url,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    },
+    schema,
+    opts,
+  );
+}

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -16,6 +16,8 @@ export const queryKeys = {
     all: (role: Role) => ['voc', role] as const,
     list: (role: Role, filter?: Filter) => ['voc', role, 'list', filter ?? {}] as const,
     detail: (role: Role, id: string) => ['voc', role, 'detail', id] as const,
+    notes: (role: Role, id: string) => ['voc', role, 'notes', id] as const,
+    history: (role: Role, id: string) => ['voc', role, 'history', id] as const,
   },
   dashboard: {
     all: (role: Role) => ['dashboard', role] as const,

--- a/frontend/src/api/voc.ts
+++ b/frontend/src/api/voc.ts
@@ -1,0 +1,49 @@
+/**
+ * VOC API client — wraps shared `api*` helpers so call-sites import a single
+ * surface. MSW vs real BE switch happens once in `main.tsx`; this module is
+ * environment-agnostic.
+ */
+import { apiGet, apiPost, apiPatch } from './client';
+import {
+  VocListResponse,
+  VocDetail,
+  type VocUpdate,
+  type VocListQuery,
+  InternalNote,
+  InternalNoteListResponse,
+  InternalNoteCreate,
+} from '../../../shared/contracts/voc';
+
+function toQs(query: Partial<VocListQuery>): string {
+  const params = new URLSearchParams();
+  if (query.status) for (const s of query.status) params.append('status', s);
+  if (query.system_id) params.set('system_id', query.system_id);
+  if (query.voc_type_id) for (const t of query.voc_type_id) params.append('voc_type_id', t);
+  if (query.assignee_id) params.set('assignee_id', query.assignee_id);
+  if (query.q) params.set('q', query.q);
+  if (query.sort) params.set('sort', query.sort);
+  if (query.order) params.set('order', query.order);
+  if (query.page) params.set('page', String(query.page));
+  if (query.limit) params.set('limit', String(query.limit));
+  if (query.includeDeleted) params.set('includeDeleted', 'true');
+  const s = params.toString();
+  return s ? `?${s}` : '';
+}
+
+export const vocApi = {
+  list(query: Partial<VocListQuery> = {}): Promise<VocListResponse> {
+    return apiGet(`/api/vocs${toQs(query)}`, VocListResponse);
+  },
+  get(id: string): Promise<VocDetail> {
+    return apiGet(`/api/vocs/${id}`, VocDetail);
+  },
+  update(id: string, patch: VocUpdate): Promise<VocDetail> {
+    return apiPatch(`/api/vocs/${id}`, patch, VocDetail);
+  },
+  notes(id: string): Promise<InternalNote[]> {
+    return apiGet(`/api/vocs/${id}/notes`, InternalNoteListResponse).then((r) => r.rows);
+  },
+  addNote(id: string, body: string): Promise<InternalNote> {
+    return apiPost(`/api/vocs/${id}/notes`, InternalNoteCreate.parse({ body }), InternalNote);
+  },
+};

--- a/frontend/src/components/voc/VocDrawer.tsx
+++ b/frontend/src/components/voc/VocDrawer.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Textarea } from '../ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { vocApi } from '../../api/voc';
+import { queryKeys } from '../../api/queryKeys';
+import { useRole } from '../../hooks/useRole';
+import {
+  VocStatus,
+  VocPriority,
+  type InternalNote,
+  type VocUpdate,
+} from '../../../../shared/contracts/voc';
+import { VocPermissionGate } from './VocPermissionGate';
+import { LoadingState } from '../common/LoadingState';
+
+interface Props {
+  vocId: string | null;
+  notes: InternalNote[] | undefined;
+  notesLoading: boolean;
+  pending: boolean;
+  onClose: () => void;
+  onPatch: (id: string, patch: VocUpdate) => Promise<unknown>;
+  onAddNote: (id: string, body: string) => Promise<unknown>;
+}
+
+function useVocDetail(id: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: id ? queryKeys.voc.detail(role, id) : ['voc', role, 'detail', 'none'],
+    queryFn: () => vocApi.get(id!),
+    enabled: !!id,
+  });
+}
+
+export function VocDrawer({
+  vocId,
+  notes,
+  notesLoading,
+  pending,
+  onClose,
+  onPatch,
+  onAddNote,
+}: Props) {
+  const detail = useVocDetail(vocId);
+  const role = useRole();
+  const [noteBody, setNoteBody] = useState('');
+
+  useEffect(() => {
+    if (!vocId) setNoteBody('');
+  }, [vocId]);
+
+  const open = !!vocId;
+  const voc = detail.data;
+  const canWriteNote = role.role !== 'user';
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent
+        className="ml-auto h-screen max-w-xl rounded-none"
+        data-testid="voc-drawer"
+        style={{ background: 'var(--bg-panel)' }}
+      >
+        <DialogHeader>
+          <DialogTitle>{voc ? voc.title : 'VOC'}</DialogTitle>
+        </DialogHeader>
+        {detail.isLoading && <LoadingState />}
+        {detail.isError && <VocPermissionGate reason="role" />}
+        {voc && (
+          <div className="flex flex-col gap-4 overflow-y-auto py-2">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="flex flex-col gap-1 text-xs">
+                Status
+                <Select
+                  value={voc.status}
+                  onValueChange={(v) =>
+                    onPatch(voc.id, { status: v as (typeof VocStatus.options)[number] })
+                  }
+                >
+                  <SelectTrigger data-testid="drawer-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VocStatus.options.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs">
+                Priority
+                <Select
+                  value={voc.priority}
+                  onValueChange={(v) =>
+                    onPatch(voc.id, { priority: v as (typeof VocPriority.options)[number] })
+                  }
+                >
+                  <SelectTrigger data-testid="drawer-priority">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VocPriority.options.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {p}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+            </div>
+            <section data-testid="drawer-notes">
+              <h3 className="mb-2 text-sm font-semibold">Internal Notes</h3>
+              {notesLoading && <LoadingState />}
+              {!notesLoading && notes && notes.length === 0 && (
+                <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                  아직 작성된 노트가 없습니다.
+                </p>
+              )}
+              <ul className="flex flex-col gap-2">
+                {notes?.map((n) => (
+                  <li
+                    key={n.id}
+                    className="rounded border p-2 text-sm"
+                    style={{ borderColor: 'var(--border-standard)' }}
+                  >
+                    {n.body}
+                  </li>
+                ))}
+              </ul>
+              {canWriteNote && (
+                <form
+                  className="mt-3 flex flex-col gap-2"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    if (noteBody.trim()) {
+                      onAddNote(voc.id, noteBody.trim()).then(() => setNoteBody(''));
+                    }
+                  }}
+                >
+                  <Textarea
+                    value={noteBody}
+                    onChange={(e) => setNoteBody(e.target.value)}
+                    placeholder="노트를 입력하세요"
+                    aria-label="new note"
+                  />
+                  <Button type="submit" disabled={pending || !noteBody.trim()} size="sm">
+                    저장
+                  </Button>
+                </form>
+              )}
+            </section>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/voc/VocFilterBar.tsx
+++ b/frontend/src/components/voc/VocFilterBar.tsx
@@ -1,0 +1,48 @@
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { VocStatus, type VocFilter } from '../../../../shared/contracts/voc';
+
+const STATUSES = VocStatus.options;
+
+interface Props {
+  value: VocFilter;
+  onChange: (next: VocFilter) => void;
+}
+
+export function VocFilterBar({ value, onChange }: Props) {
+  const toggleStatus = (s: (typeof STATUSES)[number]) => {
+    const set = new Set(value.status ?? []);
+    if (set.has(s)) set.delete(s);
+    else set.add(s);
+    onChange({ ...value, status: set.size ? Array.from(set) : undefined });
+  };
+  return (
+    <div className="flex flex-wrap items-center gap-2 py-3">
+      <div className="flex flex-wrap gap-1" role="group" aria-label="status filter">
+        {STATUSES.map((s) => {
+          const active = value.status?.includes(s) ?? false;
+          return (
+            <Button
+              key={s}
+              variant={active ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => toggleStatus(s)}
+              data-testid={`status-chip-${s}`}
+              aria-pressed={active}
+            >
+              {s}
+            </Button>
+          );
+        })}
+      </div>
+      <div className="ml-auto w-64">
+        <Input
+          placeholder="검색"
+          value={value.q ?? ''}
+          onChange={(e) => onChange({ ...value, q: e.target.value || undefined })}
+          aria-label="search"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/voc/VocListPage.tsx
+++ b/frontend/src/components/voc/VocListPage.tsx
@@ -1,0 +1,38 @@
+import { useVocPageController } from '../../features/voc/useVocPageController';
+import { VocFilterBar } from './VocFilterBar';
+import { VocTable } from './VocTable';
+import { VocDrawer } from './VocDrawer';
+import { EmptyState } from '../common/EmptyState';
+import { ErrorState } from '../common/ErrorState';
+import { LoadingState } from '../common/LoadingState';
+import { PageTitle } from '../layout/PageTitle';
+
+export function VocListPage() {
+  const ctrl = useVocPageController();
+  const { list } = ctrl;
+  const rows = list.data?.rows ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <PageTitle title="VOC" />
+      <VocFilterBar value={ctrl.filter} onChange={ctrl.setFilter} />
+      {list.isLoading && <LoadingState data-testid="voc-loading" />}
+      {list.isError && <ErrorState onRetry={() => list.refetch()} />}
+      {!list.isLoading && !list.isError && rows.length === 0 && (
+        <EmptyState title="VOC가 없습니다" description="필터를 조정해보세요." />
+      )}
+      {!list.isLoading && !list.isError && rows.length > 0 && (
+        <VocTable rows={rows} onRowClick={ctrl.drawer.open} />
+      )}
+      <VocDrawer
+        vocId={ctrl.drawer.vocId}
+        notes={ctrl.notes.data}
+        notesLoading={ctrl.notes.isLoading}
+        pending={ctrl.pending}
+        onClose={ctrl.drawer.close}
+        onPatch={ctrl.actions.patch}
+        onAddNote={ctrl.actions.addNote}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/voc/VocPermissionGate.tsx
+++ b/frontend/src/components/voc/VocPermissionGate.tsx
@@ -1,0 +1,17 @@
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert';
+
+const REASONS: Record<string, { title: string; description: string }> = {
+  role: { title: '권한이 없습니다', description: '담당자 또는 관리자만 접근할 수 있습니다.' },
+  ownership: { title: '담당자 전용', description: '본인이 담당한 VOC만 수정할 수 있습니다.' },
+  deleted: { title: '삭제된 항목', description: '이 VOC는 삭제되었습니다.' },
+};
+
+export function VocPermissionGate({ reason }: { reason: 'role' | 'ownership' | 'deleted' }) {
+  const r = REASONS[reason]!;
+  return (
+    <Alert data-testid="voc-permission-gate">
+      <AlertTitle>{r.title}</AlertTitle>
+      <AlertDescription>{r.description}</AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/src/components/voc/VocStatusBadge.tsx
+++ b/frontend/src/components/voc/VocStatusBadge.tsx
@@ -1,0 +1,21 @@
+import type { VocStatus } from '../../../../shared/contracts/voc';
+
+const TOKEN: Record<VocStatus, string> = {
+  접수: 'var(--status-pending, var(--bg-info-subtle))',
+  검토중: 'var(--status-review, var(--bg-warning-subtle))',
+  처리중: 'var(--status-progress, var(--bg-info-subtle))',
+  완료: 'var(--status-done, var(--bg-success-subtle))',
+  드랍: 'var(--status-drop, var(--bg-muted))',
+};
+
+export function VocStatusBadge({ status }: { status: VocStatus }) {
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+      style={{ background: TOKEN[status], color: 'var(--text-primary)' }}
+      data-testid={`status-badge-${status}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/components/voc/VocTable.tsx
+++ b/frontend/src/components/voc/VocTable.tsx
@@ -1,0 +1,42 @@
+import { VocStatusBadge } from './VocStatusBadge';
+import type { VocListResponse } from '../../../../shared/contracts/voc';
+
+type Row = VocListResponse['rows'][number];
+
+interface Props {
+  rows: Row[];
+  onRowClick: (id: string) => void;
+}
+
+export function VocTable({ rows, onRowClick }: Props) {
+  return (
+    <table className="w-full text-sm" data-testid="voc-table">
+      <thead className="border-b" style={{ borderColor: 'var(--border-standard)' }}>
+        <tr className="text-left" style={{ color: 'var(--text-secondary)' }}>
+          <th className="py-2 pr-2 font-medium">Issue</th>
+          <th className="py-2 pr-2 font-medium">Title</th>
+          <th className="py-2 pr-2 font-medium">Status</th>
+          <th className="py-2 pr-2 font-medium">Priority</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr
+            key={r.id}
+            className="cursor-pointer border-b transition-colors hover:bg-[var(--bg-row-hover,_var(--bg-panel))]"
+            style={{ borderColor: 'var(--border-standard)' }}
+            onClick={() => onRowClick(r.id)}
+            data-testid={`voc-row-${r.id}`}
+          >
+            <td className="py-2 pr-2 font-mono text-xs">{r.issue_code}</td>
+            <td className="py-2 pr-2">{r.title}</td>
+            <td className="py-2 pr-2">
+              <VocStatusBadge status={r.status} />
+            </td>
+            <td className="py-2 pr-2 capitalize">{r.priority}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/voc/__tests__/VocListPage.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListPage.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { VocListPage } from '../VocListPage';
+import { RoleProvider } from '../../../contexts/RoleContext';
+import { VOC_FIXTURES } from '../../../../../shared/fixtures/voc.fixtures';
+
+vi.mock('../../../api/voc', () => {
+  return {
+    vocApi: {
+      list: vi.fn(),
+      get: vi.fn(),
+      update: vi.fn(),
+      notes: vi.fn(),
+      addNote: vi.fn(),
+    },
+  };
+});
+
+import { vocApi } from '../../../api/voc';
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={['/voc']}>
+      <QueryClientProvider client={qc}>
+        <RoleProvider>
+          <VocListPage />
+        </RoleProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('VocListPage — Wave 1 RTL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('F-T1 EmptyState 시나리오 (빈 리스트)', async () => {
+    vi.mocked(vocApi.list).mockResolvedValue({ rows: [], page: 1, pageSize: 50, total: 0 });
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/VOC가 없습니다/)).toBeInTheDocument());
+  });
+
+  it('F-T2 ErrorState + 재시도', async () => {
+    vi.mocked(vocApi.list).mockRejectedValue(new Error('boom'));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /다시 시도/ })).toBeInTheDocument(),
+    );
+  });
+
+  it('F-T3 행 노출 + 필터 칩 클릭', async () => {
+    const live = VOC_FIXTURES.filter((r) => r.deleted_at === null);
+    vi.mocked(vocApi.list).mockResolvedValue({
+      rows: live.slice(0, 5).map((r) => ({ ...r, has_children: false, notes_count: 0 })),
+      page: 1,
+      pageSize: 50,
+      total: 5,
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('voc-table')).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId('status-chip-접수'));
+    expect(screen.getByTestId('status-chip-접수')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/src/features/voc/useVocFilters.ts
+++ b/frontend/src/features/voc/useVocFilters.ts
@@ -1,0 +1,54 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { VocStatus, type VocFilter } from '../../../../shared/contracts/voc';
+
+/** URL ↔ VocFilter sync. Multi-status round-trips via repeated `?status=...` keys. */
+export function useVocFilters(): {
+  filter: VocFilter;
+  setFilter: (next: VocFilter) => void;
+  vocId: string | null;
+  setVocId: (id: string | null) => void;
+} {
+  const [params, setParams] = useSearchParams();
+
+  const filter = useMemo<VocFilter>(() => {
+    const status = params
+      .getAll('status')
+      .filter((s): s is import('../../../../shared/contracts/voc').VocStatus =>
+        VocStatus.options.includes(s as never),
+      );
+    return {
+      status: status.length ? status : undefined,
+      system_id: params.get('system_id') ?? undefined,
+      assignee_id: params.get('assignee_id') ?? undefined,
+      q: params.get('q') ?? undefined,
+    };
+  }, [params]);
+
+  const setFilter = useCallback(
+    (next: VocFilter) => {
+      const p = new URLSearchParams();
+      if (next.status) for (const s of next.status) p.append('status', s);
+      if (next.system_id) p.set('system_id', next.system_id);
+      if (next.assignee_id) p.set('assignee_id', next.assignee_id);
+      if (next.q) p.set('q', next.q);
+      const id = params.get('id');
+      if (id) p.set('id', id);
+      setParams(p, { replace: true });
+    },
+    [params, setParams],
+  );
+
+  const vocId = params.get('id');
+  const setVocId = useCallback(
+    (id: string | null) => {
+      const p = new URLSearchParams(params);
+      if (id) p.set('id', id);
+      else p.delete('id');
+      setParams(p, { replace: true });
+    },
+    [params, setParams],
+  );
+
+  return { filter, setFilter, vocId, setVocId };
+}

--- a/frontend/src/features/voc/useVocList.ts
+++ b/frontend/src/features/voc/useVocList.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { vocApi } from '../../api/voc';
+import { queryKeys } from '../../api/queryKeys';
+import { useRole } from '../../hooks/useRole';
+import type { VocFilter, VocListQuery } from '../../../../shared/contracts/voc';
+
+export function useVocList(
+  filter: VocFilter,
+  sort: VocListQuery['sort'],
+  order: VocListQuery['order'],
+) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: queryKeys.voc.list(role, { ...filter, sort, order }),
+    queryFn: () => vocApi.list({ ...filter, sort, order, page: 1, limit: 50 }),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/features/voc/useVocMutation.ts
+++ b/frontend/src/features/voc/useVocMutation.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+import { vocApi } from '../../api/voc';
+import { queryKeys } from '../../api/queryKeys';
+import { useRole } from '../../hooks/useRole';
+import type { VocUpdate } from '../../../../shared/contracts/voc';
+
+export function useUpdateVoc() {
+  const qc = useQueryClient();
+  const { role } = useRole();
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: VocUpdate }) => vocApi.update(id, patch),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.voc.all(role) });
+      qc.invalidateQueries({ queryKey: queryKeys.voc.detail(role, id) });
+      qc.invalidateQueries({ queryKey: queryKeys.voc.history(role, id) });
+    },
+  });
+}
+
+export function useAddNote() {
+  const qc = useQueryClient();
+  const { role } = useRole();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: string }) => vocApi.addNote(id, body),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.voc.notes(role, id) });
+    },
+  });
+}
+
+export function useNotes(vocId: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: vocId ? queryKeys.voc.notes(role, vocId) : ['voc', role, 'notes', 'none'],
+    queryFn: () => vocApi.notes(vocId!),
+    enabled: !!vocId,
+  });
+}

--- a/frontend/src/features/voc/useVocPageController.ts
+++ b/frontend/src/features/voc/useVocPageController.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useVocList } from './useVocList';
+import { useVocFilters } from './useVocFilters';
+import { useUpdateVoc, useAddNote, useNotes } from './useVocMutation';
+import { useRole } from '../../hooks/useRole';
+import type { VocListQuery } from '../../../../shared/contracts/voc';
+
+/** Single composition root for the VOC page — keeps `VocListPage` thin. */
+export function useVocPageController() {
+  const [sort, setSort] = useState<VocListQuery['sort']>('created_at');
+  const [order, setOrder] = useState<VocListQuery['order']>('desc');
+  const role = useRole();
+  const { filter, setFilter, vocId, setVocId } = useVocFilters();
+  const list = useVocList(filter, sort, order);
+  const updateVoc = useUpdateVoc();
+  const addNote = useAddNote();
+  const notes = useNotes(vocId);
+
+  return {
+    role,
+    filter,
+    setFilter,
+    sort,
+    order,
+    setSort,
+    setOrder,
+    list,
+    drawer: { vocId, open: setVocId, close: () => setVocId(null) },
+    notes,
+    actions: {
+      patch: (id: string, patch: Parameters<typeof updateVoc.mutate>[0]['patch']) =>
+        updateVoc.mutateAsync({ id, patch }),
+      addNote: (id: string, body: string) => addNote.mutateAsync({ id, body }),
+    },
+    pending: updateVoc.isPending || addNote.isPending,
+  };
+}

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { healthHandlers } from './health';
+import { vocHandlers } from './voc';
 
-export const handlers = [...healthHandlers];
+export const handlers = [...healthHandlers, ...vocHandlers];

--- a/frontend/src/mocks/handlers/voc.ts
+++ b/frontend/src/mocks/handlers/voc.ts
@@ -1,0 +1,133 @@
+/**
+ * MSW handlers for the VOC slice — mirrors `backend/src/routes/voc.ts` shape so
+ * `VITE_USE_MSW=false` can be flipped without touching call-sites.
+ *
+ * Permission semantics (helper-level):
+ *   - manager/admin → full access
+ *   - dev          → mutate only own (assignee_id === self)
+ *   - user         → notes 404 fail-closed
+ */
+import { http, HttpResponse } from 'msw';
+import {
+  VOC_FIXTURES,
+  VOC_NOTES_FIXTURES,
+  FIXTURE_USERS,
+} from '../../../../shared/fixtures/voc.fixtures';
+
+type Voc = (typeof VOC_FIXTURES)[number];
+type Note = (typeof VOC_NOTES_FIXTURES)[number];
+
+let store: Voc[] = [...VOC_FIXTURES];
+const notes: Note[] = [...VOC_NOTES_FIXTURES];
+
+function envelope(code: string, message: string, details?: unknown) {
+  return HttpResponse.json(
+    { error: { code, message, details } },
+    { status: code === 'NOT_FOUND' ? 404 : code === 'FORBIDDEN' ? 403 : 400 },
+  );
+}
+
+// Mock session — MSW reads role from a header set by FE bootstrap (see
+// `mocks/auth.ts`, falls back to `manager` for storybook-style preview).
+function currentRole(req: Request): { role: 'admin' | 'manager' | 'dev' | 'user'; id: string } {
+  const role = (req.headers.get('x-mock-role') ?? 'manager') as
+    | 'admin'
+    | 'manager'
+    | 'dev'
+    | 'user';
+  const id =
+    role === 'admin'
+      ? FIXTURE_USERS.admin
+      : role === 'manager'
+        ? FIXTURE_USERS.manager
+        : role === 'dev'
+          ? FIXTURE_USERS.devSelf
+          : FIXTURE_USERS.user;
+  return { role, id };
+}
+
+export const vocHandlers = [
+  http.get('/api/vocs', ({ request }) => {
+    const url = new URL(request.url);
+    const status = url.searchParams.getAll('status');
+    const limit = Number(url.searchParams.get('limit') ?? 20);
+    const page = Number(url.searchParams.get('page') ?? 1);
+    if (limit > 100) return envelope('VALIDATION_ERROR', 'limit must be ≤ 100');
+    let rows = store.filter((r) => r.deleted_at === null);
+    if (status.length) rows = rows.filter((r) => status.includes(r.status));
+    const total = rows.length;
+    const start = (page - 1) * limit;
+    const slice = rows.slice(start, start + limit).map((r) => ({
+      ...r,
+      has_children: false,
+      notes_count: notes.filter((n) => n.voc_id === r.id).length,
+    }));
+    return HttpResponse.json({ rows: slice, page, pageSize: limit, total });
+  }),
+
+  http.get('/api/vocs/:id', ({ params, request }) => {
+    const { role } = currentRole(request);
+    const row = store.find((r) => r.id === params.id);
+    if (!row) return envelope('NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+    if (row.deleted_at !== null && role !== 'admin')
+      return envelope('NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+    return HttpResponse.json(row);
+  }),
+
+  http.patch('/api/vocs/:id', async ({ params, request }) => {
+    const { role, id: userId } = currentRole(request);
+    const idx = store.findIndex((r) => r.id === params.id);
+    if (idx < 0) return envelope('NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+    const row = store[idx]!;
+    if (role === 'dev' && row.assignee_id !== userId) {
+      return envelope('FORBIDDEN', '담당자만 수행할 수 있는 작업입니다.', {
+        action: 'changeStatus',
+      });
+    }
+    if (role === 'user') {
+      return envelope('FORBIDDEN', '접근 권한이 없습니다.', { action: 'changeStatus' });
+    }
+    const patch = (await request.json()) as Partial<Voc>;
+    const next = { ...row, ...patch, updated_at: new Date().toISOString() } as Voc;
+    store[idx] = next;
+    return HttpResponse.json(next);
+  }),
+
+  http.get('/api/vocs/:id/notes', ({ params, request }) => {
+    const { role } = currentRole(request);
+    if (role === 'user') return envelope('NOT_FOUND', 'Not found.');
+    const rows = notes.filter((n) => n.voc_id === params.id);
+    return HttpResponse.json({ rows });
+  }),
+
+  http.post('/api/vocs/:id/notes', async ({ params, request }) => {
+    const { role, id: userId } = currentRole(request);
+    if (role === 'user') return envelope('NOT_FOUND', 'Not found.');
+    const row = store.find((r) => r.id === params.id);
+    if (!row) return envelope('NOT_FOUND', 'VOC를 찾을 수 없습니다.');
+    if (role === 'dev' && row.assignee_id !== userId) {
+      return envelope('FORBIDDEN', '담당자만 수행할 수 있는 작업입니다.', {
+        action: 'writeInternalNote',
+      });
+    }
+    const body = (await request.json()) as { body: string };
+    const now = new Date().toISOString();
+    const note: Note = {
+      id: `dddddddd-0000-4000-8000-${String(notes.length + 1).padStart(12, '0')}`,
+      voc_id: String(params.id),
+      author_id: userId,
+      body: body.body,
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    };
+    notes.push(note);
+    return HttpResponse.json(note);
+  }),
+];
+
+export function __resetVocMocks() {
+  store = [...VOC_FIXTURES];
+  notes.length = 0;
+  notes.push(...VOC_NOTES_FIXTURES);
+}

--- a/frontend/src/pages/VocPage.tsx
+++ b/frontend/src/pages/VocPage.tsx
@@ -1,0 +1,5 @@
+import { VocListPage } from '../components/voc/VocListPage';
+
+export default function VocPage() {
+  return <VocListPage />;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,16 @@ import { PageTitle } from './components/layout/PageTitle';
 const MockLoginPage =
   import.meta.env.VITE_AUTH_MODE === 'mock' ? lazy(() => import('./pages/MockLoginPage')) : null;
 
+const VocPage = lazy(() => import('./pages/VocPage'));
+
+function VocRoute() {
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <VocPage />
+    </Suspense>
+  );
+}
+
 function MockLoginRoute() {
   if (!MockLoginPage) return <Navigate to="/" replace />;
   return (
@@ -44,7 +54,7 @@ export const router = createBrowserRouter([
     element: <AppShell />,
     children: [
       { index: true, element: <Navigate to="/voc" replace /> },
-      { path: 'voc', element: <StubPage title="VOC" /> },
+      { path: 'voc', element: <VocRoute /> },
       { path: 'dashboard', element: <StubPage title="Dashboard" /> },
       { path: 'notice', element: <StubPage title="공지" /> },
       { path: 'faq', element: <StubPage title="FAQ" /> },

--- a/scripts/check-fixture-seed-parity.ts
+++ b/scripts/check-fixture-seed-parity.ts
@@ -1,138 +1,119 @@
 #!/usr/bin/env tsx
 /**
  * check-fixture-seed-parity.ts
- * Verifies that shared/fixtures/voc.fixtures.ts and the vocs migration
- * declare the same column names + required constraints.
- * Exit 0 = OK or SKIPPED; Exit 1 = mismatch found.
+ *
+ * Verifies that every NOT NULL column declared by the `vocs` migration is
+ * populated in `shared/fixtures/voc.fixtures` (sampled from VOC_FIXTURES[0]).
+ * Columns that are nullable, have a DEFAULT, or are populated by triggers
+ * (e.g. `sequence_no`, `issue_code`) are allowed to be missing from the
+ * fixture — they simply do not break the parity contract.
+ *
+ * Exit 0 = OK or SKIPPED; Exit 1 = mismatch.
+ *
+ * Wave 1 history: an earlier regex-based version produced false positives
+ * because the fixture module contains many non-row keys (RowSpec interface,
+ * SYS / FIXTURE_USERS constants, voc_history rows, …). Importing the
+ * compiled fixture and inspecting Object.keys is robust by construction.
  */
-
 import * as fs from 'fs';
 import * as path from 'path';
 
 const ROOT = path.resolve(__dirname, '..');
-
 const FIXTURE_PATH = path.join(ROOT, 'shared', 'fixtures', 'voc.fixtures.ts');
-// Migration 003_vocs.sql is the canonical source for the vocs table DDL
 const MIGRATION_PATH = path.join(ROOT, 'backend', 'migrations', '003_vocs.sql');
 
-// ---- helpers ---------------------------------------------------------------
+interface DbCol {
+  name: string;
+  notNull: boolean;
+  hasDefault: boolean;
+}
 
-function parseDbColumns(sql: string): Map<string, boolean> {
-  // Extract CREATE TABLE vocs ( ... )
+function parseDbColumns(sql: string): DbCol[] {
   const match = sql.match(/CREATE TABLE vocs\s*\(([\s\S]*?)\);/);
-  if (!match) return new Map();
+  if (!match) return [];
 
-  const body = match[1];
-  const cols = new Map<string, boolean>(); // name -> isNotNull
-
-  for (const rawLine of body.split('\n')) {
+  const cols: DbCol[] = [];
+  for (const rawLine of match[1].split('\n')) {
     const line = rawLine.trim();
-    if (!line || line.startsWith('--') || line.startsWith('CHECK')) continue;
+    if (!line || line.startsWith('--')) continue;
 
-    // Match lines like:  col_name  type  [NOT NULL] ...
     const colMatch = line.match(/^(\w+)\s+\S+/);
     if (!colMatch) continue;
 
     const name = colMatch[1];
-    // Skip constraint keywords
     if (['PRIMARY', 'UNIQUE', 'FOREIGN', 'CHECK', 'CONSTRAINT'].includes(name.toUpperCase()))
       continue;
 
-    const notNull =
-      /NOT NULL/i.test(line) ||
-      // columns with DEFAULT are effectively required from fixture perspective too,
-      // but we only flag explicit NOT NULL for the constraint check
-      false;
-
-    cols.set(name, notNull);
+    cols.push({
+      name,
+      notNull: /NOT NULL/i.test(line),
+      hasDefault: /\bDEFAULT\b/i.test(line),
+    });
   }
   return cols;
 }
 
-function parseFixtureColumns(src: string): Map<string, boolean> {
-  // Look for object literal keys in the voc fixture array elements.
-  // Pattern: exported const/array with object literals { key: value, ... }
-  // We use a simple regex to collect all object keys inside the fixture.
-  const cols = new Map<string, boolean>(); // name -> hasValue (non-undefined)
-
-  // Find all object literal keys followed by `: ` (not inside comments)
-  const keyPattern = /^\s{2,}(\w+)\s*:/gm;
-  let m: RegExpExecArray | null;
-  // eslint-disable-next-line no-cond-assign
-  while ((m = keyPattern.exec(src)) !== null) {
-    const key = m[1];
-    // Check whether this line has an explicit undefined value
-    const lineStart = src.lastIndexOf('\n', m.index) + 1;
-    const lineEnd = src.indexOf('\n', m.index);
-    const line = src.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-    const hasValue = !/:\s*undefined\b/.test(line);
-    // Only set false if not already true
-    if (!cols.has(key)) {
-      cols.set(key, hasValue);
-    }
-  }
-  return cols;
-}
-
-// ---- main ------------------------------------------------------------------
-
-function main(): void {
-  const fixtureExists = fs.existsSync(FIXTURE_PATH);
-  const migrationExists = fs.existsSync(MIGRATION_PATH);
-
-  if (!fixtureExists || !migrationExists) {
+async function main(): Promise<void> {
+  if (!fs.existsSync(FIXTURE_PATH) || !fs.existsSync(MIGRATION_PATH)) {
     const missing = [
-      !fixtureExists ? 'shared/fixtures/voc.fixtures.ts' : null,
-      !migrationExists ? 'backend/migrations/003_vocs.sql' : null,
+      !fs.existsSync(FIXTURE_PATH) ? 'shared/fixtures/voc.fixtures.ts' : null,
+      !fs.existsSync(MIGRATION_PATH) ? 'backend/migrations/003_vocs.sql' : null,
     ]
       .filter(Boolean)
       .join(', ');
-    console.log(`[parity] SKIPPED -- files not yet present (Wave 1+): ${missing}`);
+    console.log(`[parity] SKIPPED -- files not yet present: ${missing}`);
     process.exit(0);
   }
 
-  const migrationSql = fs.readFileSync(MIGRATION_PATH, 'utf8');
-  const fixtureSrc = fs.readFileSync(FIXTURE_PATH, 'utf8');
-
-  const dbCols = parseDbColumns(migrationSql);
-  const fixtureCols = parseFixtureColumns(fixtureSrc);
-
-  if (dbCols.size === 0) {
+  const dbCols = parseDbColumns(fs.readFileSync(MIGRATION_PATH, 'utf8'));
+  if (dbCols.length === 0) {
     console.error('[parity] ERROR -- could not parse CREATE TABLE vocs from migration');
     process.exit(1);
   }
 
+  const fixtureModule = await import(FIXTURE_PATH);
+  const sample = fixtureModule.VOC_FIXTURES?.[0];
+  if (!sample || typeof sample !== 'object') {
+    console.error('[parity] ERROR -- VOC_FIXTURES[0] is not an object');
+    process.exit(1);
+  }
+
+  const fixtureKeys = new Set(Object.keys(sample));
   const errors: string[] = [];
 
-  // Columns in DB not in fixture
-  for (const [col] of dbCols) {
-    if (!fixtureCols.has(col)) {
-      errors.push(`  missing-in-fixture: ${col}`);
+  // Every NOT NULL DB column without a DEFAULT must appear in the fixture.
+  // Triggers (sequence_no, issue_code) populate values; explicitly excluded
+  // because the fixture may pre-set them but the BE insert path does not
+  // require it.
+  const TRIGGER_POPULATED = new Set(['sequence_no', 'issue_code']);
+  for (const col of dbCols) {
+    if (TRIGGER_POPULATED.has(col.name)) continue;
+    if (col.notNull && !col.hasDefault && !fixtureKeys.has(col.name)) {
+      errors.push(`  required column missing in fixture: ${col.name}`);
     }
   }
 
-  // Columns in fixture not in DB
-  for (const [col] of fixtureCols) {
-    if (!dbCols.has(col)) {
-      errors.push(`  missing-in-seed/migration: ${col}`);
-    }
-  }
-
-  // NOT NULL columns must have a value in fixture
-  for (const [col, notNull] of dbCols) {
-    if (notNull && fixtureCols.has(col) && fixtureCols.get(col) === false) {
-      errors.push(`  NOT NULL column has undefined in fixture: ${col}`);
+  // Every fixture key must correspond to an actual DB column.
+  const dbColNames = new Set(dbCols.map((c) => c.name));
+  for (const key of fixtureKeys) {
+    if (!dbColNames.has(key)) {
+      errors.push(`  fixture key not in vocs schema: ${key}`);
     }
   }
 
   if (errors.length > 0) {
-    console.error('[parity] MISMATCH -- fixture and migration are out of sync:');
+    console.error('[parity] MISMATCH -- VOC_FIXTURES[0] vs vocs migration:');
     for (const e of errors) console.error(e);
     process.exit(1);
   }
 
-  console.log('[parity] OK');
+  console.log(
+    `[parity] OK -- ${fixtureKeys.size} fixture keys reconciled against ${dbCols.length} columns`,
+  );
   process.exit(0);
 }
 
-main();
+main().catch((err) => {
+  console.error('[parity] ERROR --', err);
+  process.exit(1);
+});

--- a/shared/contracts/voc/entity.ts
+++ b/shared/contracts/voc/entity.ts
@@ -50,8 +50,8 @@ export const Voc = z.object({
   structured_payload: z.record(z.string(), z.unknown()).nullable().optional(),
   resolution_quality: VocResolutionQuality.nullable().optional(),
   drop_reason: VocDropReason.nullable().optional(),
-  due_date: Iso.nullable().optional(),
-  deleted_at: Iso.nullable().optional(),
+  due_date: Iso.nullable(),
+  deleted_at: Iso.nullable(),
   created_at: Iso,
   updated_at: Iso,
 });

--- a/shared/contracts/voc/entity.ts
+++ b/shared/contracts/voc/entity.ts
@@ -1,0 +1,81 @@
+/**
+ * @module shared/contracts/voc/entity
+ *
+ * VOC core entity Zod schemas. Source-of-truth for runtime validation across
+ * FE (RHF resolver) and BE (validate middleware). Aligns with
+ * `shared/openapi.yaml#/components/schemas/Voc` (drift caught by
+ * `backend/src/__tests__/voc-contract.test.ts` U2 guard).
+ *
+ * Authoritative DB schema: `backend/migrations/003_vocs.sql`.
+ */
+import { z } from 'zod';
+
+export const VocStatus = z.enum(['접수', '검토중', '처리중', '완료', '드랍']);
+export type VocStatus = z.infer<typeof VocStatus>;
+
+export const VocPriority = z.enum(['urgent', 'high', 'medium', 'low']);
+export type VocPriority = z.infer<typeof VocPriority>;
+
+export const VocSource = z.enum(['manual', 'import']);
+export type VocSource = z.infer<typeof VocSource>;
+
+export const VocReviewStatus = z.enum(['unverified', 'approved', 'rejected', 'pending_deletion']);
+export type VocReviewStatus = z.infer<typeof VocReviewStatus>;
+
+export const VocResolutionQuality = z.enum(['근본해결', '임시조치']);
+export type VocResolutionQuality = z.infer<typeof VocResolutionQuality>;
+
+export const VocDropReason = z.enum(['중복', '정책거부', '재현불가', '범위외', '기타']);
+export type VocDropReason = z.infer<typeof VocDropReason>;
+
+const Uuid = z.string().uuid();
+const Iso = z.string().datetime({ offset: true });
+
+export const Voc = z.object({
+  id: Uuid,
+  issue_code: z.string().min(1),
+  sequence_no: z.number().int().nonnegative(),
+  title: z.string().min(1).max(200),
+  body: z.string().nullable().optional(),
+  status: VocStatus,
+  priority: VocPriority,
+  voc_type_id: Uuid,
+  system_id: Uuid,
+  menu_id: Uuid,
+  assignee_id: Uuid.nullable(),
+  author_id: Uuid,
+  parent_id: Uuid.nullable(),
+  source: VocSource,
+  review_status: VocReviewStatus.nullable().optional(),
+  structured_payload: z.record(z.string(), z.unknown()).nullable().optional(),
+  resolution_quality: VocResolutionQuality.nullable().optional(),
+  drop_reason: VocDropReason.nullable().optional(),
+  due_date: Iso.nullable().optional(),
+  deleted_at: Iso.nullable().optional(),
+  created_at: Iso,
+  updated_at: Iso,
+});
+export type Voc = z.infer<typeof Voc>;
+
+/** List item: lightweight projection used by table rows; same shape minus heavy fields. */
+export const VocListItem = Voc.pick({
+  id: true,
+  issue_code: true,
+  title: true,
+  status: true,
+  priority: true,
+  voc_type_id: true,
+  system_id: true,
+  menu_id: true,
+  assignee_id: true,
+  author_id: true,
+  parent_id: true,
+  source: true,
+  due_date: true,
+  created_at: true,
+  updated_at: true,
+}).extend({
+  has_children: z.boolean().default(false),
+  notes_count: z.number().int().nonnegative().default(0),
+});
+export type VocListItem = z.infer<typeof VocListItem>;

--- a/shared/contracts/voc/index.ts
+++ b/shared/contracts/voc/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel for VOC contract Zod schemas. Consumers should import from
+ * `@shared/contracts/voc` rather than the per-file modules.
+ */
+export * from './entity';
+export * from './io';
+export * from './note';

--- a/shared/contracts/voc/io.ts
+++ b/shared/contracts/voc/io.ts
@@ -16,7 +16,9 @@ import {
   VocDropReason,
 } from './entity';
 
-const Uuid = z.string().uuid();
+// Loose UUID — DB-level `uuid` columns accept any 8-4-4-4-12 hex pattern;
+// strict v4 enforcement breaks legacy fixtures (e.g. permission.test.ts).
+const Uuid = z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 
 export const VocSortColumn = z.enum([
   'created_at',
@@ -32,10 +34,13 @@ export const SortDir = z.enum(['asc', 'desc']);
 export type SortDir = z.infer<typeof SortDir>;
 
 /** URL filter shape — primitive-only so it round-trips through URLSearchParams. */
+const arrayOrSingle = <T extends z.ZodTypeAny>(item: T) =>
+  z.preprocess((v) => (Array.isArray(v) ? v : v == null ? undefined : [v]), z.array(item));
+
 export const VocFilter = z.object({
-  status: z.array(VocStatus).optional(),
+  status: arrayOrSingle(VocStatus).optional(),
   system_id: Uuid.optional(),
-  voc_type_id: z.array(Uuid).optional(),
+  voc_type_id: arrayOrSingle(Uuid).optional(),
   assignee_id: Uuid.optional(),
   q: z.string().trim().max(120).optional(),
 });

--- a/shared/contracts/voc/io.ts
+++ b/shared/contracts/voc/io.ts
@@ -1,0 +1,97 @@
+/**
+ * @module shared/contracts/voc/io
+ *
+ * Request / response wire schemas. Filter, list query/response, create/update
+ * payloads. Aligns with openapi.yaml VocInput/VocPatch (U2 guard enforces).
+ */
+import { z } from 'zod';
+import {
+  Voc,
+  VocListItem,
+  VocStatus,
+  VocPriority,
+  VocSource,
+  VocReviewStatus,
+  VocResolutionQuality,
+  VocDropReason,
+} from './entity';
+
+const Uuid = z.string().uuid();
+
+export const VocSortColumn = z.enum([
+  'created_at',
+  'updated_at',
+  'priority',
+  'status',
+  'due_date',
+  'issue_code',
+]);
+export type VocSortColumn = z.infer<typeof VocSortColumn>;
+
+export const SortDir = z.enum(['asc', 'desc']);
+export type SortDir = z.infer<typeof SortDir>;
+
+/** URL filter shape — primitive-only so it round-trips through URLSearchParams. */
+export const VocFilter = z.object({
+  status: z.array(VocStatus).optional(),
+  system_id: Uuid.optional(),
+  voc_type_id: z.array(Uuid).optional(),
+  assignee_id: Uuid.optional(),
+  q: z.string().trim().max(120).optional(),
+});
+export type VocFilter = z.infer<typeof VocFilter>;
+
+export const VocListQuery = VocFilter.extend({
+  sort: VocSortColumn.default('created_at'),
+  order: SortDir.default('desc'),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  includeDeleted: z.coerce.boolean().optional(),
+});
+export type VocListQuery = z.infer<typeof VocListQuery>;
+
+export const VocListResponse = z.object({
+  rows: z.array(VocListItem),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().positive(),
+  total: z.number().int().nonnegative(),
+});
+export type VocListResponse = z.infer<typeof VocListResponse>;
+
+export const VocCreate = z.object({
+  title: z.string().min(1).max(200),
+  body: z.string().max(10_000).optional(),
+  status: VocStatus.default('접수'),
+  priority: VocPriority.default('medium'),
+  voc_type_id: Uuid,
+  system_id: Uuid,
+  menu_id: Uuid,
+  assignee_id: Uuid.optional(),
+  parent_id: Uuid.optional(),
+  source: VocSource.default('manual'),
+});
+export type VocCreate = z.infer<typeof VocCreate>;
+
+export const VocUpdate = z
+  .object({
+    title: z.string().min(1).max(200),
+    body: z.string().max(10_000),
+    status: VocStatus,
+    priority: VocPriority,
+    voc_type_id: Uuid,
+    system_id: Uuid,
+    menu_id: Uuid,
+    assignee_id: Uuid.nullable(),
+    review_status: VocReviewStatus,
+    resolution_quality: VocResolutionQuality,
+    drop_reason: VocDropReason,
+    due_date: z.string().datetime({ offset: true }).nullable(),
+  })
+  .partial();
+export type VocUpdate = z.infer<typeof VocUpdate>;
+
+export const VocIdParam = z.object({ id: Uuid });
+export type VocIdParam = z.infer<typeof VocIdParam>;
+
+export const VocDetail = Voc;
+export type VocDetail = z.infer<typeof VocDetail>;

--- a/shared/contracts/voc/note.ts
+++ b/shared/contracts/voc/note.ts
@@ -1,0 +1,42 @@
+/**
+ * @module shared/contracts/voc/note
+ *
+ * Internal notes (manager/admin/dev visibility — User → 404 fail-closed) and
+ * voc_history timeline. Aligns with openapi.yaml Note schema (U2 guard).
+ */
+import { z } from 'zod';
+
+const Uuid = z.string().uuid();
+const Iso = z.string().datetime({ offset: true });
+
+export const InternalNote = z.object({
+  id: Uuid,
+  voc_id: Uuid,
+  author_id: Uuid,
+  body: z.string().min(1).max(5_000),
+  created_at: Iso,
+  updated_at: Iso,
+  deleted_at: Iso.nullable().optional(),
+});
+export type InternalNote = z.infer<typeof InternalNote>;
+
+export const InternalNoteCreate = z.object({
+  body: z.string().min(1).max(5_000),
+});
+export type InternalNoteCreate = z.infer<typeof InternalNoteCreate>;
+
+export const InternalNoteListResponse = z.object({
+  rows: z.array(InternalNote),
+});
+export type InternalNoteListResponse = z.infer<typeof InternalNoteListResponse>;
+
+export const VocHistoryEntry = z.object({
+  id: Uuid,
+  voc_id: Uuid,
+  field: z.string().min(1),
+  old_value: z.string().nullable(),
+  new_value: z.string().nullable(),
+  changed_by: Uuid,
+  changed_at: Iso,
+});
+export type VocHistoryEntry = z.infer<typeof VocHistoryEntry>;

--- a/shared/contracts/voc/users.ts
+++ b/shared/contracts/voc/users.ts
@@ -1,0 +1,16 @@
+/**
+ * Stable mock-user UUIDs shared between BE auth scaffolding (`mockUsers.ts`)
+ * and test fixtures (`shared/fixtures/voc.fixtures.ts`). Lives in `contracts/`
+ * (not `fixtures/`) so prod backend code can import without dragging the
+ * 50-row fixture array into the production bundle.
+ */
+export const FIXTURE_USERS = {
+  admin: '00000000-0000-4000-8000-0000000000a1',
+  manager: '00000000-0000-4000-8000-0000000000b1',
+  /** Dev assignee for §6-3 B-T5 */
+  devSelf: '00000000-0000-4000-8000-0000000000c1',
+  devOther: '00000000-0000-4000-8000-0000000000c2',
+  user: '00000000-0000-4000-8000-0000000000d1',
+} as const;
+
+export type FixtureUserKey = keyof typeof FIXTURE_USERS;

--- a/shared/fixtures/voc.fixtures.ts
+++ b/shared/fixtures/voc.fixtures.ts
@@ -1,0 +1,167 @@
+/**
+ * @module shared/fixtures/voc.fixtures
+ *
+ * 50 deterministic VOC fixtures spanning the role/status/system matrix used by
+ *  - FE MSW handlers (`frontend/src/mocks/handlers/voc.ts`)
+ *  - BE Jest tests (mocked repository injection — Wave 1 §U3 decision)
+ *
+ * Design constraints:
+ *  - Stable UUIDs (no Math.random) so fixtures round-trip across runs.
+ *  - 3 systems × 5 statuses + permission-edge cases (deleted, length-overflow,
+ *    dev-self assignee, user-author).
+ *  - Schema is the source of truth: every row passes `Voc.parse()`.
+ */
+import { Voc, type Voc as VocT } from '../contracts/voc/entity';
+import {
+  InternalNote,
+  type InternalNote as InternalNoteT,
+  VocHistoryEntry,
+  type VocHistoryEntry as VocHistoryEntryT,
+} from '../contracts/voc/note';
+
+const SYS = {
+  ANALYSIS: '11111111-1111-4111-8111-111111111111',
+  REPORT: '22222222-2222-4222-8222-222222222222',
+  PORTAL: '33333333-3333-4333-8333-333333333333',
+} as const;
+
+const MENU = '44444444-4444-4444-8444-444444444444';
+const TYPE = '55555555-5555-4555-8555-555555555555';
+
+export const FIXTURE_USERS = {
+  admin: '00000000-0000-4000-8000-0000000000a1',
+  manager: '00000000-0000-4000-8000-0000000000b1',
+  /** Dev assignee for §6-3 B-T5 */
+  devSelf: '00000000-0000-4000-8000-0000000000c1',
+  devOther: '00000000-0000-4000-8000-0000000000c2',
+  user: '00000000-0000-4000-8000-0000000000d1',
+} as const;
+
+const STATUSES = ['접수', '검토중', '처리중', '완료', '드랍'] as const;
+
+const pad = (n: number) => String(n).padStart(4, '0');
+const baseDate = (offsetDays: number) =>
+  new Date(Date.UTC(2026, 4, 1) - offsetDays * 86_400_000).toISOString();
+
+interface RowSpec {
+  systemSlug: keyof typeof SYS;
+  status: VocT['status'];
+  priority: VocT['priority'];
+  assigneeId: VocT['assignee_id'];
+  authorId: VocT['author_id'];
+  parentId?: VocT['parent_id'];
+  deletedAt?: string | null;
+  longTitle?: boolean;
+}
+
+const SPECS: ReadonlyArray<RowSpec> = (() => {
+  const out: RowSpec[] = [];
+  let n = 0;
+  for (const sys of Object.keys(SYS) as Array<keyof typeof SYS>) {
+    for (const status of STATUSES) {
+      for (const priority of ['urgent', 'high', 'medium'] as const) {
+        out.push({
+          systemSlug: sys,
+          status,
+          priority,
+          assigneeId: n % 4 === 0 ? FIXTURE_USERS.devSelf : FIXTURE_USERS.devOther,
+          authorId: FIXTURE_USERS.user,
+        });
+        n += 1;
+      }
+    }
+  }
+  // edge cases
+  out.push({
+    systemSlug: 'ANALYSIS',
+    status: '드랍',
+    priority: 'low',
+    assigneeId: null,
+    authorId: FIXTURE_USERS.user,
+    deletedAt: baseDate(2),
+  });
+  out.push({
+    systemSlug: 'PORTAL',
+    status: '검토중',
+    priority: 'high',
+    assigneeId: FIXTURE_USERS.devSelf,
+    authorId: FIXTURE_USERS.user,
+    longTitle: true,
+  });
+  out.push({
+    systemSlug: 'REPORT',
+    status: '처리중',
+    priority: 'medium',
+    assigneeId: FIXTURE_USERS.devSelf,
+    authorId: FIXTURE_USERS.user,
+  });
+  out.push({
+    systemSlug: 'ANALYSIS',
+    status: '접수',
+    priority: 'low',
+    assigneeId: null,
+    authorId: FIXTURE_USERS.user,
+  });
+  out.push({
+    systemSlug: 'ANALYSIS',
+    status: '처리중',
+    priority: 'high',
+    assigneeId: FIXTURE_USERS.devSelf,
+    authorId: FIXTURE_USERS.user,
+    parentId: 'aaaaaaaa-0000-4000-8000-100000000001',
+  });
+  return out.slice(0, 50);
+})();
+
+export const VOC_FIXTURES: ReadonlyArray<VocT> = SPECS.map((s, i) => {
+  const created = baseDate(i);
+  return Voc.parse({
+    id: `aaaaaaaa-0000-4000-8000-${pad(i + 1).padStart(12, '0')}`,
+    issue_code: `${s.systemSlug}-2026-${pad(i + 1)}`,
+    sequence_no: i + 1,
+    title: s.longTitle
+      ? '[LongTitle] '.repeat(15) + 'overflow guard'
+      : `[${s.systemSlug}] sample VOC #${i + 1}`,
+    body: 'lorem ipsum sample body content',
+    status: s.status,
+    priority: s.priority,
+    voc_type_id: TYPE,
+    system_id: SYS[s.systemSlug],
+    menu_id: MENU,
+    assignee_id: s.assigneeId,
+    author_id: s.authorId,
+    parent_id: s.parentId ?? null,
+    source: 'manual',
+    review_status: null,
+    resolution_quality: null,
+    drop_reason: s.status === '드랍' ? '기타' : null,
+    due_date: null,
+    deleted_at: s.deletedAt ?? null,
+    created_at: created,
+    updated_at: created,
+  });
+});
+
+export const VOC_NOTES_FIXTURES: ReadonlyArray<InternalNoteT> = [
+  InternalNote.parse({
+    id: 'bbbbbbbb-0000-4000-8000-000000000001',
+    voc_id: VOC_FIXTURES[0]!.id,
+    author_id: FIXTURE_USERS.manager,
+    body: 'Triage start — checking duplicates.',
+    created_at: baseDate(0),
+    updated_at: baseDate(0),
+    deleted_at: null,
+  }),
+];
+
+export const VOC_HISTORY_FIXTURES: ReadonlyArray<VocHistoryEntryT> = [
+  VocHistoryEntry.parse({
+    id: 'cccccccc-0000-4000-8000-000000000001',
+    voc_id: VOC_FIXTURES[0]!.id,
+    field: 'status',
+    old_value: '접수',
+    new_value: '검토중',
+    changed_by: FIXTURE_USERS.manager,
+    changed_at: baseDate(0),
+  }),
+];

--- a/shared/fixtures/voc.fixtures.ts
+++ b/shared/fixtures/voc.fixtures.ts
@@ -18,6 +18,9 @@ import {
   VocHistoryEntry,
   type VocHistoryEntry as VocHistoryEntryT,
 } from '../contracts/voc/note';
+import { FIXTURE_USERS } from '../contracts/voc/users';
+
+export { FIXTURE_USERS };
 
 const SYS = {
   ANALYSIS: '11111111-1111-4111-8111-111111111111',
@@ -27,15 +30,6 @@ const SYS = {
 
 const MENU = '44444444-4444-4444-8444-444444444444';
 const TYPE = '55555555-5555-4555-8555-555555555555';
-
-export const FIXTURE_USERS = {
-  admin: '00000000-0000-4000-8000-0000000000a1',
-  manager: '00000000-0000-4000-8000-0000000000b1',
-  /** Dev assignee for §6-3 B-T5 */
-  devSelf: '00000000-0000-4000-8000-0000000000c1',
-  devOther: '00000000-0000-4000-8000-0000000000c2',
-  user: '00000000-0000-4000-8000-0000000000d1',
-} as const;
 
 const STATUSES = ['접수', '검토중', '처리중', '완료', '드랍'] as const;
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,5 +2,8 @@
   "name": "@vocpage/shared",
   "private": true,
   "version": "0.0.1",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.4.1"
+  }
 }


### PR DESCRIPTION
## Summary

Phase 8 Wave 1 — VOC 리스트 + 검토 드로어 vertical slice (계약/BE/FE 단일 PR).

**LOC 합계**: ~1500 (테스트 포함, plan §2 예산 부합).

## Commit 구조 (plan §8 vs 실제)

| plan | 실제 commit | 비고 |
| --- | --- | --- |
| C1 | `454c8ca` | shared 계약 + fixture + U2 가드 |
| C2 + C3 | `20a6a73` | BE RED + GREEN 결합 (TDD discipline 은 작성 순서로 유지) |
| C4 | `93ae273` | FE api/voc + MSW |
| C5–C9 | `b7030dd` | FE 슬라이스 결합 (RTL 5건 → 3건 핵심 시나리오) |
| C10 | (follow-up) | Playwright e2e + phase-8-pattern.md 회고 |

> RED commit 분리 비용 vs 가치 trade-off 로 결합 채택. drawer 분할(Header/Form/Notes/History) 대신 단일 파일(180 LOC) 로 단순화.

## 결정 로그 (plan §0 + adversarial review)

- **Q1=B** shared/contracts/voc 3-분할 (entity/io/note + barrel)
- **Q2=A** BE service 단일 파일 유지
- **Q3=A** 신규 마이그 0건
- **Q4=B** shadcn mini-PR (#108 머지)
- **Q5=A** F12 setPriority 회귀 (B-T6) Wave 1 포함
- **U1=B** `/api/vocs` 복수형 (기존 코드 일관성)
- **U2=B** lightweight zod ↔ openapi 양방향 가드 (`voc-contract.test.ts` 9 테스트)
- **U3=A** `jest.mock('../repository/voc')` 모듈 단위 mocking
- **U4=B** `openapi.yaml` 본 PR 미변경

## 추가 처리

- **B-T7** (architect 권고): user → GET notes 404 fail-closed 회귀 추가
- `assertCanManageVoc` 에 user role + (read|write)InternalNote → 404 흡수 (route 의 role 분기 회피)
- `MOCK_USERS.id` 를 `FIXTURE_USERS` 와 정렬 (v4 UUID)
- `validate.ts` 3-generic 시그니처 (body/query/params 독립 타입)
- `logger.ts` test 환경 transport 차단

## 검증 (plan §9 게이트)

- [x] shared tsc clean
- [x] backend typecheck clean (`tsconfig.typecheck.json` 신설 — shared/ 임포트 허용)
- [x] backend jest: 8 suites / 42 PASS + 7 todo
- [x] frontend tsc clean
- [x] frontend vitest: 7 suites / 30 PASS
- [x] hex/raw OKLCH 위반 0 (모든 색은 `var(--*)` 토큰)
- [ ] Playwright happy path — follow-up
- [ ] `VITE_USE_MSW=false` 통합 verification — 머지 후 수동
- [ ] Lighthouse a11y ≥ 95 — follow-up
- [ ] `/codex:adversarial-review` — 사용자 트리거 대기
- [ ] `phase-8-pattern.md` (Wave 2 진입 게이트) — 머지 후 회고로 작성

## Test plan
- [ ] BE `npm -w backend test`: 42 PASS 확인
- [ ] FE `npm -w frontend test`: 30 PASS 확인
- [ ] FE 빌드: `npm -w frontend build`
- [ ] dev: `docker compose up` → `/voc` 진입 → 필터/검색/드로어/노트 작성 happy path
- [ ] adversarial-review 라운드 ≥ 2회 APPROVE 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)