### PR TITLE
fix(backend): install pino-pretty devDep + extract buildLoggerOptions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "@types/swagger-ui-express": "^4.1.6",
     "jest": "^29.7.0",
     "pg-mem": "^3.0.14",
+    "pino-pretty": "^13.1.3",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "tsx": "^4.21.0",

--- a/backend/src/__tests__/logger.test.ts
+++ b/backend/src/__tests__/logger.test.ts
@@ -1,0 +1,51 @@
+import { buildLoggerOptions } from '../logger';
+
+describe('buildLoggerOptions', () => {
+  it('includes pino-pretty transport in development', () => {
+    const opts = buildLoggerOptions({ NODE_ENV: 'development' } as NodeJS.ProcessEnv);
+    expect(opts.transport).toEqual({
+      target: 'pino-pretty',
+      options: { colorize: true, ignore: 'pid,hostname' },
+    });
+    expect(opts.level).toBe('info');
+  });
+
+  it('omits transport and silences level in test', () => {
+    const opts = buildLoggerOptions({ NODE_ENV: 'test' } as NodeJS.ProcessEnv);
+    expect(opts.transport).toBeUndefined();
+    expect(opts.level).toBe('silent');
+  });
+
+  it('omits transport in production with default info level', () => {
+    const opts = buildLoggerOptions({ NODE_ENV: 'production' } as NodeJS.ProcessEnv);
+    expect(opts.transport).toBeUndefined();
+    expect(opts.level).toBe('info');
+  });
+
+  it('respects LOG_LEVEL override across envs', () => {
+    expect(
+      buildLoggerOptions({ NODE_ENV: 'production', LOG_LEVEL: 'debug' } as NodeJS.ProcessEnv).level,
+    ).toBe('debug');
+    expect(
+      buildLoggerOptions({ NODE_ENV: 'test', LOG_LEVEL: 'warn' } as NodeJS.ProcessEnv).level,
+    ).toBe('warn');
+  });
+});
+
+describe('logger module init', () => {
+  const origEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = origEnv;
+    jest.resetModules();
+  });
+
+  it('initializes in development without throwing — confirms pino-pretty is installed', () => {
+    process.env.NODE_ENV = 'development';
+    expect(() => {
+      jest.isolateModules(() => {
+        require('../logger');
+      });
+    }).not.toThrow();
+  });
+});

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,12 +1,15 @@
 import pino from 'pino';
 
-const useDevTransport = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+export function buildLoggerOptions(env: NodeJS.ProcessEnv = process.env): pino.LoggerOptions {
+  const useDevTransport = env.NODE_ENV !== 'production' && env.NODE_ENV !== 'test';
+  return {
+    level: env.LOG_LEVEL ?? (env.NODE_ENV === 'test' ? 'silent' : 'info'),
+    ...(useDevTransport && {
+      transport: { target: 'pino-pretty', options: { colorize: true, ignore: 'pid,hostname' } },
+    }),
+  };
+}
 
-const logger = pino({
-  level: process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'test' ? 'silent' : 'info'),
-  ...(useDevTransport && {
-    transport: { target: 'pino-pretty', options: { colorize: true, ignore: 'pid,hostname' } },
-  }),
-});
+const logger = pino(buildLoggerOptions());
 
 export default logger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@types/swagger-ui-express": "^4.1.6",
         "jest": "^29.7.0",
         "pg-mem": "^3.0.14",
+        "pino-pretty": "^13.1.3",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
         "tsx": "^4.21.0",
@@ -4564,6 +4565,16 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -4782,6 +4793,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5348,6 +5369,13 @@
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5999,6 +6027,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hookified": {
       "version": "1.15.1",
@@ -6907,6 +6942,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-levenshtein": {
@@ -8554,6 +8599,44 @@
         "process-warning": "^5.0.0"
       }
     },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "license": "MIT"
@@ -8840,6 +8923,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -9415,6 +9509,23 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -11406,7 +11517,10 @@
     },
     "shared": {
       "name": "@vocpage/shared",
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^4.4.1"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- backend `npm run dev` crashed with `unable to determine transport target for "pino-pretty"` because `pino-pretty` was missing from devDependencies
- `pino-pretty@^13.1.3` added to backend devDeps; `logger.ts` refactored to extract `buildLoggerOptions(env)` pure function for testability

## Changes

- `backend/package.json` — add `pino-pretty@^13.1.3` (devDeps)
- `backend/src/logger.ts` — extract `buildLoggerOptions(env)`, no behavior change
- `backend/src/__tests__/logger.test.ts` — new — 4 structural cases (transport shape + level per env + LOG_LEVEL override) + 1 module-init smoke

## Verification

- jest 49/49 pass (was 47, +2 from split)
- typecheck clean
- module-init smoke confirms red→green for the original crash

Reviewed by 5 OMC subagents — all APPROVE (round-2 after test-engineer round-1 REQUEST_CHANGES on false-positive risk; resolved by extracting `buildLoggerOptions` and adding structural assertions).

## Notes

- TDD red phase was demonstrated locally (failing test before pino-pretty install) but not captured in commit history since the branch had no commits at that moment. test-engineer accepted.
- Out of scope: `npm run dev` still hits a separate `AUTH_MODE` env crash (no .env loader for non-docker dev path). To be addressed via item 3 (real-BE verify via `docker compose up`).

## Test plan

- [x] backend `npm test` passes (49)
- [x] backend `npm run typecheck` passes
- [ ] post-merge: `npm run dev` boots past pino transport step (next layer is AUTH_MODE — separate item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)