### PR TITLE
fix(backend): docker shared mount + Wave 1 follow-up C verification

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,8 @@ COPY backend/package.json ./backend/
 # 루트에서 설치
 RUN npm ci
 
-# 소스 복사
+# 소스 복사 (shared/는 backend 런타임에서 상대 경로로 import됨 — Wave 1부터 도입)
+COPY shared/ ./shared/
 COPY backend/ ./backend/
 
 WORKDIR /app/backend

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -23,9 +23,11 @@
 
 - Follow-up A (Playwright e2e) — Wave 1 보강과 시나리오 겹침 → **다음
   세션 보강 후** 진행.
-- Follow-up C (`VITE_USE_MSW=false` 통합) — Docker Desktop 시작 →
-  `docker compose up -d` → `/voc` 실 BE/Postgres 검증. **본 세션 별도
-  PR로 처리.**
+- Follow-up C-1 (Docker shared mount) — backend Dockerfile/compose
+  fix. **본 세션 PR로 처리** (`docs/wave1-followup-c-verify`).
+- Follow-up C-2 (seed UUID v4 drift) — `dev_seed.sql` user UUIDs가
+  `FIXTURE_USERS` v4 포맷과 불일치 → `VocListResponse.safeParse` FAIL.
+  다음 세션 단독 PR `feat/wave1-followup-c-seed`.
 
 **Wave 2 prerequisites**: ❌ **보류**. Wave 1 보강 PR 머지 +
 follow-up A·C 종결 후 진입. 그 전에 Wave 2 implementation 금지.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     volumes:
       - uploads_data:/app/backend/uploads
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -55,9 +55,17 @@
 6. **5명 OMC subagent 리뷰** (code-reviewer · security-reviewer · verifier · test-engineer · architect) × (정량 · 정성 · 리스크) 3관점 — 1라운드 이상 + 모든 REQUEST_CHANGES 해소.
 7. APPROVE 5/5 시 push + PR + 사용자 merge.
 
+### Wave 1 follow-up PRs (Wave 1.5 보강 PR과 병렬 가능)
+
+| ID                            | 항목                                                                                                                                                                                                                                                    | 상태                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| follow-up A (Playwright e2e)  | `frontend/e2e/voc-happy-path.spec.ts` + `@playwright/test` install + CI workflow                                                                                                                                                                        | ⏳ Wave 1.5 보강 후 (시나리오 재작성 회피)        |
+| follow-up C-1 (Docker fix)    | backend Dockerfile `COPY shared/`, `docker-compose.yml` `./shared:/app/shared` 마운트                                                                                                                                                                   | ✅ 본 PR (`docs/wave1-followup-c-verify`)         |
+| follow-up C-2 (seed UUID fix) | `backend/seeds/dev_seed.sql` user UUIDs를 `FIXTURE_USERS` 정식 v4로 교체 + FK cascade(`vocs.author_id`/`assignee_id`, `comments.author_id`) + `backend/src/__tests__/seed-fixture-parity.test.ts` 회귀 (pg-mem 기반 `VocListResponse.parse` smoke) 추가 | ⏳ 다음 세션 단독 PR `feat/wave1-followup-c-seed` |
+
 ### Wave 2 진입 hard-block
 
-위 Wave 1 보강 PR 머지 + follow-up A (Playwright) + follow-up C (real-BE) 종결 전까지 **Wave 2 implementation 금지**.
+위 Wave 1 보강 PR 머지 + follow-up A (Playwright) + follow-up C-2 (seed UUID fix) 종결 전까지 **Wave 2 implementation 금지**. follow-up C-1은 본 PR로 종결.
 
 ---
 

--- a/docs/specs/plans/phase-8-wave1-closure-report.md
+++ b/docs/specs/plans/phase-8-wave1-closure-report.md
@@ -246,3 +246,124 @@ buildLoggerOptions`) merged this session — `npm run dev` no longer
 crashes at the pino transport. (A separate `AUTH_MODE` env crash
 remains; that path is exercised by docker-compose, addressed via
 follow-up C.)
+
+---
+
+## Follow-up C — verification results (2026-05-01)
+
+### Stack startup (after BE Dockerfile fix)
+
+`docker compose up -d postgres backend` initially failed at two layers:
+
+1. **Stale postgres volume** — old `postgres_data` volume from a 5-day
+   prior schema state (`008_alter_due_date` already applied) collided
+   with newer migration ordering. Resolved by `docker compose down -v`
+   - fresh start.
+2. **Backend image missing `shared/`** — `backend/Dockerfile` previously
+   only copied `./backend/`, but Wave 1 introduced runtime imports of
+   `shared/contracts/voc/users` (and `shared/fixtures/voc.fixtures` for
+   tests). Container crashed with `MODULE_NOT_FOUND` at
+   `/app/backend/src/auth/mockUsers.ts`. **Fixed in this PR**:
+   - `backend/Dockerfile` — `COPY shared/ ./shared/` before
+     `COPY backend/ ./backend/`.
+   - `docker-compose.yml` — added `./shared:/app/shared` bind mount
+     under `services.backend.volumes` so `tsx watch` picks up shared
+     contract edits without rebuild.
+
+After both fixes: `docker compose ps` shows postgres + backend `(healthy)`
+in ~30s; `GET /api/health` returns `200`.
+
+### `GET /api/vocs?limit=2` against real BE/Postgres
+
+After `npm run db:seed` inside the backend container, the endpoint
+returned `total: 10` (the seed's `vocs` table count; the other inserts
+populate `users`, `systems`, `menus`, `voc_types`, `tags`, `comments`
+but are not part of the list response). Pagination param is `limit`
+(not `per_page`) per `shared/contracts/voc/io.ts:53` — `limit=2`
+returns 2 rows of the 10-row total, with `page=1` and `pageSize=2`.
+Sample row 0 keys (17 fields):
+
+```
+id, issue_code, title, status, priority, voc_type_id, system_id,
+menu_id, assignee_id, author_id, parent_id, source, due_date,
+created_at, updated_at, has_children, notes_count
+```
+
+Shape matches `shared/contracts/voc/entity.ts` `VocListItem` exactly
+(15 picked + 2 extended). `sequence_no` is intentionally projected
+out by `backend/src/services/voc.ts:24-44 toListItem` — list endpoint
+returns the lightweight summary, full `Voc` is fetched per-row via
+`GET /api/vocs/:id`. Not a drift — by design.
+
+### 🔴 Drift: seed UUIDs are not v4 (entity-level strict UUID)
+
+`VocListResponse.safeParse(real-BE-response)` **FAIL** — first issue
+raised on `rows[0].system_id`, then cascades to `voc_type_id`,
+`menu_id`, `assignee_id`, `author_id`. Note: `shared/contracts/voc/io.ts:21`
+defines a **loose hex regex `Uuid`** for query/IO use cases (legacy
+fixture support) but `VocListItem` (which `VocListResponse.rows` uses)
+is defined in `shared/contracts/voc/entity.ts:61` and inherits the
+**strict `z.string().uuid()`** from `entity.ts:32`. Strict zod uuid
+enforces RFC 4122 v1-v8 (version digit `[1-8]` at position 14 +
+variant `[89abAB]` at position 19). Seed values fail both. Trace:
+
+| Source                                          | Example UUID                           | v4 valid?              |
+| ----------------------------------------------- | -------------------------------------- | ---------------------- |
+| `dev_seed.sql` users                            | `00000000-0000-0000-0000-000000000003` | ❌ (version digit `0`) |
+| `shared/contracts/voc/users.ts` `FIXTURE_USERS` | `00000000-0000-4000-8000-0000000000d1` | ✅ (v4 marker)         |
+
+Zod `z.string().uuid()` enforces RFC 4122 v1-v8 with the version digit
+in position 14. Seed values use all-zeros + counter, so the version
+digit is `0` → schema rejection. FE in `VITE_USE_MSW=false` would
+crash on first table render.
+
+**Impact assessment:**
+
+- ❌ Wave 1 FE never tested against real BE response — MSW handlers
+  return fixture rows (which DO use v4 UUIDs) so the gap was masked.
+- ❌ BE itself does not validate response shape (raw repo row → JSON).
+  This means the FE strict schema is the only catch — and it never
+  ran against real seed data this session.
+
+### Fix routing
+
+Per closure-report Open Item #2 playbook, seed UUID drift goes to a
+**separate PR** `feat/wave1-followup-c-seed` (next session entry).
+Audit shows the drift is broader than users: **every PK in
+`dev_seed.sql` uses the `XX000000-0000-0000-0000-...` v0 pattern**
+(users `00000000-…`, systems `10000000-…`, menus `20000000-…`,
+voc_types `30000000-…`, vocs `50000000-…`, comments, tags).
+
+Scope:
+
+1. Rewrite `backend/seeds/dev_seed.sql` UUIDs into RFC 4122 v4 form
+   (version digit at position 14 ∈ `[1-8]`, variant at position 19 ∈
+   `[89ab]`) while preserving deterministic prefixes for grep-ability.
+   Where users overlap `FIXTURE_USERS` (admin / manager / devSelf /
+   devOther / user — `shared/contracts/voc/users.ts`), reuse the
+   fixture UUIDs verbatim. Add `dev` role user (migration 013).
+2. Cascade FK references in the seed: `vocs.author_id`,
+   `vocs.assignee_id`, `vocs.system_id`, `vocs.menu_id`,
+   `vocs.voc_type_id`, `comments.author_id`, `voc_tags.tag_id`, etc.
+3. Per test-engineer round-1 guidance: add
+   `backend/src/__tests__/seed-fixture-parity.test.ts` as a **pure
+   parsing unit test** — `fs.readFileSync('seeds/dev_seed.sql')` →
+   regex-extract every UUID literal → assert each passes
+   `z.string().uuid()`. Faster than pg-mem and catches the same drift
+   class. (FK cascade verification stays in supertest integration
+   tests, not bundled here.)
+4. Re-run `VocListResponse.safeParse` smoke against the running
+   stack — must return `{ success: true, data: …rows: 10… }` before
+   merge.
+
+### Verification artifacts captured
+
+- `/tmp/voc-resp.json` (44 bytes empty → 10-row response after seed)
+- `/tmp/voc-cookie.txt` (admin session cookie via mock-login)
+- Docker compose logs available via `docker compose logs backend`
+
+### Status of Wave 2 prereq #3
+
+⏳ **Real-BE verification ran**, surfaced one drift (seed UUIDs).
+Stack startup blockers fixed in this PR. Drift fix is a separate PR
+before Wave 2 can ship safely.


### PR DESCRIPTION
## Summary

- **C-1 (this PR)**: backend Dockerfile + docker-compose.yml — `shared/` mount/copy missing was crashing BE container (Wave 1 PR #110 introduced runtime imports of `shared/contracts/voc/users`)
- **C-2 (next session)**: surfaced seed UUID v0 drift via `VocListResponse.safeParse` failing on real BE response. Routed to separate PR `feat/wave1-followup-c-seed`.

## Code changes (C-1)

- `backend/Dockerfile` — `COPY shared/ ./shared/` before `COPY backend/`
- `docker-compose.yml` — `./shared:/app/shared` bind mount under backend service

After fix: `docker compose up -d` brings stack to `(healthy)` in ~30s; `GET /api/health → 200`.

## Verification (C-2 finding)

- `GET /api/vocs?limit=2` returns `total: 10` (vocs only) with `VocListItem` shape (17 fields). `sequence_no` projected out by `toListItem` — by design.
- `VocListResponse.safeParse(real-BE-response)` **FAIL** — first issue on `rows[0].system_id`, "Invalid UUID". Strict zod uuid (`entity.ts:31` `z.string().uuid()`) rejects v0 seed UUIDs (`XX000000-0000-0000-0000-...` — version digit `0`). io.ts has its own loose Uuid for query params but VocListItem uses entity.ts strict.
- Audit: every PK in `dev_seed.sql` is v0. Seed fix scope = rewrite all to v4 (preserve grep-able prefixes), reuse `FIXTURE_USERS` v4 UUIDs where overlap exists, add `seed-fixture-parity.test.ts` pure parsing unit test.

## Review (5 OMC subagents × 3 perspectives)

| Reviewer          | Round 1                                | Round 2 |
| ----------------- | -------------------------------------- | ------- |
| code-reviewer     | APPROVE (1 MEDIUM non-blocking)        | —       |
| security-reviewer | APPROVE                                | —       |
| test-engineer     | APPROVE (TDD waiver for build files)   | —       |
| architect         | APPROVE                                | —       |
| verifier          | **REQUEST_CHANGES** (3 factual errors) | APPROVE |

verifier round-1 caught: row count 41→10, param `per_page`→`limit`, safeParse error path source. All corrected; round-2 APPROVE.

## Test plan

- [x] `docker compose up -d` → backend healthy (verified)
- [x] `GET /api/health` 200 (verified)
- [x] `GET /api/vocs?limit=2` returns expected shape (verified)
- [x] `VocListResponse.safeParse` reproduces drift (verified — drift fix → C-2)
- [ ] post-merge: docker compose verified by user

## Notes

- Wave 2 hard-block updated: now requires Wave 1.5 보강 PR + follow-up A (Playwright) + **follow-up C-2** (seed UUID fix) before Wave 2 ships.
- BE prod runtime depends on the Dockerfile fix; `docker compose --profile prod` (if added later) will inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)