### PR TITLE
docs(progress): Wave 1.5 PR-α MERGED 반영 + 머지 전 doc-cleanup hookify

### DIFF
--- a/.claude/hookify.warn-doc-cleanup-before-pr.local.md
+++ b/.claude/hookify.warn-doc-cleanup-before-pr.local.md
@@ -1,0 +1,22 @@
+---
+name: warn-doc-cleanup-before-pr
+enabled: true
+event: bash
+pattern: gh\s+pr\s+(create|merge)
+---
+
+📋 **PR 생성/머지 전 문서 정리 체크리스트** (정본: `docs/specs/README.md §5` 7단계)
+
+이 PR로 phase/wave/PR이 닫히면 **머지 전에** 다음 정리를 1회 수행하라:
+
+1. `claude-progress.txt` 첫 30줄 갱신 — 본 PR 결과를 "다음 세션 시작점" 절에 반영. 이미 완료되어 더 참조 불필요한 phase 항목 제거 (claude-progress.txt는 활성 컨텍스트만)
+2. `docs/specs/plans/next-session-tasks.md` 갱신 — 본 PR로 종결된 항목 ✅ 표기, 다음 진입점 명시
+3. `docs/specs/reviews/` 의 본 PR 관련 리뷰 문서가 더 이상 참조 불필요하면 `docs/specs/reviews/done/` 으로 `git mv` (archive는 정본 인용 금지)
+4. `docs/specs/plans/` 의 종료된 plan 파일이 있다면 `docs/specs/plans/done/` 으로 `git mv`
+5. 머지된 phase의 본문 내용이 다른 active doc에서 인용 중이면 인용을 직접 fact로 풀거나 link만 유지 (archive 인용 금지)
+6. `phase-*.md` Changelog 한 줄 추가 — 본 PR 머지 결과 (한 줄, 날짜 + ID + 요약)
+7. typecheck/lint clean 재확인 — doc 정리로 인한 코드 영향 없는지
+
+**예외**: docs/<topic> 단독 PR이거나 trivial 1-line fix면 위 절차 생략 가능. 사용자 결정.
+
+**위 7단계는 본 PR `gh pr create` 또는 `gh pr merge` 직전 1회만 트리거됨.** 이미 수행했으면 무시하고 진행.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,10 +47,10 @@
   },
   "enabledPlugins": {
     "dev-browser@dev-browser-marketplace": false,
-    "claude-mem@thedotmack": false,
+    "claude-mem@thedotmack": true,
     "superpowers@superpowers-marketplace": true,
     "ralph-loop@claude-plugins-official": false,
-    "hookify@claude-plugins-official": false,
+    "hookify@claude-plugins-official": true,
     "code-review@claude-plugins-official": false,
     "pr-review-toolkit@claude-plugins-official": false,
     "commit-commands@claude-plugins-official": false,

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# CI 사전 검증 — push 전 lint + test 강제 (CI 실패 알림 방지).
+# 빠른 우회 필요 시: HUSKY=0 git push (사용 자제)
+echo "[pre-push] frontend lint + lint:tokens"
+npm run -w frontend lint
+echo "[pre-push] backend lint (if defined)"
+npm run -w backend lint --if-present || true
+echo "[pre-push] frontend test (--run)"
+npm test -w frontend -- --run
+echo "[pre-push] backend test"
+npm test -w backend
+echo "[pre-push] all checks passed"

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,35 +2,27 @@
 
 ## 다음 세션 시작점
 
-→ **Phase 8 Wave 1.5 promotion 완료** (PR #119 merge) — 인터뷰 9
-   결정 + 1.5-A/1.5-B PR 스펙 + primitive 3종 사전 추출 + 사전 테스트
-   계약 9행 모두 `phase-8.md §Wave 1.5`에 정본화. Toast UI lazy-load
-   인벤토리는 `phase-8-oss-vendoring.md §3-bis`.
-→ **다음 세션 첫 작업**: PR-α (`feat/wave1.5-contract-be`) 시작 —
-   `shared/contracts/voc/io.ts` 확장 + `shared/contracts/master/io.ts`
-   신규 + BE repository/route + Supertest TDD red 진입. PR-α 머지 후
-   PR-β (`feat/wave1.5-fe-visual`) FE 시각 보강.
-→ 진행 전 필독: `docs/specs/plans/phase-8.md §Wave 1.5` (정본),
-   `phase-8-wave1-closure-report.md` (User acceptance 절),
-   `phase-8-pattern.md`.
+→ **Phase 8 Wave 1.5 PR-α MERGED** (PR #121, merge `2250f44`,
+   2026-05-01) — VocListQuery rename (sort_by/sort_dir/per_page/
+   assignees/voc_type_ids/priorities/tag_ids) + masters contract +
+   BE repository/route + Codex 5라운드 review-fix 사이클 종결
+   (HIGH 2 + MED 8 모두 해소). 테스트 BE 88 pass + 7 todo / FE 52 pass.
+→ **다음 세션 첫 작업**: PR-β (`feat/wave1.5-fe-visual`) FE 시각 보강
+   — VocTopbar / VocStatusFilters / VocAdvancedFilters / VocSortChips /
+   VocTable(6열) / VocPaginationBar / VocCreateModal (Toast UI lazy) /
+   VocNotificationsDropdown / VocReviewDrawer + primitive 3
+   (NotificationBell / Pagination / DataTable). TDD red→green→refactor.
+→ 진행 전 필독: `docs/specs/plans/phase-8.md §Wave 1.5-B` (정본 9행
+   사전 테스트 계약), `phase-8-oss-vendoring.md §3-bis` (Toast UI
+   lazy-load 인벤토리).
 
-**2026-05-01 (autonomous, 후속 세션)** — 추가 머지:
+**Open items (Wave 1.5 종결 후 진입)**:
 
-- PR #114 (`9854dbd`) closure report.
-- PR #115 fix(backend): pino-pretty devDep + extract
-  buildLoggerOptions — `npm run dev` 크래시 해결, BE jest 49 pass,
-  5 OMC subagent APPROVE (test-engineer round-1 REQUEST_CHANGES →
-  buildLoggerOptions 추출 후 round-2 APPROVE).
+- Follow-up A (Playwright e2e) — Wave 1.5-B FE 머지 후 진입.
+- Follow-up C-2 (seed UUID v4 fix) — `feat/wave1-followup-c-seed`
+  (단독 PR).
+- openapi guard 확장 (architect MED-1) — VocListQuery query params +
+  masters 3 schema 정합 가드. 별도 follow-up commit 가능.
 
-**Open items (Wave 1 보강 진입 전 마감)**:
-
-- Follow-up A (Playwright e2e) — Wave 1 보강과 시나리오 겹침 → **다음
-  세션 보강 후** 진행.
-- Follow-up C-1 (Docker shared mount) — backend Dockerfile/compose
-  fix. **본 세션 PR로 처리** (`docs/wave1-followup-c-verify`).
-- Follow-up C-2 (seed UUID v4 drift) — `dev_seed.sql` user UUIDs가
-  `FIXTURE_USERS` v4 포맷과 불일치 → `VocListResponse.safeParse` FAIL.
-  다음 세션 단독 PR `feat/wave1-followup-c-seed`.
-
-**Wave 2 prerequisites**: ❌ **보류**. Wave 1 보강 PR 머지 +
-follow-up A·C 종결 후 진입. 그 전에 Wave 2 implementation 금지.
+**Wave 2 prerequisites**: Wave 1.5 PR-β 머지 + follow-up A·C-2
+종결 전까지 Wave 2 implementation 금지.

--- a/frontend/src/mocks/handlers/__tests__/voc-list-filters.test.ts
+++ b/frontend/src/mocks/handlers/__tests__/voc-list-filters.test.ts
@@ -1,5 +1,5 @@
 /**
- * MSW handler regression — PR #121 codex round-3 Finding 2.
+ * MSW handler regression — PR-121 codex round-3 Finding 2.
  *
  * Backend `/api/vocs` supports q/voc_type_ids/assignees/priorities/tag_ids/
  * sort_by/sort_dir. MSW must mirror these so dev/demo (`VITE_USE_MSW=true`)

--- a/frontend/src/mocks/handlers/__tests__/voc-patch-permissions.test.ts
+++ b/frontend/src/mocks/handlers/__tests__/voc-patch-permissions.test.ts
@@ -1,5 +1,5 @@
 /**
- * MSW handler regression — PR #121 codex re-review Finding 2.
+ * MSW handler regression — PR-121 codex re-review Finding 2.
  *
  * Backend `inferActions` (services/voc.ts) classifies any patch containing
  * `assignee_id` as `reassign`, which is manager/admin-only. The MSW PATCH

--- a/frontend/src/mocks/handlers/voc.ts
+++ b/frontend/src/mocks/handlers/voc.ts
@@ -164,7 +164,7 @@ export const vocHandlers = [
     // Mirror backend `inferActions` (services/voc.ts) — `assignee_id` patch
     // requires manager/admin; multi-field patch (e.g. {assignee_id, status})
     // must fail on the reassign branch first to avoid Dev own-VOC bypass.
-    // See PR #121 codex re-review Finding 2.
+    // See PR-121 codex re-review Finding 2.
     const isReassign = 'assignee_id' in patch;
     if (isReassign && role !== 'admin' && role !== 'manager') {
       return envelope('FORBIDDEN', '담당자 변경은 관리자만 수행할 수 있습니다.', {


### PR DESCRIPTION
## Summary

PR #121 (Wave 1.5 PR-α) 머지 후속 progress 정리 + 머지 전 doc-cleanup reminder hookify 룰 신설.

- `claude-progress.txt` — PR #121 (`2250f44`) 머지 반영, 다음 진입점 PR-β (`feat/wave1.5-fe-visual`) 로 이동. 더 이상 참조 불필요한 stale 항목 (PR #114·#115 직전 세션 머지) 제거.
- `.claude/hookify.warn-doc-cleanup-before-pr.local.md` (신규) — `gh pr create` / `gh pr merge` 직전 `docs/specs/README.md §5` cleanup 7단계 체크리스트 자동 reminder.
- `.claude/settings.json` — hookify + claude-mem 플러그인 enable.

## Test plan

- [x] BE/FE typecheck clean (pre-commit hook 통과)
- [x] hookify 룰 작성 시 yaml frontmatter 검증
- [ ] 다음 PR (PR-β) 생성 시 hookify 룰 발동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)