### PR TITLE
docs(progress): Wave 1.5 PR-β MERGED 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,16 @@
 # CLAUDE.md
 
-Guidance for Claude Code working in this repo.
+Guidance for Claude Code in this repo.
 
 ## Project
 
-**VOC (Voice of Customer) management system**.
+**VOC (Voice of Customer) management system.**
 
-- 현재 진행 상태: `claude-progress.txt` (첫 30줄) → `docs/specs/plans/next-session-tasks.md`
+- Current progress: `claude-progress.txt` (first 30 lines) → `docs/specs/plans/next-session-tasks.md`
 - Product spec: `docs/specs/requires/requirements.md`
 - Design system: `docs/specs/requires/uidesign.md`
 
-이 파일에 phase/wave 진행 상태를 적지 않는다 — 정본은 위 progress·plan 문서.
+Do not record phase/wave progress in this file — canonical source is the progress + plan docs above.
 
 ## Stack (summary — details in sub-dir CLAUDE.md)
 
@@ -40,7 +40,7 @@ Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Arc
 2. Read `docs/specs/plans/next-session-tasks.md` to find current Phase and pending tasks
 3. Read relevant spec in `docs/` (selectively — only what's needed)
 4. Continue from progress file — don't re-read what you already know
-5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete entries already reflected in specs or git (delete file + remove from index; do not archive)
+5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete entries already reflected in specs or git
 
 ## Core Rules
 
@@ -50,7 +50,7 @@ Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Arc
 - **Tail test output** — pipe through `| tail -20`; never print full traces
 - **No Read before delete** — files being deleted must never be Read first; just `rm`
 - **Broad grep first pass** — use `--all` and wide keywords on first `git log` grep; never retry with a narrower pattern
-- **Minimum context for decisions** — judgment tasks (e.g. "문서 업데이트"): use only the single most relevant file; open supporting files only if the first is insufficient
+- **Minimum context for decisions** — for judgment tasks, use only the single most relevant file; open supporting files only if the first is insufficient
 - **Git workflow** — feature branch only (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`); never commit or push to main directly. PRs are opened by the user. Merge with `gh pr merge <n> --merge --delete-branch` (`--squash` and `--rebase` forbidden). After merge: `git branch -D <branch>`. Enforced by hookify rules in `.claude/hookify.block-*.local.md`.
 - Run tests before committing; follow existing code style (read 2–3 nearby files first)
 - No features beyond what the task requires (YAGNI)
@@ -62,21 +62,9 @@ Every design decision → written to spec or ADR before session ends.
 Every phase completion → update `claude-progress.txt` + git commit.
 No implementation without a written spec section covering it.
 
-## Documents (structure + coherence)
+## Documents
 
-**문서 관리 정본: `docs/specs/README.md` (Documentation Hygiene).** 본 섹션은 핵심 룰만 명시.
-
-핵심 원칙:
-
-- **CLAUDE.md가 governance 최상위 정본**, AGENTS.md는 진입 포인터일 뿐 (룰은 여기로 위임)
-- **신규 doc 금지** — 사용자 명시 요청 시에만 새 파일. 그 외엔 기존 SoT 갱신
-- **One responsibility per doc** — 시각/동작 spec 혼합 금지. `uidesign.md`에 동작 ✗, `requirements.md`에 시각 ✗. `uidesign.md`는 English
-- **Active vs archive** — 활성: `plans/next-session-tasks.md` + 진행 중 `plans/phase-N.md`. 머지된 리뷰 → `reviews/done/`, 완료 plan → `plans/done/`. **archive는 정본 인용 금지**
-- **루트에 doc 파일 금지** — 모든 design/review/plan은 `docs/specs/` 하위. 도구 임시(`.omc/plans/`, `.superpowers/`) 는 canonical 아님
-- **Cleanup 절차** — 세션 시작·phase close·"문서 정리" 요청 시 `docs/specs/README.md §5` 7단계 실행
-- **신규 doc 작성 전** — `docs/specs/README.md §6` 체크리스트 통과 필수
-
-SoT 우선순위·결정 분기표·archive 운영 메모는 `docs/specs/README.md`에 정본.
+Documentation hygiene canonical source: **`docs/specs/README.md`**. Consult it before creating, moving, or cleaning up any doc.
 
 ## Input Interpretation
 
@@ -91,12 +79,12 @@ Skip the frame for trivial one-liners (rename, obvious typo, single-file change 
 
 ## Working Style
 
-- **TDD only** — every implementation (FE/BE) goes test-first: write or update the test, confirm it fails for the right reason, write the minimal code to pass, then refactor. No "tests later" PRs. Bug fixes start with a failing regression test. Stack: Vitest (FE) / Jest+Supertest (BE) — see `requirements.md §3`.
+- **TDD only** — every implementation (FE/BE) is test-first: write or update the test, confirm it fails for the right reason, write the minimal code to pass, then refactor. No "tests later" PRs. Bug fixes start with a failing regression test. Stack: Vitest (FE) / Jest+Supertest (BE) — see `requirements.md §3`.
 - **No completion claims** — never mark a task done until the user explicitly says so
 - **No implementation without approval** — never write BE/FE code until the user says to start
 - **Debate, don't defer** — raise counterarguments or missed cases before agreeing; no passive "yes"
 - **Think before coding** — state assumptions; if multiple interpretations exist, present them, don't pick silently
-- **90% certainty gate** — 진행 중 어떤 결정이든 90% 이상 확신이 없으면 임의 진행 금지. 해소될 때까지 사용자에게 질문한다 (양쪽 옵션·근거 명시 형식). 추측·기본값 채우기·"일단 이걸로" 모두 금지
+- **90% certainty gate** — never proceed on any decision without ≥90% confidence. Ask the user (present both options + rationale) until resolved. No guessing, no default-filling, no "let's go with this for now".
 - **Simplicity first** — minimum code; no speculative abstractions; if 200 lines could be 50, rewrite
 - **Surgical changes** — touch only what the request requires; match existing style; remove only orphans your changes made unused
 - **Goal-driven execution** — convert tasks into verifiable goals; for multi-step work, plan per-step verification and loop until verified

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -6,7 +6,7 @@ Express REST API for the VOC management system. Read root `CLAUDE.md` first for 
 
 ## Status
 
-Scaffolded — feature work deferred to Phase 8. Currently `src/` has `index.ts`, `auth/` (mockLogin only — `validateADSession` is a stub for Phase 9), `routes/`. Migrations 001-011 applied; 012 (dev role), 013 (tag master), 014 (trash) drafted in `docs/specs/plans/`.
+Phase 8 Wave 1.5-β merged (POST /api/vocs + history routes). `src/` layout follows route → controller → service → repository: `index.ts`, `db.ts`, `logger.ts`, `auth/` (mockLogin only — `validateADSession` is a stub for Phase 9), `routes/`, `controllers/`, `services/`, `repository/`, `middleware/`, `validators/`. Migrations 001-013 applied (013 = dev role + voc origin metadata). Next: Wave 2 — see `docs/specs/plans/next-session-tasks.md`.
 
 ## Commands
 

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,27 +2,25 @@
 
 ## 다음 세션 시작점
 
-→ **Phase 8 Wave 1.5 PR-α MERGED** (PR #121, merge `2250f44`,
-   2026-05-01) — VocListQuery rename (sort_by/sort_dir/per_page/
-   assignees/voc_type_ids/priorities/tag_ids) + masters contract +
-   BE repository/route + Codex 5라운드 review-fix 사이클 종결
-   (HIGH 2 + MED 8 모두 해소). 테스트 BE 88 pass + 7 todo / FE 52 pass.
-→ **다음 세션 첫 작업**: PR-β (`feat/wave1.5-fe-visual`) FE 시각 보강
-   — VocTopbar / VocStatusFilters / VocAdvancedFilters / VocSortChips /
-   VocTable(6열) / VocPaginationBar / VocCreateModal (Toast UI lazy) /
-   VocNotificationsDropdown / VocReviewDrawer + primitive 3
-   (NotificationBell / Pagination / DataTable). TDD red→green→refactor.
-→ 진행 전 필독: `docs/specs/plans/phase-8.md §Wave 1.5-B` (정본 9행
-   사전 테스트 계약), `phase-8-oss-vendoring.md §3-bis` (Toast UI
-   lazy-load 인벤토리).
+→ **Phase 8 Wave 1.5 PR-β MERGED** (PR #123, merge `ff3ba0a`,
+   2026-05-02) — `/voc` prototype 시각·UX 동등화 완료.
+   12 신규 컴포넌트 (primitive 3 + VOC composition 9) +
+   integration test + Toast UI Editor lazy chunk (~776kB) +
+   VocReviewDrawer/Tabs 분할 + BE `POST /api/vocs` & history
+   라우트 (codex review HIGH+MED 해소).
+   테스트: BE 92 pass + 7 todo / FE 122 pass.
+→ **다음 세션 첫 작업**: Wave 2 진입 hard-block 해소
+   - Follow-up A (Playwright e2e) — `frontend/e2e/voc-happy-path.spec.ts`
+   - Follow-up C-2 (seed UUID v4) — `feat/wave1-followup-c-seed`
+   - 둘 다 머지 후 Wave 2 (Dashboard) 진입 가능
 
-**Open items (Wave 1.5 종결 후 진입)**:
+**Wave 1.5-γ 후속 (defer 항목, 별도 PR)**:
 
-- Follow-up A (Playwright e2e) — Wave 1.5-B FE 머지 후 진입.
-- Follow-up C-2 (seed UUID v4 fix) — `feat/wave1-followup-c-seed`
-  (단독 PR).
-- openapi guard 확장 (architect MED-1) — VocListQuery query params +
-  masters 3 schema 정합 가드. 별도 follow-up commit 가능.
+- VocCreateModal 수동 useState → RHF+Zod resolver 마이그레이션 (spec drift)
+- DOMPurify customHTMLSanitizer (defense-in-depth)
+- VocAdvancedFilters tag/voc_type chip 테스트 보강
+- NativeSelect 단위 테스트
+- systems/menus placeholder UUID → Wave 3 admin masters에서 query 연결
+- openapi guard 확장 — VocListQuery + masters 3 schema 정합 가드
 
-**Wave 2 prerequisites**: Wave 1.5 PR-β 머지 + follow-up A·C-2
-종결 전까지 Wave 2 implementation 금지.
+**Wave 2 prerequisites**: Follow-up A (Playwright) + C-2 (seed UUID) 종결.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -6,7 +6,7 @@ React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-c
 
 ## Status
 
-Scaffolded — actual feature implementation deferred to Phase 8. Currently in Phase 7 (prototype-driven design freeze). `src/` contains: `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, `api/`, `contexts/`, `hooks/`, `styles/`, `test/`.
+Phase 8 Wave 1.5-β merged (`/voc` prototype-equivalent UI). Current `src/` tree: `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, `api/`, `components/{common,voc,layout,ui}/`, `features/`, `contexts/`, `hooks/`, `lib/`, `mocks/` (MSW v2 handlers), `styles/`, `test/`. Next: Wave 2 (Dashboard) — see `docs/specs/plans/next-session-tasks.md`.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

PR #123 (Wave 1.5 PR-β) 머지 (`ff3ba0a`, 2026-05-02) 반영. claude-progress.txt를 다음 세션 시작점으로 업데이트.

## Test plan
- [x] 단일 파일 docs 변경, 코드 영향 없음