### PR TITLE
feat(wave-1.6 Phase B): VOC token gap sync — status trio + row/avatar/mark + overlay fix

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -15,31 +15,17 @@
    `voc-prototype-decomposition.md` ~700줄 + plan `wave-1-6-voc-parity.md`.
    리뷰: architect/critic/document-specialist 3종 internal + codex adversarial 1종 → critical/high 9건 fix 적용.
    plan §5.3 amend: §7 임계 실측은 Phase B 종료 후 캘리브레이션 단계로 이전.
-→ **다음 세션 첫 작업**: Wave 1.6 **Phase B (토큰 갭 채우기)** 착수.
-   범위: §6.5 통합 체크리스트 (status 트리오 15개 spec→CSS 동기화, raw OKLCH 토큰화 4종, #fff→`--text-on-brand` 치환, overlay 이름 정합). 컴포넌트 코드 변경 금지.
-   파일: `frontend/src/styles/index.css` 추가 + `docs/specs/requires/uidesign.md` §10·§12 동기화.
-   게이트: 토큰 lint 통과(§7.3 색상 literal regex 3종) + 사용자 승인 → Phase C 진입.
+→ **Wave 1.6 Phase B PR OPEN** (PR #128, 2026-05-02) — 토큰 갭 채우기 완료.
+   변경: `frontend/src/styles/index.css` +29 (status 트리오 15개 spec→CSS 동기화 + §B 신규 6개) + `docs/specs/requires/uidesign.md` +13/-1 (§B 신규 6개 + §C `var(--overlay)`→`var(--bg-overlay)` 정정).
+   리뷰: architect/code-reviewer/critic 3종 internal + codex adversarial 1종 — high/critical 0건. critic Major 2건은 사후 docs follow-up으로 분리 (plan §8 ↔ spec §7.3 lint 정합화).
+   상태: 사용자 검수 대기 → 머지 후 Phase C 진입.
 
-**다음 세션 자동 시작 프롬프트** (그대로 붙여넣기):
-
-```
-/oh-my-claudecode:autopilot Wave 1.6 Phase B 착수.
-산출물: docs/specs/requires/voc-prototype-decomposition.md §6.5 체크리스트 그대로 적용.
-- §A: status 트리오 15개를 uidesign.md:618-632에서 frontend/src/styles/index.css로 복사 동기화
-- §B: --voc-row-hover-bg, --voc-row-selected-bg, --avatar-{steel,teal,violet}, --mark-bg 신규 정의 (uidesign.md §10 + index.css 동시)
-- §C: uidesign.md:1062 var(--overlay) 표기 → var(--bg-overlay) 정정
-- 컴포넌트 코드 변경 금지 (style 파일 + 문서만)
-워크플로우: 설계(plan §6 정독) → 구현(/gated-team-dev 가능시 사용) → 리뷰(architect/code-reviewer/critic 3종 + codex:adversarial-review). 셀프 리뷰 금지. 각 리뷰어는 3개 관점 체크리스트.
-복잡도에 맞는 모델 할당. 종료 전 300줄 초과 코드 있으면 SRP에 따라 분리.
-PR 올린 후 codex 리뷰 → 수정사항 발생 시 적용 여부 자체 판단 후 반영.
-워치독 백그라운드 1개 운영, 멈추면 재개.
-머지·완료 선언은 사용자 검수 후만.
-```
+→ **다음 세션 첫 작업**: PR #128 머지 후 Wave 1.6 **Phase C (컴포넌트 1개씩 rebuild)** 착수. Phase A 산출물 §5.2 우선순위 표(`voc-prototype-decomposition.md`)에 따라 leaf 컴포넌트부터.
 
 **Wave 1.6 전체 흐름** (정본 plan: `docs/specs/plans/wave-1-6-voc-parity.md`)
 - ✅ Phase A — 분해 산출물 (PR #126 merged)
-- ⏳ Phase B — 토큰 갭 채우기 (다음 세션)
-- Phase C — 컴포넌트 1개씩 rebuild (Phase B 통과 후)
+- 🟡 Phase B — 토큰 갭 채우기 (PR #128 open, 머지 대기)
+- ⏳ Phase C — 컴포넌트 1개씩 rebuild (Phase B 머지 후)
 - Phase D — 종합 검증
 - 금지: Wave 2 + Follow-up C-2 hard-block (Wave 1.6 종료 전)
 

--- a/docs/specs/requires/uidesign.md
+++ b/docs/specs/requires/uidesign.md
@@ -631,6 +631,18 @@ Full token set — copy into `:root` as the single source of truth.
   --status-drop-fg: light-dark(oklch(50% 0.16 68), oklch(72% 0.16 72));
   --status-drop-border: light-dark(oklch(80% 0.065 72), oklch(33% 0.068 70));
 
+  /* VOC row state backgrounds (Wave 1.6 Phase B — prototype list.css:L83/L90) */
+  --voc-row-hover-bg: light-dark(oklch(94% 0.014 257), oklch(21% 0.028 261));
+  --voc-row-selected-bg: light-dark(oklch(90% 0.03 260), oklch(24% 0.042 262));
+
+  /* Mini-avatar palette — muted, distinct from brand blue (prototype list.css:L289–L303) */
+  --avatar-steel: oklch(44% 0.08 255);
+  --avatar-teal: oklch(42% 0.1 155);
+  --avatar-violet: oklch(42% 0.1 300);
+
+  /* Inline highlight (`<mark>`, prototype misc.css:L17) */
+  --mark-bg: oklch(75% 0.16 72 / 0.35);
+
   /* Role pill — Admin · Manager · Dev · User (D18 / D20, 2026-04-26) */
   /* admin / manager / user reuse existing brand & status tokens; only `dev` requires net-new tokens. */
   --role-dev-fg: light-dark(
@@ -1059,7 +1071,7 @@ Three severity tiers — every Notice list row leads with one of these.
 
 > Spec lives in `feature-notice-faq.md §10.3.2`. Visual contract:
 
-- Reuse the standard Modal pattern (overlay = `var(--overlay)`, dialog surface = `var(--bg-surface)` with `box-shadow: var(--shadow-dialog)`).
+- Reuse the standard Modal pattern (overlay = `var(--bg-overlay)`, dialog surface = `var(--bg-surface)` with `box-shadow: var(--shadow-dialog)`).
 - Severity badge in the header (`§13.6.1`), title in `font-size: 16px; font-weight: 700`, body in `font-size: 13.5px; color: var(--text-secondary)`.
 - Footer holds two controls aligned right: `[ ] 오늘 하루 보지 않기` (checkbox, `var(--text-tertiary)` label) and primary `닫기` button (`.admin-btn` ghost variant).
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -121,6 +121,35 @@
   --status-dot-done: light-dark(oklch(46% 0.19 155), oklch(63% 0.21 158)); /* 완료 */
   --status-dot-drop: light-dark(oklch(60% 0.18 70), oklch(70% 0.17 72)); /* 드랍 */
 
+  /* Status badge trio — bg / fg / border per VOC status (uidesign.md §10:618–632) */
+  --status-received-bg: light-dark(oklch(91% 0.006 260), oklch(22% 0.008 262));
+  --status-received-fg: light-dark(oklch(50% 0.01 260), oklch(56% 0.008 260));
+  --status-received-border: light-dark(oklch(84% 0.01 260), oklch(28% 0.012 262));
+  --status-reviewing-bg: light-dark(oklch(91% 0.035 242), oklch(21% 0.05 245));
+  --status-reviewing-fg: light-dark(oklch(45% 0.18 245), oklch(68% 0.17 242));
+  --status-reviewing-border: light-dark(oklch(78% 0.06 242), oklch(32% 0.07 244));
+  --status-processing-bg: light-dark(oklch(91% 0.04 152), oklch(20% 0.055 154));
+  --status-processing-fg: light-dark(oklch(42% 0.17 152), oklch(66% 0.19 155));
+  --status-processing-border: light-dark(oklch(76% 0.065 152), oklch(30% 0.075 154));
+  --status-done-bg: light-dark(oklch(91% 0.038 155), oklch(20% 0.05 158));
+  --status-done-fg: light-dark(oklch(40% 0.18 155), oklch(65% 0.2 158));
+  --status-done-border: light-dark(oklch(75% 0.065 155), oklch(30% 0.072 158));
+  --status-drop-bg: light-dark(oklch(93% 0.04 72), oklch(21% 0.048 68));
+  --status-drop-fg: light-dark(oklch(50% 0.16 68), oklch(72% 0.16 72));
+  --status-drop-border: light-dark(oklch(80% 0.065 72), oklch(33% 0.068 70));
+
+  /* VOC row state backgrounds (prototype list.css:L83/L90) */
+  --voc-row-hover-bg: light-dark(oklch(94% 0.014 257), oklch(21% 0.028 261));
+  --voc-row-selected-bg: light-dark(oklch(90% 0.03 260), oklch(24% 0.042 262));
+
+  /* Mini-avatar palette — muted, distinct from brand blue (prototype list.css:L289–L303) */
+  --avatar-steel: oklch(44% 0.08 255);
+  --avatar-teal: oklch(42% 0.1 155);
+  --avatar-violet: oklch(42% 0.1 300);
+
+  /* Inline highlight (`<mark>`, prototype misc.css:L17) */
+  --mark-bg: oklch(75% 0.16 72 / 0.35);
+
   /* Semantic aliases */
   --danger: var(--status-red);
   --text-on-brand: oklch(100% 0 0);


### PR DESCRIPTION
## Summary

Wave 1.6 Phase B — `voc-prototype-decomposition.md §6.5` 통합 체크리스트 적용. **컴포넌트 코드 변경 없음** (Phase B 스코프 = style file + docs only).

### §A spec → CSS 동기화 (15 tokens)
`--status-{received,reviewing,processing,done,drop}-{bg,fg,border}` 15개를 `docs/specs/requires/uidesign.md:618–632`에서 `frontend/src/styles/index.css`로 1:1 복사. 값 변경 없음, frontend가 spec과 일치하지 않던 격차 해소.

### §B 신규 정의 (6 tokens, uidesign.md §10 + index.css 동시 추가)
- `--voc-row-hover-bg`, `--voc-row-selected-bg` — `prototype/css/layout/list.css:83/90`
- `--avatar-steel`, `--avatar-teal`, `--avatar-violet` — `prototype/css/layout/list.css:289–303`
- `--mark-bg` — `prototype/css/components/misc.css:17`

### §C 정합 정정
- `docs/specs/requires/uidesign.md:1062` `var(--overlay)` → `var(--bg-overlay)` (stale doc ref; production에는 `--bg-overlay`만 존재)

## Phase B 게이트 (`voc-prototype-decomposition.md §7.3`)

| 검사 | 결과 |
| --- | --- |
| regex 1 (hex literal in src/) | 0 hits |
| regex 2 (raw OKLCH in src/) | `frontend/src/tokens.ts`만 — `frontend/CLAUDE.md` 정책상 raw OKLCH 단일 정의 소스 (정책 준수) |
| regex 3 (inline JSX color style) | 모두 `var(--*)` 경유, raw 값 0 |
| pre-commit (prettier/stylelint/typecheck) | green |

## Out of scope (의도적)

- 컴포넌트 코드 변경 — Phase C 대상
- prototype CSS의 `#fff` 4건 직접 수정 — prototype은 reference이므로 본 Wave 미대상 (production rebuild 시 `--text-on-brand` 사용 강제)
- §B 토큰의 `frontend/src/tokens.ts` 미러링 — 기존 `--status-*-{bg,fg,border}` 등 동일 패턴(light-dark pair는 index.css 단독 정의). JS 동적 색상 소비자 부재.
- `--avatar-*`/`--mark-bg` light-dark pair화 — prototype 원본이 단일 모드. Phase C 컴포넌트 wiring 시 light-mode 시각 검증 후 결정 (별도 follow-up).

## Follow-up (post-merge)

- `docs/specs/plans/wave-1-6-voc-parity.md §8` lint 명세를 `voc-prototype-decomposition.md §7.3` 3종 regex와 일치시키는 docs PR (스펙 단일 정본화).

## Test plan

- [x] reviewer 3종(architect/code-reviewer/critic) 독립 패스 — high/critical 0건
- [x] codex adversarial review — 0 finding
- [ ] 사용자 검수 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)