### PR TITLE
docs(wave-1.6): Phase C 병렬 batch 실행 순서 (§7.2/§7.3)

### DIFF
--- a/docs/specs/plans/wave-1-6-voc-parity.md
+++ b/docs/specs/plans/wave-1-6-voc-parity.md
@@ -113,8 +113,35 @@ Phase D: 종합 검증
 - 컴포넌트 1개 rebuild가 200줄 초과 → 더 작게 쪼개거나 디자인 단순화 협의
 - 임계 미달 컴포넌트 누적 3개 → Phase 중단, 원인 분석
 
+### 7.2 Batch 실행 순서 (병렬 슬롯)
+
+원칙: 코딩은 병렬, 머지는 순서대로. 같은 파일 충돌 회피 + 의존성 역피라미드.
+
+총 19 rebuild 잔여 (C-1 VocStatusBadge 완료, PR #129).
+
+| Batch | 컴포넌트 (PR 번호 leaf id)                                                                                             | 병렬도     | 의존·메모                                                                                                                                                                |
+| ----- | ---------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **α** | C-2 VocPriorityBadge → C-3 VocTagPill ∥ C-4 VocSubRow → **B-add-1** → C-5 VocAssignee → C-6 VocListHeader → C-7 VocRow | 2 슬롯     | C-2 단독 머지 후 C-3·C-4 동시. C-5는 avatar colorCls 6 토큰 → §5.1 ≥4 → **Phase B addendum 별도 PR(B-add-1) 선행 필수**. C-6/C-7은 VocTable.tsx 충돌로 sequential closer |
+| **β** | C-8 VocSortChips ∥ C-9 VocAdvancedFilters ∥ C-10 NotifButton+NotifPanel                                                | 3 슬롯     | 서로 다른 파일·의존 0                                                                                                                                                    |
+| **γ** | C-11 VocCreateModal+AttachmentZone                                                                                     | 1          | atom 동봉 1 PR. 200줄 초과 시 분할 (§7.1)                                                                                                                                |
+| **δ** | C-12 VocReviewDrawer → C-13 VocReviewTabs                                                                              | sequential | δ shell 의존                                                                                                                                                             |
+| **ε** | C-14 VocCommentList ∥ C-15 VocInternalNotes ∥ C-16 VocSubTaskList                                                      | 3 슬롯     | δ 머지 후 진입                                                                                                                                                           |
+| **ζ** | C-17 SidebarUserSwitcher → C-18 Sidebar ∥ C-19 Topbar                                                                  | 2 슬롯     | C-18은 C-17 popover 의존. C-19는 **β의 NotifButton 머지 후** 시작 (props 충돌 회피)                                                                                      |
+
+- **AppShell**은 token-align 분류이므로 Phase C rebuild 대상 아님. Phase D 종합 검증에서 일괄 점검.
+- Critical path (sequential): C-2 → B-add-1 → C-5 → C-7 → C-11 → C-12 → C-13 → C-19. ≈ 8 단계.
+- 총 PR 수: rebuild 19 PR + addendum 1 PR = **20 PR**. 추정 6~10 세션.
+- D9(컴포넌트당 1 PR) 유지. 병렬 슬롯이라도 PR은 별도.
+
+### 7.3 Batch 진입·종료 게이트
+
+- Batch 진입: 직전 Batch 마지막 PR 머지 + 사용자 검수 통과.
+- Batch 내 병렬 슬롯: 각 PR 독립 TDD RED→GREEN, 같은 Batch 내 머지 순서는 충돌 없는 한 자유.
+- Batch 종료 보고: Batch 끝날 때 progress.txt 갱신 + 다음 Batch 첫 leaf 명시.
+
 ## 8. Phase D 상세
 
+- AppShell token-align 일괄 점검 (Phase C rebuild 대상 외 token-align 7종 모두 포함)
 - /voc 전체 visual-diff (data-pcomp 자손 포함) SKIP 0
 - E2E 전체 그린
 - 토큰 lint 통과 (`grep -rE '#[0-9a-fA-F]{3,8}\b' src/` → 0 hits, 토큰 정의부 제외)


### PR DESCRIPTION
## Summary

Wave 1.6 Phase C 잔여 19 rebuild을 병렬 실행 가능한 6개 batch로 분할. 다음 세션부터 순서대로 진행.

- §7.2 추가: Batch α(C-2~C-7, 2슬롯) → β(C-8~C-10, 3슬롯) → γ(C-11) → δ(C-12~C-13, sequential) → ε(C-14~C-16, 3슬롯) → ζ(C-17~C-19) + B-add-1 (avatar 6 토큰 addendum)
- §7.3 추가: Batch 진입·종료 게이트
- §8 보강: Phase D 종합 검증에서 AppShell + token-align 7종 일괄 점검

Critical path: C-2 → B-add-1 → C-5 → C-7 → C-11 → C-12 → C-13 → C-19 (~8 sequential 단계).
총 PR: rebuild 19 + addendum 1 = 20 PR. 추정 6~10 세션 (이전 12~25에서 단축).

결정 잠금 (사용자 승인 2026-05-02):
1. VocAssignee colorCls 6 토큰 → Phase B addendum 별도 PR
2. AppShell → Phase D에서 일괄 점검 (Phase C rebuild 제외)
3. Topbar(C-19) → β의 NotifButton 머지 후 시작

## Test plan
- [ ] 문서만 수정. 코드/테스트 영향 없음
- [ ] typecheck 통과 (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)