### PR TITLE
docs: per-folder CLAUDE.md for token-efficient navigation

### DIFF
--- a/.claude/hookify.warn-doc-cleanup-before-pr.local.md
+++ b/.claude/hookify.warn-doc-cleanup-before-pr.local.md
@@ -5,18 +5,24 @@ event: bash
 pattern: gh\s+pr\s+(create|merge)
 ---
 
-📋 **PR 생성/머지 전 문서 정리 체크리스트** (정본: `docs/specs/README.md §5` 7단계)
+📋 **Pre-PR doc cleanup checklist** (canonical: `docs/specs/README.md §5`)
 
-이 PR로 phase/wave/PR이 닫히면 **머지 전에** 다음 정리를 1회 수행하라:
+If this PR closes a phase / wave / PR, do the following once before the merge:
 
-1. `claude-progress.txt` 첫 30줄 갱신 — 본 PR 결과를 "다음 세션 시작점" 절에 반영. 이미 완료되어 더 참조 불필요한 phase 항목 제거 (claude-progress.txt는 활성 컨텍스트만)
-2. `docs/specs/plans/next-session-tasks.md` 갱신 — 본 PR로 종결된 항목 ✅ 표기, 다음 진입점 명시
-3. `docs/specs/reviews/` 의 본 PR 관련 리뷰 문서가 더 이상 참조 불필요하면 `docs/specs/reviews/done/` 으로 `git mv` (archive는 정본 인용 금지)
-4. `docs/specs/plans/` 의 종료된 plan 파일이 있다면 `docs/specs/plans/done/` 으로 `git mv`
-5. 머지된 phase의 본문 내용이 다른 active doc에서 인용 중이면 인용을 직접 fact로 풀거나 link만 유지 (archive 인용 금지)
-6. `phase-*.md` Changelog 한 줄 추가 — 본 PR 머지 결과 (한 줄, 날짜 + ID + 요약)
-7. typecheck/lint clean 재확인 — doc 정리로 인한 코드 영향 없는지
+1. Update first 30 lines of `claude-progress.txt` — reflect this PR in the next-session entry point. Remove phase entries no longer needed (active context only).
+2. Update `docs/specs/plans/next-session-tasks.md` — ✅ closed items, state next entry point.
+3. `git mv` review docs under `docs/specs/reviews/` to `reviews/done/` if no longer needed (archives are not canonical).
+4. `git mv` finished plans under `docs/specs/plans/` to `plans/done/`.
+5. If a merged phase is quoted by an active doc, inline the fact or keep only a link (no archive citations).
+6. Append a one-line Changelog entry to the relevant `phase-*.md` (date + ID + summary).
+7. **Refresh `CLAUDE.md` for every folder this PR touched — only if it earns its tokens.** A redundant child is a net loss (auto-loaded on entry).
+   - **Update** when role / "when to look where" / cross-file invariants changed.
+   - **Create only if** the folder carries signal a future session can't infer from the folder name, parent `CLAUDE.md`, or a single `ls`.
+   - **Do not create** in: `__tests__/`, `__snapshots__/`, `cache/`, `done/`, leaf `screenshots/`, gitignored runtime dirs, dot-folders.
+   - **Delete** an existing child if its content collapses to a paraphrase of the folder name or parent.
+   - Scope: only `## Role` and `## When to look where` sections.
+8. Re-verify typecheck/lint clean.
 
-**예외**: docs/<topic> 단독 PR이거나 trivial 1-line fix면 위 절차 생략 가능. 사용자 결정.
+**Exceptions:** `docs/<topic>` branch or trivial 1-line fixes may skip. User decides.
 
-**위 7단계는 본 PR `gh pr create` 또는 `gh pr merge` 직전 1회만 트리거됨.** 이미 수행했으면 무시하고 진행.
+**Fires once before `gh pr create` or `gh pr merge`.** If done already, ignore.

--- a/backend/config/CLAUDE.md
+++ b/backend/config/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/config/CLAUDE.md
+
+## Role
+
+Static configuration data loaded by the backend at boot.
+
+## When to look where
+
+- Master data (enums, lookup tables) seeded into the DB or served via `external-masters` endpoints → `masters/`
+- Spec for master data shape → `docs/specs/requires/external-masters.md`
+- Schema for master files → `shared/contracts/master/`

--- a/backend/config/masters/CLAUDE.md
+++ b/backend/config/masters/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/config/masters/CLAUDE.md
+
+## Role
+
+Master data files (JSON/CSV) for VOC types, statuses, departments, and other lookups.
+
+## When to look where
+
+- Adding/changing a master entry → file here, plus matching fixture in `shared/fixtures/`
+- Schema reference → `shared/contracts/master/`
+- Spec → `docs/specs/requires/external-masters.md`

--- a/backend/migrations/CLAUDE.md
+++ b/backend/migrations/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/migrations/CLAUDE.md
+
+## Role
+
+Sequential append-only SQL migrations applied in numeric order. Filename pattern: `NNN_description.sql`.
+
+## When to look where
+
+- Current schema state → latest numbered migration (013 as of Wave 1.5-β: dev role + voc origin metadata)
+- pgvector setup → first migration (`CREATE EXTENSION vector` runs before any DDL)
+- Schema overview, business meaning of columns → `backend/CLAUDE.md` and `docs/specs/requires/requirements.md`

--- a/backend/seeds/CLAUDE.md
+++ b/backend/seeds/CLAUDE.md
@@ -1,0 +1,10 @@
+# backend/seeds/CLAUDE.md
+
+## Role
+
+Database seed data for dev/test. Mirrors `shared/fixtures/` so FE mocks and BE tests see the same IDs and shapes.
+
+## When to look where
+
+- Adding/changing a seed → here, plus matching fixture in `shared/fixtures/`
+- Parity check (CI) → `scripts/check-fixture-seed-parity.ts`

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -1,0 +1,19 @@
+# backend/src/CLAUDE.md
+
+## Role
+
+Backend source. Layered: `routes/` → `controllers/` → `services/` → `repository/`.
+
+## When to look where
+
+- App bootstrap → `index.ts`
+- Postgres pool + pgvector → `db.ts`
+- Structured logger → `logger.ts`
+- Auth (mockLogin, AD session stub) → `auth/`
+- HTTP route definitions → `routes/`
+- Thin HTTP adapters (parse/validate/delegate) → `controllers/`
+- Domain logic (auto-tag, permissions, side-effects) → `services/`
+- SQL queries → `repository/`
+- Express middleware → `middleware/`
+- zod-to-Express adapters → `validators/`
+- Cross-layer integration tests → `__tests__/`

--- a/backend/src/auth/CLAUDE.md
+++ b/backend/src/auth/CLAUDE.md
@@ -1,0 +1,12 @@
+# backend/src/auth/CLAUDE.md
+
+## Role
+
+Authentication primitives. Currently dev-mode only; AD/OIDC lands in Phase 9.
+
+## When to look where
+
+- Dev login (`POST /api/auth/mock-login`, 4 roles) → mockLogin module
+- AD session middleware (stub for Phase 9) → `validateADSession`
+- Auth helper unit tests → `__tests__/`
+- Permission decisions (not auth) → `services/permissions/`

--- a/backend/src/controllers/CLAUDE.md
+++ b/backend/src/controllers/CLAUDE.md
@@ -1,0 +1,12 @@
+# backend/src/controllers/CLAUDE.md
+
+## Role
+
+Thin HTTP adapters — parse, validate, delegate to a service, format the response. No business logic.
+
+## When to look where
+
+- Tracing a request from route → service → here is the pass-through
+- Request shaping / response formatting decisions → here
+- Validation wiring → `validators/`
+- Error → HTTP status mapping → `middleware/`

--- a/backend/src/middleware/CLAUDE.md
+++ b/backend/src/middleware/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/src/middleware/CLAUDE.md
+
+## Role
+
+Express middleware — auth, logging, error mapping, request ID, CORS.
+
+## When to look where
+
+- Why an error returned a specific HTTP status → error middleware (single source of HTTP status from exceptions)
+- Where auth runs in the request lifecycle → auth middleware here
+- Cross-cutting request concerns (logging, request ID) → here

--- a/backend/src/repository/CLAUDE.md
+++ b/backend/src/repository/CLAUDE.md
@@ -1,0 +1,12 @@
+# backend/src/repository/CLAUDE.md
+
+## Role
+
+Persistence layer — SQL queries against Postgres. The only place that touches `db.ts`.
+
+## When to look where
+
+- A specific table query or join → repo file for that resource
+- Hierarchical VOC tree queries (`parent_id` self-join) → VOC repository
+- Schema overview → `backend/CLAUDE.md`
+- Domain logic (not SQL) → `services/`

--- a/backend/src/routes/CLAUDE.md
+++ b/backend/src/routes/CLAUDE.md
@@ -1,0 +1,12 @@
+# backend/src/routes/CLAUDE.md
+
+## Role
+
+Express route definitions — wire URL + method + middleware + controller. Declarative; no logic.
+
+## When to look where
+
+- Finding the entry point for a URL → here
+- Validation hookup for a route → `validators/`
+- REST contract reference → `shared/openapi.yaml`
+- Route-level integration tests → `__tests__/`

--- a/backend/src/services/CLAUDE.md
+++ b/backend/src/services/CLAUDE.md
@@ -1,0 +1,12 @@
+# backend/src/services/CLAUDE.md
+
+## Role
+
+Business logic. Coordinates repositories, enforces domain rules, runs side-effects (auto-tagging, notifications).
+
+## When to look where
+
+- Permission checks (`assertCanManageVoc`) → `permissions/`
+- Auto-tagging, notifications, hierarchy rules → service file for the resource
+- Behavioral spec → `docs/specs/requires/feature-voc.md` (and related `feature-*.md`)
+- HTTP/SQL details (not business rules) → `controllers/` and `repository/`

--- a/backend/src/services/permissions/CLAUDE.md
+++ b/backend/src/services/permissions/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/src/services/permissions/CLAUDE.md
+
+## Role
+
+Single source of permission truth. `assertCanManageVoc(user, voc, action)` is the entry point used everywhere.
+
+## When to look where
+
+- Asking "can role X do action Y on resource Z" → here
+- Matrix spec (role × action × ownership) → `docs/specs/requires/feature-voc.md §8.4-bis`
+- Tests covering the matrix → `__tests__/`

--- a/backend/src/validators/CLAUDE.md
+++ b/backend/src/validators/CLAUDE.md
@@ -1,0 +1,11 @@
+# backend/src/validators/CLAUDE.md
+
+## Role
+
+Express middleware that wires zod schemas (from `shared/contracts/`) into routes for input validation.
+
+## When to look where
+
+- Wiring/changing input validation for a route → here
+- Schema definitions themselves → `shared/contracts/`
+- Error response shape → `middleware/` (error mapper)

--- a/benchmark/CLAUDE.md
+++ b/benchmark/CLAUDE.md
@@ -1,0 +1,11 @@
+# benchmark/CLAUDE.md
+
+## Role
+
+Visual ground-truth PNGs (`01-…` through `22-…`) for the implemented UI. Compared against frontend output by `scripts/visual-diff.ts`.
+
+## When to look where
+
+- About to implement a screen → open the matching numbered PNG to confirm the intended visual
+- "Which PNG is which screen" → `INDEX.md`
+- Adding a new screen → add a new baseline + a row in `INDEX.md`

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,14 @@
+# docs/CLAUDE.md
+
+## Role
+
+Canonical documentation tree for the project — the single source of truth for everything decided outside the code.
+
+## When to look where
+
+- Phase/wave cleanup procedure for this PR → `specs/README.md`
+- What phase/wave we're currently on → root `claude-progress.txt`, then `specs/plans/next-session-tasks.md`
+- Product requirements / feature definitions → `specs/requires/`
+- Active vs finished plans → `specs/plans/` (closed ones in `plans/done/`)
+- Reviews and audit traces → `specs/reviews/` (closed ones in `reviews/done/`)
+- Reference images embedded by specs → `screenshots/`

--- a/docs/screenshots/CLAUDE.md
+++ b/docs/screenshots/CLAUDE.md
@@ -1,0 +1,10 @@
+# docs/screenshots/CLAUDE.md
+
+## Role
+
+Reference images cited by `docs/specs/**`.
+
+## When to look where
+
+- A spec embeds an image → find it here
+- Wave-scoped captures → wave subfolders like `wave-1-6/`

--- a/docs/specs/CLAUDE.md
+++ b/docs/specs/CLAUDE.md
@@ -1,0 +1,13 @@
+# docs/specs/CLAUDE.md
+
+## Role
+
+The canonical spec tree, split into requirements / plans / reviews. The doc-hygiene policy itself lives in `README.md`.
+
+## When to look where
+
+- Where to put a doc, when to archive it → `README.md`
+- "What" we're building (stable, long-lived) → `requires/`
+- "How/when" we're building it (mutable) → `plans/` (closed → `plans/done/`)
+- Review and adversarial-audit traces → `reviews/` (closed → `reviews/done/`)
+- Images cited by specs → `screenshots/`

--- a/docs/specs/plans/CLAUDE.md
+++ b/docs/specs/plans/CLAUDE.md
@@ -1,0 +1,16 @@
+# docs/specs/plans/CLAUDE.md
+
+## Role
+
+Active implementation plans — phase/wave/feature roadmaps. Mutable; finished plans move to `done/`.
+
+## When to look where
+
+- Current entry point for the next session → `next-session-tasks.md`
+- NextGen / future backlog → `nextgen-backlog.md`
+- Phase 8 plan trees → `phase-8*.md`
+- Wave 1.5 follow-up plans → `wave1.5-followup-a-*.md`
+- Wave 1.6 plan + precedent → `wave-1-6-voc-parity.md`, `wave-1-6-phase-c-precedent.md`
+- Migration drafts → `migration-*-draft.md`
+- Closed/archived plans (do not cite as source of truth) → `done/`
+- Long-tail history → `progress-archive.md`

--- a/docs/specs/requires/CLAUDE.md
+++ b/docs/specs/requires/CLAUDE.md
@@ -1,0 +1,15 @@
+# docs/specs/requires/CLAUDE.md
+
+## Role
+
+Stable, long-lived product/design requirements. The "what" of the system.
+
+## When to look where
+
+- Top-level product spec (data model, flows) → `requirements.md`
+- Feature-scoped requirements → `feature-voc.md`, `feature-notice-faq.md`
+- Dashboard requirements → `dashboard.md`
+- Design tokens, typography, spacing → `uidesign.md`
+- External master data shape → `external-masters.md`
+- VOC prototype decomposition reference → `voc-prototype-decomposition.md`
+- Subfolder readme / index of requires → `README.md`

--- a/docs/specs/reviews/CLAUDE.md
+++ b/docs/specs/reviews/CLAUDE.md
@@ -1,0 +1,12 @@
+# docs/specs/reviews/CLAUDE.md
+
+## Role
+
+Active reviews, adversarial audits, and supporting screenshots.
+
+## When to look where
+
+- Wave 1.6 VOC badge audit → `wave-1-6-voc-badge-audit.md`
+- Wave 1.5 follow-up review tree → `wave1.5-followup-a/`
+- Spot-check screenshots used by reviews → `c-5-voc-assignee*.png`
+- Closed reviews (do not cite as source of truth) → `done/`

--- a/docs/specs/reviews/wave1.5-followup-a/CLAUDE.md
+++ b/docs/specs/reviews/wave1.5-followup-a/CLAUDE.md
@@ -1,0 +1,10 @@
+# docs/specs/reviews/wave1.5-followup-a/CLAUDE.md
+
+## Role
+
+Review and supporting evidence for Wave 1.5 Follow-up A (PR #125 line).
+
+## When to look where
+
+- Review notes and decisions for Follow-up A → markdown files here
+- Visual evidence for the review → `screenshots/`

--- a/frontend/docs/CLAUDE.md
+++ b/frontend/docs/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/docs/CLAUDE.md
+
+## Role
+
+Frontend-local docs (screenshots, FE-only notes). Canonical product/design specs live in `docs/specs/` at repo root.
+
+## When to look where
+
+- FE-side capture during development → `screenshots/`
+- Wave-scoped FE evidence → `screenshots/<wave>/`
+- Authoritative product/design spec → root `docs/specs/`

--- a/frontend/e2e/CLAUDE.md
+++ b/frontend/e2e/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/e2e/CLAUDE.md
+
+## Role
+
+End-to-end browser tests (Playwright). Component/unit tests live in Vitest under `src/**/__tests__/`.
+
+## When to look where
+
+- A user flow spans pages/routes → here
+- A regression depends on real browser behavior (focus, keyboard, scroll) → here
+- Component-level coverage → Vitest under `src/`

--- a/frontend/eslint-rules/CLAUDE.md
+++ b/frontend/eslint-rules/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/eslint-rules/CLAUDE.md
+
+## Role
+
+Project-local custom ESLint rules (e.g. token-purity: no hex/raw OKLCH outside `src/tokens.ts`).
+
+## When to look where
+
+- Token-purity check failed → rule source here
+- Adding a new project-specific lint rule → here, then wire into `.eslintrc.base.js`

--- a/frontend/public/CLAUDE.md
+++ b/frontend/public/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/public/CLAUDE.md
+
+## Role
+
+Vite static-asset directory — files served verbatim from site root.
+
+## When to look where
+
+- Self-hosted webfonts (Pretendard Variable, D2Coding) → `fonts/`
+- Anything served at a fixed root URL → here, referenced as `/path` (no relative imports)

--- a/frontend/public/fonts/CLAUDE.md
+++ b/frontend/public/fonts/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/public/fonts/CLAUDE.md
+
+## Role
+
+Self-hosted webfonts (Pretendard Variable for UI, D2Coding for code/issue IDs).
+
+## When to look where
+
+- Font files referenced by `@font-face` in `src/styles/`
+- Typography spec → `docs/specs/requires/uidesign.md`

--- a/frontend/src/CLAUDE.md
+++ b/frontend/src/CLAUDE.md
@@ -1,0 +1,22 @@
+# frontend/src/CLAUDE.md
+
+## Role
+
+Frontend application source.
+
+## When to look where
+
+- Vite entry → `main.tsx`
+- Route table → `router.tsx`
+- Design token SSOT (Tailwind config + CSS vars derive from this) → `tokens.ts`
+- HTTP clients + react-query hooks → `api/`
+- Page-level route components → `pages/`
+- Reusable UI (generic / layout / shadcn / VOC table) → `components/{common,layout,ui,voc}/`
+- Feature-scoped UI + logic → `features/<feature>/`
+- Cross-feature primitives (badges, etc.) → `shared/ui/`
+- Custom hooks → `hooks/`
+- Pure helpers, no React → `lib/`
+- MSW handlers + test fixtures → `mocks/`
+- Global CSS / CSS-vars layer → `styles/`
+- Test setup, providers, harnesses → `test/`
+- App-level state (providers/contexts) → `contexts/`

--- a/frontend/src/api/CLAUDE.md
+++ b/frontend/src/api/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/api/CLAUDE.md
+
+## Role
+
+HTTP clients and react-query hooks — the single boundary between FE and the backend.
+
+## When to look where
+
+- A specific resource's calls (`vocs.ts`, `comments.ts`, …) → file per resource
+- Types / runtime schemas → `shared/types/`, `shared/contracts/`
+- Tests using MSW handlers → `__tests__/`

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -1,0 +1,13 @@
+# frontend/src/components/CLAUDE.md
+
+## Role
+
+Reusable UI components shared across pages/features.
+
+## When to look where
+
+- Generic widgets (loaders, error boundaries, formatters) → `common/`
+- App shell (navbar, sidebar, drawer host) → `layout/`
+- shadcn/ui derivatives (Radix primitives, token-aligned) → `ui/`
+- VOC list/row/header table parts → `voc/`
+- Feature-only UI → `src/features/<feature>/components/` (not here)

--- a/frontend/src/components/common/CLAUDE.md
+++ b/frontend/src/components/common/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/components/common/CLAUDE.md
+
+## Role
+
+Generic, app-agnostic widgets — error boundaries, loaders, date/text formatters.
+
+## When to look where
+
+- Reaching for a small reusable widget (no domain coupling) → here
+- Tests → `__tests__/`
+- Domain-coupled component (e.g. references "VOC") → `components/voc/` or `features/voc/`

--- a/frontend/src/components/layout/CLAUDE.md
+++ b/frontend/src/components/layout/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/components/layout/CLAUDE.md
+
+## Role
+
+App shell — navbar, sidebar, page frames, drawer host. Owns viewport-level concerns.
+
+## When to look where
+
+- Navigation chrome, sidebar/drawer host, scroll containers → here
+- Routing decisions → `router.tsx`
+- Visual proportions and tokens → `docs/specs/requires/uidesign.md`

--- a/frontend/src/components/ui/CLAUDE.md
+++ b/frontend/src/components/ui/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/components/ui/CLAUDE.md
+
+## Role
+
+shadcn/ui derivatives — Radix primitives wrapped with project token-aligned styling. Ghost buttons, translucent cards, border-focused inputs.
+
+## When to look where
+
+- Button / Card / Input / Dialog / Popover primitives → here
+- Token rewrite after a fresh shadcn pull → `scripts/shadcn-token-rewrite.ts`
+- Domain-specific composition → use these as building blocks in `components/voc/` or `features/`

--- a/frontend/src/components/voc/CLAUDE.md
+++ b/frontend/src/components/voc/CLAUDE.md
@@ -1,0 +1,13 @@
+# frontend/src/components/voc/CLAUDE.md
+
+## Role
+
+VOC list/table components — header, row, table composition (Wave 1.6 C-7 result).
+
+## When to look where
+
+- Row rendering, grid layout, ARIA roles → `VocRow.tsx`
+- Header (sticky, role=row) → `VocListHeader.tsx`
+- Table composition (header + rows) → `VocTable.tsx`
+- Token-purity CSS markers → `src/styles/index.css` (C-7 marker block)
+- Tests → `__tests__/`

--- a/frontend/src/components/voc/__tests__/CLAUDE.md
+++ b/frontend/src/components/voc/__tests__/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/src/components/voc/**tests**/CLAUDE.md
+
+## Role
+
+Vitest tests for VOC table components.
+
+## When to look where
+
+- Row/header rendering, gridcell ARIA, token purity → tests here
+- Note: `getAllByRole('cell')` does not match `gridcell` (testing-library limitation) — use `'gridcell'` directly

--- a/frontend/src/contexts/CLAUDE.md
+++ b/frontend/src/contexts/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/contexts/CLAUDE.md
+
+## Role
+
+App-level React contexts — providers for global filter, drawer state, selection, auth session.
+
+## When to look where
+
+- Cross-page state shared by multiple features → here
+- Tests for provider behavior → `__tests__/`
+- Local component state → keep in the component, not here

--- a/frontend/src/features/CLAUDE.md
+++ b/frontend/src/features/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/src/features/CLAUDE.md
+
+## Role
+
+Feature-scoped UI + logic. Pages compose features; features own the components and hooks specific to them.
+
+## When to look where
+
+- VOC feature (list view composition, filters, drawer wiring) → `voc/`
+- Cross-feature reusable primitives → `src/components/` or `src/shared/ui/`

--- a/frontend/src/features/voc/CLAUDE.md
+++ b/frontend/src/features/voc/CLAUDE.md
@@ -1,0 +1,12 @@
+# frontend/src/features/voc/CLAUDE.md
+
+## Role
+
+VOC feature implementation — components, hooks, and logic specific to the VOC list/drawer/create flow.
+
+## When to look where
+
+- Feature-specific components → `components/`
+- Feature-specific tests → `components/__tests__/`
+- Cross-feature VOC primitives (table parts) → `src/components/voc/`
+- Spec → `docs/specs/requires/feature-voc.md`

--- a/frontend/src/features/voc/components/CLAUDE.md
+++ b/frontend/src/features/voc/components/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/features/voc/components/CLAUDE.md
+
+## Role
+
+Components used only by the VOC feature (filters, drawer body, create modal pieces).
+
+## When to look where
+
+- VOC-only UI not reused elsewhere → here
+- Reusable VOC table parts (used by multiple pages) → `src/components/voc/`
+- Tests → `__tests__/`

--- a/frontend/src/hooks/CLAUDE.md
+++ b/frontend/src/hooks/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/hooks/CLAUDE.md
+
+## Role
+
+App-wide custom hooks — `useVOCFilter`, `useAutoTag`, `useDrawer`, etc.
+
+## When to look where
+
+- Cross-feature behavior abstracted as a hook → here
+- API-specific hooks (`useXxxQuery`) → `src/api/`
+- Feature-only hooks → `src/features/<feature>/`

--- a/frontend/src/lib/CLAUDE.md
+++ b/frontend/src/lib/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/src/lib/CLAUDE.md
+
+## Role
+
+Pure helpers — no React, no DOM. Date formatting, sorting, parsing, predicates.
+
+## When to look where
+
+- A small pure utility you'd unit-test in isolation → here
+- React-specific helpers → `hooks/` or component utility files

--- a/frontend/src/mocks/CLAUDE.md
+++ b/frontend/src/mocks/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/mocks/CLAUDE.md
+
+## Role
+
+MSW v2 mocks for development and tests.
+
+## When to look where
+
+- Per-resource handlers → `handlers/`
+- Handler tests → `handlers/__tests__/`
+- Shared fixture data → `shared/fixtures/` (parity with `backend/seeds/`)

--- a/frontend/src/mocks/handlers/CLAUDE.md
+++ b/frontend/src/mocks/handlers/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/src/mocks/handlers/CLAUDE.md
+
+## Role
+
+MSW handlers — one file per resource. Backend-shaped responses for FE dev + tests.
+
+## When to look where
+
+- Stubbing a new endpoint for FE dev/test → handler file per resource
+- Fixture data drawn from → `shared/fixtures/`

--- a/frontend/src/pages/CLAUDE.md
+++ b/frontend/src/pages/CLAUDE.md
@@ -1,0 +1,12 @@
+# frontend/src/pages/CLAUDE.md
+
+## Role
+
+Route-level components. Each file maps to one route in `router.tsx`.
+
+## When to look where
+
+- Layout/composition of a route → page file here
+- Feature implementation that the page renders → `src/features/<feature>/`
+- Reusable building blocks → `src/components/`
+- Tests → `__tests__/`

--- a/frontend/src/shared/CLAUDE.md
+++ b/frontend/src/shared/CLAUDE.md
@@ -1,0 +1,9 @@
+# frontend/src/shared/CLAUDE.md
+
+## Role
+
+Cross-feature primitives that don't belong to any one feature but aren't generic enough for `components/common/`.
+
+## When to look where
+
+- Cross-feature UI atoms (badges, chips, tag-style primitives) → `ui/`

--- a/frontend/src/shared/ui/CLAUDE.md
+++ b/frontend/src/shared/ui/CLAUDE.md
@@ -1,0 +1,10 @@
+# frontend/src/shared/ui/CLAUDE.md
+
+## Role
+
+Cross-feature UI primitives. Token-aligned, reused by multiple features.
+
+## When to look where
+
+- Badge system (3 primitives + 4 semantic wrappers) → `badge/`
+- Adding a new cross-feature atom → here, with `__tests__/`

--- a/frontend/src/shared/ui/badge/CLAUDE.md
+++ b/frontend/src/shared/ui/badge/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/shared/ui/badge/CLAUDE.md
+
+## Role
+
+Badge system — 3 base primitives + 4 semantic wrappers (status / priority / type / count). Chip token SSOT lives here.
+
+## When to look where
+
+- Picking a badge variant → semantic wrapper first, primitive only if no semantic match
+- Adding a new semantic wrapper → here, plus chip tokens (don't introduce new colors)
+- Tests → `__tests__/`

--- a/frontend/src/styles/CLAUDE.md
+++ b/frontend/src/styles/CLAUDE.md
@@ -1,0 +1,12 @@
+# frontend/src/styles/CLAUDE.md
+
+## Role
+
+Global CSS — `@font-face`, CSS-vars layer (derived from `tokens.ts`), reset, top-level utilities. C-marker blocks (e.g. C-7) live in `index.css`.
+
+## When to look where
+
+- Global CSS variable definitions → `index.css`
+- Token-purity marker blocks for component CSS (C-6, C-7, …) → `index.css`
+- Font face declarations → `index.css`
+- Tests for marker purity → `__tests__/`

--- a/frontend/src/test/CLAUDE.md
+++ b/frontend/src/test/CLAUDE.md
@@ -1,0 +1,11 @@
+# frontend/src/test/CLAUDE.md
+
+## Role
+
+Test infrastructure — Vitest setup, providers, MSW server bootstrap, custom render helpers.
+
+## When to look where
+
+- Vitest globals / setup → setup file here
+- Custom `render(...)` wrapping providers → here
+- MSW server start/stop hooks → here

--- a/prototype/css/CLAUDE.md
+++ b/prototype/css/CLAUDE.md
@@ -1,0 +1,12 @@
+# prototype/css/CLAUDE.md
+
+## Role
+
+Prototype CSS, split into modules (each file ≤500 lines). Spec: `docs/specs/requires/uidesign.md §10`.
+
+## When to look where
+
+- Admin-page styles → `admin/`
+- Reusable component styles (cards, buttons, lists) → `components/`
+- Layout / shell / grid → `layout/`
+- Tokens (defined in root prototype CSS) → top of the prototype CSS chain

--- a/prototype/css/admin/CLAUDE.md
+++ b/prototype/css/admin/CLAUDE.md
@@ -1,0 +1,10 @@
+# prototype/css/admin/CLAUDE.md
+
+## Role
+
+Admin-page-only styles for the prototype.
+
+## When to look where
+
+- Tag rules / system menu / VOC type / users / notices / FAQ admin screens → files here
+- Cross-page styles → `prototype/css/components/` or `prototype/css/layout/`

--- a/prototype/css/components/CLAUDE.md
+++ b/prototype/css/components/CLAUDE.md
@@ -1,0 +1,10 @@
+# prototype/css/components/CLAUDE.md
+
+## Role
+
+Reusable prototype component styles — cards, buttons, badges, drawers, modals, tables.
+
+## When to look where
+
+- Visual reference for an FE component being implemented → matching file here
+- Layout-level styles → `prototype/css/layout/`

--- a/prototype/css/layout/CLAUDE.md
+++ b/prototype/css/layout/CLAUDE.md
@@ -1,0 +1,10 @@
+# prototype/css/layout/CLAUDE.md
+
+## Role
+
+App shell, grid, and structural layout styles for the prototype.
+
+## When to look where
+
+- Navbar, sidebar, page frame proportions → here
+- Component-level styles → `prototype/css/components/`

--- a/prototype/js/CLAUDE.md
+++ b/prototype/js/CLAUDE.md
@@ -1,0 +1,11 @@
+# prototype/js/CLAUDE.md
+
+## Role
+
+Classic-script JS modules driving the prototype. 16+ files; data exposed on `window` via explicit aliases in `data.js` (no auto-attach for `const`).
+
+## When to look where
+
+- Mock data shape (the source of truth for prototype-driven UX) → `data.js`
+- Behavior of a specific screen → matching script file
+- Stage A-2 / A-4 split rationale → `docs/specs/plans/done/prototype-phase7-wave3-plan.md`

--- a/prototype/scripts/CLAUDE.md
+++ b/prototype/scripts/CLAUDE.md
@@ -1,0 +1,10 @@
+# prototype/scripts/CLAUDE.md
+
+## Role
+
+Playwright-driven smoke verification + tooling helpers for the prototype.
+
+## When to look where
+
+- Prototype smoke / capture scripts → here
+- Generated graph artifacts (per-prototype graphify run) → `graphify-out/`

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,11 @@
+# scripts/CLAUDE.md
+
+## Role
+
+Repo-level utilities — codemods, parity checks, visual diff. Not application code.
+
+## When to look where
+
+- `shared/fixtures` ↔ `backend/seeds` parity broken → `check-fixture-seed-parity.ts`
+- New shadcn component pulled in, needs token rewrite → `shadcn-token-rewrite.ts`
+- Prototype vs frontend visual diff → `visual-diff.ts` + `visual-diff/`

--- a/scripts/visual-diff/CLAUDE.md
+++ b/scripts/visual-diff/CLAUDE.md
@@ -1,0 +1,11 @@
+# scripts/visual-diff/CLAUDE.md
+
+## Role
+
+Helper modules and tests used by `scripts/visual-diff.ts` to compare prototype baselines against frontend output.
+
+## When to look where
+
+- Tuning diff algorithm or thresholds → modules here
+- Baseline path / naming conventions → top of the modules
+- Regression coverage → `__tests__/`

--- a/shared/CLAUDE.md
+++ b/shared/CLAUDE.md
@@ -1,0 +1,13 @@
+# shared/CLAUDE.md
+
+## Role
+
+Types, schemas, and fixtures used by **both** `frontend/` and `backend/`. The single contract surface neither side owns alone.
+
+## When to look where
+
+- Domain types shared by FE/BE → `types/`
+- zod schemas (runtime validation, form + route input from one source) → `contracts/`
+- Mock + seed shared data → `fixtures/`
+- REST contract reference → `openapi.yaml`
+- Workspace config → `package.json`, `tsconfig.json`

--- a/shared/contracts/CLAUDE.md
+++ b/shared/contracts/CLAUDE.md
@@ -1,0 +1,11 @@
+# shared/contracts/CLAUDE.md
+
+## Role
+
+zod schemas — single source of runtime validation for FE forms and BE route input. Same shape, same error messages, both sides.
+
+## When to look where
+
+- VOC schemas (create/update/list/filter) → `voc/`
+- Notification schemas → `notification/`
+- Master data schemas (lookups, enums) → `master/`

--- a/shared/contracts/master/CLAUDE.md
+++ b/shared/contracts/master/CLAUDE.md
@@ -1,0 +1,11 @@
+# shared/contracts/master/CLAUDE.md
+
+## Role
+
+zod schemas for master data (lookup tables, enums, departments, statuses).
+
+## When to look where
+
+- Master data shape used by either side → here
+- Source data files → `backend/config/masters/`
+- Spec → `docs/specs/requires/external-masters.md`

--- a/shared/contracts/notification/CLAUDE.md
+++ b/shared/contracts/notification/CLAUDE.md
@@ -1,0 +1,10 @@
+# shared/contracts/notification/CLAUDE.md
+
+## Role
+
+zod schemas for notifications.
+
+## When to look where
+
+- Wiring notification payloads (FE display + BE emit) → here
+- Behavioral spec → `docs/specs/requires/feature-voc.md` and related

--- a/shared/contracts/voc/CLAUDE.md
+++ b/shared/contracts/voc/CLAUDE.md
@@ -1,0 +1,10 @@
+# shared/contracts/voc/CLAUDE.md
+
+## Role
+
+zod schemas for the VOC resource — create, update, query, filter shapes consumed by FE forms and BE validators.
+
+## When to look where
+
+- Wiring a VOC form on FE or a VOC route on BE → here
+- Spec for VOC fields/enums → `docs/specs/requires/feature-voc.md`

--- a/shared/fixtures/CLAUDE.md
+++ b/shared/fixtures/CLAUDE.md
@@ -1,0 +1,10 @@
+# shared/fixtures/CLAUDE.md
+
+## Role
+
+Test/seed data shared by FE MSW handlers and BE seed scripts. Parity is enforced by `scripts/check-fixture-seed-parity.ts`.
+
+## When to look where
+
+- Adding a new mock VOC/comment/etc → here, plus matching seed in `backend/seeds/`
+- Looking up a known fixture ID used in tests → here

--- a/shared/types/CLAUDE.md
+++ b/shared/types/CLAUDE.md
@@ -1,0 +1,10 @@
+# shared/types/CLAUDE.md
+
+## Role
+
+TypeScript types referenced by both FE and BE — domain entities, enums, response shapes.
+
+## When to look where
+
+- Looking up a domain entity's shape → here first
+- Type used by only one side → keep it in that side's app, not here


### PR DESCRIPTION
## Summary

- Add \`## Role\` + \`## When to look where\` CLAUDE.md to every non-dot subfolder where the signal isn't obvious from the folder name or parent
- Skip noise folders (\`__tests__/\`, \`__snapshots__/\`, \`cache/\`, \`done/\`, leaf screenshots, gitignored runtime dirs) to avoid net-loss overhead from auto-loading
- Translate the pre-PR doc-cleanup hook to English and add **step 7**: refresh folder CLAUDE.md only when it earns its tokens (scoped to navigational sections)

## Test plan

- [x] typecheck (FE+BE) clean
- [x] FE lint + token-purity check clean
- [x] FE 303 tests + BE 99 tests green