### PR TITLE
chore(claude): add serena-hooks lifecycle hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,46 @@
             "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks remind --client=claude-code"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__serena__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks auto-approve --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks activate --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks cleanup --client=claude-code"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Wire `serena-hooks` into `.claude/settings.json`: PreToolUse remind + auto-approve `mcp__serena__*`, SessionStart activate, Stop cleanup.

## Test plan
- [x] `jq .` validates settings.json
- [x] `serena-hooks` binary present in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)