### PR TITLE
docs(hookify): restore detailed pre-PR cleanup checklist

### DIFF
--- a/.claude/hookify.warn-doc-cleanup-before-pr.local.md
+++ b/.claude/hookify.warn-doc-cleanup-before-pr.local.md
@@ -9,9 +9,19 @@ pattern: gh\s+pr\s+(create|merge)
 
 If this PR closes a phase / wave / PR, do this once before the merge:
 
-1. Run `docs/specs/README.md §5` cleanup.
-2. Apply `docs/specs/README.md §7` folder `CLAUDE.md` refresh policy for touched folders.
-3. Re-verify typecheck/lint clean.
+1. Update first 30 lines of `claude-progress.txt` — reflect this PR in the next-session entry point. Remove phase entries no longer needed (active context only).
+2. Update `docs/specs/plans/next-session-tasks.md` — ✅ closed items, state next entry point.
+3. `git mv` review docs under `docs/specs/reviews/` to `reviews/done/` if no longer needed (archives are not canonical).
+4. `git mv` finished plans under `docs/specs/plans/` to `plans/done/`.
+5. If a merged phase is quoted by an active doc, inline the fact or keep only a link (no archive citations).
+6. Append a one-line Changelog entry to the relevant `phase-*.md` (date + ID + summary).
+7. **Refresh `CLAUDE.md` for every folder this PR touched — only if it earns its tokens.** A redundant child is a net loss (auto-loaded on entry).
+   - **Update** when role / "when to look where" / cross-file invariants changed.
+   - **Create only if** the folder carries signal a future session can't infer from the folder name, parent `CLAUDE.md`, or a single `ls`.
+   - **Do not create** in: `__tests__/`, `__snapshots__/`, `cache/`, `done/`, leaf `screenshots/`, gitignored runtime dirs, dot-folders.
+   - **Delete** an existing child if its content collapses to a paraphrase of the folder name or parent.
+   - Scope: only `## Role` and `## When to look where` sections.
+8. Re-verify typecheck/lint clean.
 
 **Exceptions:** `docs/<topic>` branch or trivial 1-line fixes may skip. User decides.
 


### PR DESCRIPTION
## Summary

- Reverts `warn-doc-cleanup-before-pr` body to the explicit 8-step checklist (progress doc, next-session-tasks, reviews/plans archival, phase changelog, folder CLAUDE.md refresh policy, typecheck).
- The compressed 3-line version dropped operational detail relied on at PR-time.

## Test plan

- [x] Trivial doc-only edit; typecheck clean (lint-staged ran on commit).