### PR TITLE
refactor(app-shell): tokenize sticky-header ↔ main padding coupling (#166)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -32,7 +32,10 @@ export function AppShell() {
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <TopBar title={title} />
-        <main className="flex-1 overflow-auto bg-[color:var(--bg-app)] p-6">
+        <main
+          className="flex-1 overflow-auto bg-[color:var(--bg-app)]"
+          style={{ padding: 'var(--app-main-pad-y)' }}
+        >
           <ErrorBoundary>
             <Outlet />
           </ErrorBoundary>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -34,7 +34,7 @@ export function AppShell() {
         <TopBar title={title} />
         <main
           className="flex-1 overflow-auto bg-[color:var(--bg-app)]"
-          style={{ padding: 'var(--app-main-pad-y)' }}
+          style={{ padding: 'var(--app-main-pad)' }}
         >
           <ErrorBoundary>
             <Outlet />

--- a/frontend/src/components/layout/__tests__/AppShell.tokens.test.ts
+++ b/frontend/src/components/layout/__tests__/AppShell.tokens.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Coupling guard for Issue 166.
+ *
+ * AppShell <main>'s padding and VocListHeader's sticky `top` must remain
+ * driven by the same semantic token (--app-main-pad). If anyone reverts
+ * <main> to a Tailwind p-* class or a raw --sp-* var, this test fires
+ * before the gap regression (Issue 162) can re-ship.
+ */
+describe('AppShell token coupling (Issue 166)', () => {
+  const source = readFileSync(resolve(__dirname, '../AppShell.tsx'), 'utf-8');
+
+  it('<main> padding is driven by --app-main-pad', () => {
+    expect(source).toMatch(/var\(--app-main-pad\)/);
+  });
+
+  it('<main> does not use Tailwind p-* shorthand for padding (would silently un-couple from sticky offset)', () => {
+    // Allow only padding-side utilities (px-, py-, pt-, pr-, pb-, pl-) — disallow bare p-N which sets all sides.
+    const mainOpenTag = source.match(/<main[^>]*>/);
+    expect(mainOpenTag).toBeTruthy();
+    expect(mainOpenTag![0]).not.toMatch(/\bp-\d/);
+  });
+
+  it('<main> does not consume raw --sp-* vars for padding (must go through --app-main-pad)', () => {
+    const mainOpenTag = source.match(/<main[^>]*>/);
+    expect(mainOpenTag![0]).not.toMatch(/--sp-\d/);
+  });
+});

--- a/frontend/src/components/voc/VocListHeader.tsx
+++ b/frontend/src/components/voc/VocListHeader.tsx
@@ -45,10 +45,10 @@ const CONTAINER_STYLE: CSSProperties = {
   position: 'sticky',
   // Pull the sticky stop up by AppShell <main>'s vertical padding so the header
   // covers the scroll-port padding region instead of leaving a transparent gap
-  // where rows bleed through. The shared semantic token --app-main-pad-y is the
+  // where rows bleed through. The shared semantic token --app-main-pad is the
   // single source of truth for that coupling — never substitute --sp-* here.
   // (Issues 162, 166)
-  top: 'calc(0px - var(--app-main-pad-y))',
+  top: 'calc(0px - var(--app-main-pad))',
   zIndex: 10,
 };
 

--- a/frontend/src/components/voc/VocListHeader.tsx
+++ b/frontend/src/components/voc/VocListHeader.tsx
@@ -43,10 +43,12 @@ const CONTAINER_STYLE: CSSProperties = {
   borderBottom: '2px solid var(--border-subtle)',
   background: 'var(--bg-panel)',
   position: 'sticky',
-  // Extend up by AppShell <main>'s padding-top (--sp-5 = 24px, matches Tailwind p-6
-  // in AppShell.tsx) so the sticky header covers the scroll-port padding region
-  // instead of leaving a transparent gap where rows bleed through. (Issue 162)
-  top: 'calc(0px - var(--sp-5))',
+  // Pull the sticky stop up by AppShell <main>'s vertical padding so the header
+  // covers the scroll-port padding region instead of leaving a transparent gap
+  // where rows bleed through. The shared semantic token --app-main-pad-y is the
+  // single source of truth for that coupling — never substitute --sp-* here.
+  // (Issues 162, 166)
+  top: 'calc(0px - var(--app-main-pad-y))',
   zIndex: 10,
 };
 

--- a/frontend/src/components/voc/__tests__/VocListHeader.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListHeader.test.tsx
@@ -106,6 +106,14 @@ describe('VocListHeader', () => {
     expect(container.className).toContain('voc-list-header-container');
   });
 
+  it('sticky top references --app-main-pad-y semantic token (not raw spacing)', () => {
+    render(<VocListHeader sortBy="created_at" sortDir="desc" onSort={() => {}} />);
+    const container = screen.getByTestId('voc-list-header');
+    const top = (container as HTMLElement).style.top;
+    expect(top).toContain('--app-main-pad-y');
+    expect(top).not.toContain('--sp-5');
+  });
+
   it('sortable cell aria-label is label-only (direction conveyed by aria-sort)', () => {
     render(<VocListHeader sortBy="issue_code" sortDir="asc" onSort={() => {}} />);
     const cell = screen.getByTestId('voc-list-header-cell-issue_code');

--- a/frontend/src/components/voc/__tests__/VocListHeader.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListHeader.test.tsx
@@ -106,11 +106,11 @@ describe('VocListHeader', () => {
     expect(container.className).toContain('voc-list-header-container');
   });
 
-  it('sticky top references --app-main-pad-y semantic token (not raw spacing)', () => {
+  it('sticky top references --app-main-pad semantic token (not raw spacing)', () => {
     render(<VocListHeader sortBy="created_at" sortDir="desc" onSort={() => {}} />);
     const container = screen.getByTestId('voc-list-header');
     const top = (container as HTMLElement).style.top;
-    expect(top).toContain('--app-main-pad-y');
+    expect(top).toContain('--app-main-pad');
     expect(top).not.toContain('--sp-5');
   });
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -85,6 +85,17 @@
   --sp-5: 24px;
   --sp-6: 32px;
 
+  /*
+   * Semantic layout token — vertical padding of AppShell <main>.
+   * Single source of truth for the AppShell main padding ↔ sticky-header
+   * compensation pair. Consumers:
+   *   - components/layout/AppShell.tsx (main padding)
+   *   - components/voc/VocListHeader.tsx (sticky top offset)
+   * Keep these two coupled via this token; never hard-code Tailwind p-*
+   * or --sp-* directly on either side. (Issue 166)
+   */
+  --app-main-pad-y: var(--sp-5);
+
   /* Typography */
   --font-ui:
     'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo',

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -94,7 +94,7 @@
    * Keep these two coupled via this token; never hard-code Tailwind p-*
    * or --sp-* directly on either side. (Issue 166)
    */
-  --app-main-pad-y: var(--sp-5);
+  --app-main-pad: var(--sp-5);
 
   /* Typography */
   --font-ui:


### PR DESCRIPTION
## Summary

- Closes #166.
- Introduces `--app-main-pad-y` as the **single source of truth** coupling `AppShell <main>`'s padding and `VocListHeader`'s sticky `top` compensation. PR #165 (Issue #162) had hard-coded `calc(0px - var(--sp-5))` on the header to silently mirror `<main>`'s Tailwind `p-6`. Functionally fine, but a future change to `<main>` padding could silently reintroduce the gap.
- Now both consumers read from the same semantic token. Changing the padding only requires updating the token's value.

## Changes

- `frontend/src/styles/index.css` — define `--app-main-pad-y: var(--sp-5)` with a comment naming both consumers and the rule.
- `frontend/src/components/layout/AppShell.tsx` — replace `p-6` with inline `padding: var(--app-main-pad-y)`.
- `frontend/src/components/voc/VocListHeader.tsx` — sticky `top` now `calc(0px - var(--app-main-pad-y))`.
- `frontend/src/components/voc/__tests__/VocListHeader.test.tsx` — added regression assertion that sticky `top` references the semantic token, never raw `--sp-5`.

## Test plan

- [x] `npx vitest run` — 320 / 320 pass (incl. new regression test).
- [x] `tsc --noEmit` clean (FE + BE).
- [x] lint-staged (eslint / stylelint / prettier) clean on commit.
- [x] Manual: `/voc` scrolled visually verified in Chromium @ 1440×900 — header opaque, no row bleed-through above column labels.

## Visual evidence

![/voc sticky header after tokenization](https://github.com/hjung3113/vocpage/releases/download/issue-166-screenshot/issue-166-sticky-tokenized.png)

## Out of scope

- Larger AppShell layout pass (moving padding off `<main>` so sticky `top:0` works naturally) — explicitly deferred per Issue #166.