### PR TITLE
fix(wave-1-6): F-bundle deferred minor cleanup — a11y wiring + 2 test gaps

### DIFF
--- a/frontend/src/components/voc/__tests__/VocListPage.integration.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListPage.integration.test.tsx
@@ -178,4 +178,18 @@ describe('VocListPage — Wave D D5 integration', () => {
     expect(screen.queryByTestId('voc-loading')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /다시 시도/ })).not.toBeInTheDocument();
   });
+
+  it('vocTypeMap threads VocListPage → VocTable → VocRow → VocTypeBadge (renders type icon for each row)', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('voc-table')).toBeInTheDocument());
+
+    // All fixture rows reference TYPE_PRIMARY ("기능 요청", slug=feature) — see master.fixtures.ts
+    const renderedRows = screen.getAllByTestId('voc-row');
+    expect(renderedRows.length).toBeGreaterThan(0);
+
+    // Each rendered row's title cell should contain a VocTypeBadge with aria-label "유형 기능 요청"
+    // (proves vocTypeMap was threaded VocListPage → VocTable → VocRow → VocTypeBadge).
+    const badges = await screen.findAllByLabelText('유형 기능 요청');
+    expect(badges.length).toBe(renderedRows.length);
+  });
 });

--- a/frontend/src/features/voc/components/VocAdvancedFilters.tsx
+++ b/frontend/src/features/voc/components/VocAdvancedFilters.tsx
@@ -23,6 +23,8 @@ export interface VocAdvancedFiltersProps {
   onReset: () => void;
 }
 
+export const VOC_ADVANCED_FILTERS_PANEL_ID = 'voc-advanced-filters-panel';
+
 export interface VocAdvancedFiltersToggleProps {
   open: boolean;
   onToggle: () => void;
@@ -34,6 +36,7 @@ export function VocAdvancedFiltersToggle({ open, onToggle }: VocAdvancedFiltersT
       type="button"
       onClick={onToggle}
       aria-expanded={open}
+      aria-controls={VOC_ADVANCED_FILTERS_PANEL_ID}
       className="advanced-filters-toggle"
     >
       <SlidersHorizontal className="advanced-filters-toggle-icon" aria-hidden />
@@ -109,6 +112,7 @@ export function VocAdvancedFilters({
 }: VocAdvancedFiltersProps) {
   return (
     <div
+      id={VOC_ADVANCED_FILTERS_PANEL_ID}
       data-pcomp="voc-advanced-filters"
       className={open ? 'advanced-filters advanced-filters--open' : 'advanced-filters'}
       aria-hidden={!open}

--- a/frontend/src/features/voc/components/__tests__/VocAdvancedFilters.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocAdvancedFilters.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
-import { VocAdvancedFilters, VocAdvancedFiltersToggle } from '../VocAdvancedFilters';
+import {
+  VOC_ADVANCED_FILTERS_PANEL_ID,
+  VocAdvancedFilters,
+  VocAdvancedFiltersToggle,
+} from '../VocAdvancedFilters';
 import type {
   AssigneeListItem,
   TagListItem,
@@ -122,5 +126,18 @@ describe('VocAdvancedFiltersToggle (F-3)', () => {
       'aria-expanded',
       'true',
     );
+  });
+
+  it('toggle aria-controls matches the panel id (a11y wiring)', () => {
+    const { unmount } = render(<VocAdvancedFiltersToggle open={false} onToggle={vi.fn()} />);
+    const toggleBtn = screen.getByRole('button', { name: /필터 더보기/ });
+    const controlsId = toggleBtn.getAttribute('aria-controls');
+    expect(controlsId).toBe(VOC_ADVANCED_FILTERS_PANEL_ID);
+    unmount();
+
+    renderClosed();
+    const panel = document.getElementById(controlsId!);
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveAttribute('data-pcomp', 'voc-advanced-filters');
   });
 });

--- a/frontend/src/features/voc/components/__tests__/VocStatusFilters.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocStatusFilters.test.tsx
@@ -49,4 +49,24 @@ describe('VocStatusFilters', () => {
     // After removing '접수' from ['접수'], result should be empty array
     expect(onChange).toHaveBeenCalledWith([]);
   });
+
+  it('renders rightSlot ReactNode at the end of the row when provided', () => {
+    render(
+      <VocStatusFilters
+        value="all"
+        onChange={() => {}}
+        rightSlot={<button type="button">필터 더보기</button>}
+      />,
+    );
+    // 7 buttons total: 6 status pills + 1 rightSlot button
+    expect(screen.getAllByRole('button')).toHaveLength(7);
+    expect(screen.getByRole('button', { name: /필터 더보기/ })).toBeInTheDocument();
+  });
+
+  it('omits rightSlot wrapper when rightSlot is not provided', () => {
+    const { container } = render(<VocStatusFilters value="all" onChange={() => {}} />);
+    // Only the 6 pill buttons; no extra wrapper
+    expect(screen.getAllByRole('button')).toHaveLength(6);
+    expect(container.querySelectorAll('.ml-auto')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Wave 1.6 F-bundle deferred minor 3-item cleanup (~56 LOC, FE-only). Follow-up to PR #175.

- **F-1 follow-up — a11y wiring**: `VocAdvancedFiltersToggle` now exposes `aria-controls` pointing at the panel `id`. Both anchor a new exported constant `VOC_ADVANCED_FILTERS_PANEL_ID` so the pairing can't drift. New test asserts the toggle's `aria-controls` resolves to the actual panel element.
- **F-2 follow-up — integration test**: new test in `VocListPage.integration.test.tsx` verifies `vocTypeMap` threads end-to-end (VocListPage → VocTable → VocRow → VocTypeBadge) by counting `aria-label="유형 기능 요청"` against rendered rows.
- **F-3 follow-up — rightSlot tests**: 2 tests in `VocStatusFilters.test.tsx` covering both render paths (with rightSlot → 7 buttons, without rightSlot → 6 buttons + no `.ml-auto` wrapper).

## Test plan

- [x] `npx vitest run` — 326/326 pass (40 files)
- [x] `npx tsc --noEmit` — clean (frontend + backend via pre-push hook)
- [x] Codex adversarial review — clean, no blocking findings

## Notes

- **No screenshot attached.** Changes are invisible to end users — item #1 adds an ARIA attribute (no DOM/style change), items #2 and #3 are tests-only. The toggle button visual remains identical to PR #175.
- All 3 items are scoped exactly to what was deferred from PR #175 review feedback. No scope expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)