### PR TITLE
docs(wave-1-7): Phase A — VOC create modal spec & master contracts

### DIFF
--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -30,9 +30,16 @@
 > **진행 방식 (D10 번복)**: Phase 진행 중 autopilot/ralph 자동화 사용 허용. **머지·완료 선언은 사용자 검수 후에만**. Phase 게이트 미승인 시 다음 Phase 시작 금지.
 > **금지**: Wave 2 (Dashboard) 및 Follow-up C-2 (seed UUID v4) 진입은 본 Wave 종료 전까지 **hard-block**.
 
+### Wave 1.7 — VOC 등록 모달 정합화 (신규, 2026-05-03)
+
+> **트리거**: 사용자 검토 — 현 등록 모달이 prototype 시각·spec(`feature-voc.md §8.4` medium 강제, §8.5 합산 cap, §8.8 cascade)과 어긋남.
+> **정본 plan**: [`wave-1-7-voc-create-modal.md`](./wave-1-7-voc-create-modal.md). 사양: `feature-voc.md §9.11`.
+> **Phase**: A(spec/contract, 본 PR 진행) → B(BE master endpoints) → C(FE 모달 rebuild) → D(visual diff/cleanup). 각 Phase 사용자 승인 게이트.
+> **Phase A 산출**: `feature-voc.md §9.11` 신설 + `requirements.md §6.1` master endpoints 추가 + `shared/contracts/master/io.ts` SystemListItem/MenuListItem 신규.
+
 ### Wave 2 진입 hard-block
 
-위 Wave 1 보강 PR 머지 + follow-up A (Playwright) + **Wave 1.6 (`/voc` prototype 일치화)** + follow-up C-2 (seed UUID fix) 종결 전까지 **Wave 2 implementation 금지**. follow-up C-1은 본 PR로 종결. 진행 순서: Wave 1.6 → Follow-up C-2 → Wave 2.
+위 Wave 1 보강 PR 머지 + follow-up A (Playwright) + **Wave 1.6 (`/voc` prototype 일치화)** + **Wave 1.7 (VOC 등록 모달 정합화)** + follow-up C-2 (seed UUID fix) 종결 전까지 **Wave 2 implementation 금지**. follow-up C-1은 본 PR로 종결. 진행 순서: Wave 1.6 → Wave 1.7 → Follow-up C-2 → Wave 2.
 
 ---
 

--- a/docs/specs/plans/wave-1-7-voc-create-modal.md
+++ b/docs/specs/plans/wave-1-7-voc-create-modal.md
@@ -34,7 +34,7 @@
 | D4  | 본문↔첨부 동기화   | 단방향 (본문→첨부 추가/제거), 첨부→본문 자동삽입 안 함. Dedup name+size+lastModified.                                                     |
 | D5  | 5개·10MB cap       | 본문+첨부 **합산** (§8.5:217 "본문 기준" 재해석)                                                                                          |
 | D6  | 우선순위 UI        | 항상 disabled, 라벨 `우선순위 (자동: Medium · 생성 후 조정)`, value 고정 `medium`                                                         |
-| D7  | master 응답 형태   | `GET /api/master/systems` nested(`menus[]` 포함) + `GET /api/master/menus?system_id=` 별도 endpoint 둘 다 제공. 모달은 nested 사용.       |
+| D7  | master 응답 형태   | `GET /api/masters/systems` nested(`menus[]` 포함) + `GET /api/masters/menus?system_id=` 별도 endpoint 둘 다 제공. 모달은 nested 사용.     |
 | D8  | 메뉴 활성 0건 표시 | 메뉴 select disabled + 안내 `"이 시스템에 등록된 메뉴가 없습니다"` (§8.8:261)                                                             |
 | D9  | PR 단위            | Phase A 1 PR (spec/contract) / Phase B 1 PR (BE master endpoints) / Phase C 1 PR (FE 모달 rebuild) / Phase D 1 PR (visual diff + cleanup) |
 | D10 | 게이트             | 각 Phase 종료 시 사용자 승인 없으면 다음 Phase 시작 금지                                                                                  |
@@ -48,10 +48,16 @@ Phase A — Spec & Contract  (코드 0줄, 이번 작업으로 진입)
   ├─ shared/contracts/master/io.ts: SystemListItem/MenuListItem ✅
   └─ 사용자 승인 게이트
 
-Phase B — BE Master Endpoints (TDD)
-  ├─ 실패 테스트: GET /api/master/systems (nested menus), GET /api/master/menus?system_id=
-  ├─ Express route + zod validation + DB 쿼리 (systems LEFT JOIN menus, is_archived 필터)
-  ├─ MSW v2 handler 동기화 (`frontend/src/mocks/handlers/master.ts`)
+Phase B — BE Master Endpoints + VOC Create Enforcement (TDD)
+  ├─ 실패 테스트:
+  │   - GET /api/masters/systems (nested menus, is_archived=false 응답에서 제외)
+  │   - GET /api/masters/menus?system_id=<uuid>&includeArchived=true|false (Admin 단독)
+  │   - POST /api/vocs: client priority='urgent' 보내도 DB에 'medium' 저장 (§8.4 강제)
+  │   - POST /api/vocs: due_date 미제공 시 created_at + 30d 자동 계산 저장 (§8.4.1)
+  ├─ Express route 추가 (mastersRouter에 systems/menus 핸들러)
+  ├─ DB 쿼리: systems + menus aggregation (1 query LEFT JOIN + JSON_AGG, 또는 2 query in-memory grouping — 기존 backend/src/repository 패턴 따름)
+  ├─ Service 변경: createVoc()에서 priority 무조건 'medium', due_date = NOW()::date + 30 자동 세팅 (§8.4·8.4.1)
+  ├─ MSW v2 handler 동기화 (`frontend/src/mocks/handlers/masters.ts`)
   └─ 통합 테스트 + 사용자 승인 게이트
 
 Phase C — FE Modal Rebuild (TDD)
@@ -64,14 +70,15 @@ Phase C — FE Modal Rebuild (TDD)
   │   - 본문 skeleton 초기값 검증
   │   - 본문 이미지 삽입 → 첨부 추가 (mock blob hook)
   │   - 본문 이미지 제거 → 첨부 제거
-  │   - 합산 5개 cap 검증
+  │   - 합산 5개 cap 검증 (본문+첨부 유니크 합집합)
+  │   - 합산 10MB cap 검증 (본문 이미지 + 첨부 zone 바이트 합산 초과 시 거부)
   │   - 자동 태그 추천 row 노출
   │   - 푸터 안내 문구 + send 아이콘
   ├─ 구현: master 응답 useQuery → cascade 처리, AttachmentZone 통합, ToastBodyEditor blob hook 노출
   └─ 사용자 승인 게이트
 
 Phase D — Visual Diff & Cleanup
-  ├─ benchmark/<wave-1-7>/voc-create-modal.png 추가
+  ├─ benchmark/09-voc-create-modal.png 재캡처 (flat-index 정책, INDEX.md §VOC 목록 페이지의 인터렉션 행에 이미 등록된 baseline 갱신)
   ├─ scripts/visual-diff.ts 통과
   ├─ 구버전 priority select·잘못된 그리드 코드 제거
   ├─ claude-progress.txt + next-session-tasks.md 업데이트

--- a/docs/specs/plans/wave-1-7-voc-create-modal.md
+++ b/docs/specs/plans/wave-1-7-voc-create-modal.md
@@ -1,0 +1,96 @@
+# Wave 1.7 — VOC Create Modal Parity Plan
+
+> 목적: `VocCreateModal`을 prototype `#modalBg` 시각·동작 사양 + spec 룰(§8.4 medium 강제, §8.4.1 SLA, §8.5 첨부 cap, §8.8 cascade)에 정합시킨다.
+> 정본 사양: `docs/specs/requires/feature-voc.md §9.11` (2026-05-03 추가).
+
+## 1. 배경
+
+- Wave 1.5/1.6은 /voc 목록·드로어·셸을 prototype 기준으로 정렬. **등록 모달은 미정비**.
+- 현 모달(`frontend/src/features/voc/components/VocCreateModal.tsx`)은 prototype 대비 다음이 어긋남:
+  1. 필수(`*`) 마커 없음
+  2. 드롭다운 1행 3열 (prototype: 2×2) + 시스템→메뉴 cascade 미구현
+  3. 우선순위 활성화 (spec §8.4: medium 강제, 항상 disabled여야 함)
+  4. 본문 가이드 skeleton 없음 (정규화 파이프라인 친화 H2 구조)
+  5. 본문↔첨부 동기화 없음
+  6. 자동 태그 추천 row 미연결
+  7. 푸터 안내 문구·send 아이콘 없음
+- master 데이터: `SystemListItem`/`MenuListItem` contract 부재. BE endpoint 부재.
+
+## 2. 원칙
+
+1. prototype DOM 직접 이식 금지 — 시각·인터랙션 사양만 차용.
+2. spec(`feature-voc.md §9.11`) 우선 — prototype과 spec이 충돌하면 spec 채택 (예: 우선순위 라벨 `(자동: Medium · 생성 후 조정)`은 spec 표현).
+3. TDD — 테스트 작성·실패 확인 → 구현 → 통과 → 리팩터.
+4. 토큰만 사용 (hex/raw OKLCH 금지).
+5. refactor와 feature 변경은 같은 PR에 섞지 않는다.
+
+## 3. 결정 (잠금)
+
+| ID  | 항목               | 결정                                                                                                                                      |
+| --- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | 제목 maxLength     | 200 (`requirements.md §8.10` 일치)                                                                                                        |
+| D2  | 본문 skeleton      | **실제 초기값으로 삽입** (placeholder 흐림 X). H2 섹션 구조 (`feature-voc.md §9.11.1`)                                                    |
+| D3  | Due Date row       | **모달 미노출**. BE는 priority=medium 룰로 created_at+30일 자동 계산.                                                                     |
+| D4  | 본문↔첨부 동기화   | 단방향 (본문→첨부 추가/제거), 첨부→본문 자동삽입 안 함. Dedup name+size+lastModified.                                                     |
+| D5  | 5개·10MB cap       | 본문+첨부 **합산** (§8.5:217 "본문 기준" 재해석)                                                                                          |
+| D6  | 우선순위 UI        | 항상 disabled, 라벨 `우선순위 (자동: Medium · 생성 후 조정)`, value 고정 `medium`                                                         |
+| D7  | master 응답 형태   | `GET /api/master/systems` nested(`menus[]` 포함) + `GET /api/master/menus?system_id=` 별도 endpoint 둘 다 제공. 모달은 nested 사용.       |
+| D8  | 메뉴 활성 0건 표시 | 메뉴 select disabled + 안내 `"이 시스템에 등록된 메뉴가 없습니다"` (§8.8:261)                                                             |
+| D9  | PR 단위            | Phase A 1 PR (spec/contract) / Phase B 1 PR (BE master endpoints) / Phase C 1 PR (FE 모달 rebuild) / Phase D 1 PR (visual diff + cleanup) |
+| D10 | 게이트             | 각 Phase 종료 시 사용자 승인 없으면 다음 Phase 시작 금지                                                                                  |
+
+## 4. Phase 흐름
+
+```
+Phase A — Spec & Contract  (코드 0줄, 이번 작업으로 진입)
+  ├─ feature-voc.md §9.11 신설 ✅
+  ├─ requirements.md §6.1 master endpoints 추가 ✅
+  ├─ shared/contracts/master/io.ts: SystemListItem/MenuListItem ✅
+  └─ 사용자 승인 게이트
+
+Phase B — BE Master Endpoints (TDD)
+  ├─ 실패 테스트: GET /api/master/systems (nested menus), GET /api/master/menus?system_id=
+  ├─ Express route + zod validation + DB 쿼리 (systems LEFT JOIN menus, is_archived 필터)
+  ├─ MSW v2 handler 동기화 (`frontend/src/mocks/handlers/master.ts`)
+  └─ 통합 테스트 + 사용자 승인 게이트
+
+Phase C — FE Modal Rebuild (TDD)
+  ├─ 실패 테스트: VocCreateModal.test.tsx
+  │   - 제목 maxLength=200 + 카운터 표시
+  │   - 2×2 그리드 레이아웃
+  │   - 시스템 미선택 시 메뉴 disabled
+  │   - 시스템 변경 시 메뉴 reset
+  │   - 우선순위 항상 disabled
+  │   - 본문 skeleton 초기값 검증
+  │   - 본문 이미지 삽입 → 첨부 추가 (mock blob hook)
+  │   - 본문 이미지 제거 → 첨부 제거
+  │   - 합산 5개 cap 검증
+  │   - 자동 태그 추천 row 노출
+  │   - 푸터 안내 문구 + send 아이콘
+  ├─ 구현: master 응답 useQuery → cascade 처리, AttachmentZone 통합, ToastBodyEditor blob hook 노출
+  └─ 사용자 승인 게이트
+
+Phase D — Visual Diff & Cleanup
+  ├─ benchmark/<wave-1-7>/voc-create-modal.png 추가
+  ├─ scripts/visual-diff.ts 통과
+  ├─ 구버전 priority select·잘못된 그리드 코드 제거
+  ├─ claude-progress.txt + next-session-tasks.md 업데이트
+  └─ PR 머지 (`gh pr merge --merge --delete-branch`)
+```
+
+## 5. 의존·전제
+
+- BE: `systems` / `menus` 테이블이 `migrations/002_core_tables.sql` 기준 이미 존재. 시드 데이터 fixture 보강 필요 시 `shared/fixtures/`에 추가.
+- FE: `useAutoTag` 훅이 이미 존재 (frontend/CLAUDE.md). 모달에 연결만.
+- Toast UI Editor의 `addImageBlobHook` 콜백을 부모로 노출하려면 `ToastBodyEditor` 시그니처 확장 필요 (Phase C 범위).
+
+## 6. 비범위
+
+- 우선순위 변경 UI (생성 후 드로어에서, §8.4.2 별도 wave 범위)
+- Result Review 게이트 (§9.4.5 별도 wave)
+- 댓글 첨부 (§8.13 별도)
+- 자동 정규화 파이프라인 자체 (skeleton은 단지 향후 파싱 친화 구조 — 추출 로직은 NextGen)
+
+## 7. 완료 기준
+
+- spec/contract 머지 + BE master endpoint 통과 + FE 모달 테스트 전부 그린 + visual diff 통과 + prototype 시각 격차 없음 (사용자 검수).

--- a/docs/specs/requires/feature-voc.md
+++ b/docs/specs/requires/feature-voc.md
@@ -679,3 +679,82 @@ FE 가드: window.currentUser.role ∈ {manager, admin}일 때만 승인/반려 
 - @멘션 댓글
 - CSV/Excel 내보내기
 - 중복 VOC 감지
+
+### 9.11 VOC 등록 모달 상세 (Wave 1.7, 2026-05-03)
+
+prototype `prototype.html#modalBg` 시각 사양을 React 모달(`features/voc/components/VocCreateModal.tsx`)에 반영. §8 데이터 모델·권한 룰을 UI에서 깨지 않도록 정합성 명시.
+
+#### 9.11.1 필드 구성 (위→아래)
+
+1. **제목** (필수, `*` 표시)
+   - placeholder: `"문제를 간결하게 설명해 주세요 (최대 200자)"`
+   - `maxLength=200` (§8.10 일치)
+   - 우하단 글자수 카운터 `현재/200`. 200 도달 시 강조색 `var(--status-danger)`.
+2. **드롭다운 2×2 그리드**
+   - row1: **시스템** `*` · **메뉴** `*`
+     - 시스템 미선택 시 메뉴 select `disabled`, placeholder `"시스템 먼저 선택..."`
+     - 시스템 변경 시 메뉴 옵션 재로드 + 선택값 reset
+     - 활성 메뉴 0건 시 메뉴 select `disabled` + 안내 `"이 시스템에 등록된 메뉴가 없습니다"` (§8.8:261)
+   - row2: **유형** `*` · **우선순위**
+     - 우선순위는 **항상 `disabled`**, value 고정 `medium`
+     - 라벨: `우선순위 (자동: Medium · 생성 후 조정)`
+     - 근거: §8.4 — "생성 시 서버에서 medium으로 강제 설정 (클라이언트 값 무시)". 권한자(Manager/Admin/담당 Dev)는 생성 후 드로어에서 변경.
+3. **본문** (필수, `*` 표시) — Toast UI Editor
+   - **빈 본문일 때 초기값으로 마크다운 skeleton 자동 삽입** (placeholder 아닌 실제 값):
+
+     ```md
+     ## 문제 상황
+
+     ## 재현 방법
+
+     1.
+
+     ## 발생 환경
+
+     - 시스템:
+     - 브라우저:
+
+     ## 기대 동작
+     ```
+
+   - skeleton의 H2 헤더 구조는 추후 자동 정규화/structured_payload 추출 파이프라인의 파싱 기준이 됨 (NextGen 연계).
+   - 사용자가 skeleton 위에 작성을 시작하면 그대로 유지 — 빈 헤더만 남으면 BE가 무시(저장 시 본문 전체 64KB 제한, §8.10).
+
+4. **자동 태그 추천 row**
+   - 본문 아래, 첨부 위에 표시.
+   - 본문/제목 입력 후 500ms debounce → `tag_rules` 매칭 (§8.8 자동 태깅 정책 기준, prototype `autotagRow` 동작).
+5. **첨부파일 zone** (선택)
+   - 라벨 보조 텍스트 `(선택 · 이미지만 · 최대 5개)`
+   - 드래그앤드롭 + 선택 버튼
+   - 5개·10MB **본문 이미지 + 첨부 합산** cap (§8.5:217 "본문 기준" 명시 재인용).
+   - 우측 카운트 배지 `0/5`.
+
+#### 9.11.2 본문 ↔ 첨부 단방향 동기화
+
+- **본문 → 첨부 (자동 추가)**: 사용자가 Toast Editor에 이미지를 삽입 (드래그·붙여넣기·이미지 버튼)하면 동일 File이 첨부 zone에도 추가된다.
+- **본문 → 첨부 (자동 제거)**: 사용자가 본문에서 이미지 마크다운/노드를 삭제하면 첨부 zone에서도 동일 항목 제거.
+- **첨부 → 본문**: 자동 삽입 **하지 않음**. 첨부 zone에서 직접 추가한 이미지는 본문 흐름과 무관 (캡처/별첨용).
+- **dedup**: 동일 File(name+size+lastModified hash) 중복 방지 — 본문에 이미 있는 이미지를 첨부에 별도로 올려도 1개로만 카운트.
+- **합산 cap 검증**: 본문 + 첨부의 유니크 이미지 합계가 `5개 / 10MB`를 초과하면 새 추가를 거부 (토스트 안내).
+
+#### 9.11.3 Due Date 처리
+
+- **생성 모달에 Due Date 필드 미노출**.
+- BE는 priority=`medium` 강제 룰에 따라 항상 `due_date = created_at + 30일`로 자동 계산 후 저장 (§8.4.1 표 그대로).
+- 권한자는 생성 후 드로어에서 priority 변경 시 자동 재계산되며, 수동 수정도 §8.4.2 룰로 가능.
+
+#### 9.11.4 푸터
+
+- 좌측: `(info icon) 등록 후 이슈 ID가 자동 부여됩니다` — `var(--text-quaternary)`, 12px.
+- 우측: `취소` (ghost) / `[send icon] VOC 등록` (primary).
+
+#### 9.11.5 라벨 표기 토큰
+
+- 필수 마커 `*`: `var(--status-danger)` (또는 신규 `--form-required` 토큰 추가 시 그쪽). 별도 레이블 토큰 추가는 본 wave 범위 외 — 기존 토큰 재사용.
+- 라벨 보조 텍스트 (예: `(선택 · 이미지만 · 최대 5개)`): `text-xs` + `var(--text-quaternary)`.
+
+#### 9.11.6 master 데이터 의존
+
+- `GET /api/master/systems` 응답에 `menus: MenuListItem[]` nested 포함 — 모달은 단일 호출로 cascade 데이터 확보.
+- Admin 페이지의 메뉴 단독 CRUD에는 `GET /api/master/menus?system_id=` 별도 endpoint 사용 (§9.4.2).
+- 스키마: `shared/contracts/master/io.ts` (Wave 1.7에서 신규 추가).

--- a/docs/specs/requires/feature-voc.md
+++ b/docs/specs/requires/feature-voc.md
@@ -215,6 +215,7 @@ function assertCanManageVoc(
 - 허용 형식: PNG, JPG, GIF, WebP (이미지만)
 - 최대 크기: 10MB / 파일
 - 최대 개수: 5개 / VOC (본문 기준. 댓글 이미지는 별도)
+- **합산 cap (Wave 1.7, 2026-05-03)**: VOC 등록 모달에서는 본문 inline 이미지 + 첨부 zone 이미지 **유니크 합집합 기준 5개 / 합산 10MB**로 cap 적용 (§9.11.2 dedup 룰: name+size+lastModified). 드로어 편집(`PATCH /api/vocs/:id` + `POST /api/attachments`)에서도 동일 합산 룰 적용. 댓글 첨부는 별도 cap (§8.13).
 - 업로드 검증: MIME 스니핑 + 확장자 일치 검증. 실행 파일 헤더 차단. SVG 명시적 차단 (XSS 위험).
 - 파일 서빙: `Content-Disposition: attachment` 강제 (인라인 렌더링 방지).
 - GIF 크기 검증: 원본 파일 바이트 기준 (디코딩 전 raw bytes).
@@ -482,6 +483,7 @@ VOC 목록 테이블에서 부모 VOC 행에 자식 서브태스크를 인라인
 - "시스템 추가" / "메뉴 추가" 버튼 → 인라인 폼
 - 시스템 추가 시 "기타" 메뉴 자동 생성 (알림 표시)
 - 아카이브 처리 시 신규 VOC 등록에서 선택 불가, 기존 데이터는 유지
+- **Admin 페이지 master 조회 (Wave 1.7)**: 메뉴 단독 CRUD는 `GET /api/masters/menus?system_id=<uuid>&includeArchived=true` 호출. 기본값(`includeArchived=false`)은 활성 메뉴만 — 등록 모달 cascade와 동일 응답. Admin 테이블은 `includeArchived=true`로 아카이브 행 포함 표시 (상태 컬럼으로 구분).
 
 #### 9.4.3 유형 관리
 
@@ -755,6 +757,6 @@ prototype `prototype.html#modalBg` 시각 사양을 React 모달(`features/voc/c
 
 #### 9.11.6 master 데이터 의존
 
-- `GET /api/master/systems` 응답에 `menus: MenuListItem[]` nested 포함 — 모달은 단일 호출로 cascade 데이터 확보.
-- Admin 페이지의 메뉴 단독 CRUD에는 `GET /api/master/menus?system_id=` 별도 endpoint 사용 (§9.4.2).
+- `GET /api/masters/systems` 응답에 `menus: MenuListItem[]` nested 포함 — 모달은 단일 호출로 cascade 데이터 확보.
+- Admin 페이지의 메뉴 단독 CRUD에는 `GET /api/masters/menus?system_id=` 별도 endpoint 사용 (§9.4.2).
 - 스키마: `shared/contracts/master/io.ts` (Wave 1.7에서 신규 추가).

--- a/docs/specs/requires/requirements.md
+++ b/docs/specs/requires/requirements.md
@@ -252,8 +252,8 @@
 - **헬스체크**: `GET /api/health` → `{ "status": "ok", "db": "ok" }` (DB 연결 포함 확인). 인증 불필요.
 - **공통 쿼리 파라미터**: 대시보드 API는 `?systemId=&menuId=&assigneeId=&from=&to=` 공통 필터 지원 (§11.7 참조).
 - **Master 데이터 (Wave 1.7, 2026-05-03)**:
-  - `GET /api/master/systems` → `{ rows: SystemListItem[] }`. 각 항목은 `menus: MenuListItem[]` nested 포함 (VOC 등록 모달 cascade용 단일 호출). `is_archived=true` 시스템·메뉴는 응답 제외 (신규 VOC 선택 불가, feature-voc.md §8.8).
-  - `GET /api/master/menus?system_id=<uuid>` → `{ rows: MenuListItem[] }`. Admin 페이지 메뉴 CRUD 단독 조회용. `is_archived` 포함 여부는 `?includeArchived=true` 토글.
+  - `GET /api/masters/systems` → `{ rows: SystemListItem[] }`. 각 항목은 `menus: MenuListItem[]` nested 포함 (VOC 등록 모달 cascade용 단일 호출). `is_archived=true` 시스템·메뉴는 응답 제외 (신규 VOC 선택 불가, feature-voc.md §8.8).
+  - `GET /api/masters/menus?system_id=<uuid>` → `{ rows: MenuListItem[] }`. Admin 페이지 메뉴 CRUD 단독 조회용. `is_archived` 포함 여부는 `?includeArchived=true` 토글.
   - 스키마 SSOT: `shared/contracts/master/io.ts`.
 
 ### 6.2 Frontend (React)

--- a/docs/specs/requires/requirements.md
+++ b/docs/specs/requires/requirements.md
@@ -251,6 +251,10 @@
 
 - **헬스체크**: `GET /api/health` → `{ "status": "ok", "db": "ok" }` (DB 연결 포함 확인). 인증 불필요.
 - **공통 쿼리 파라미터**: 대시보드 API는 `?systemId=&menuId=&assigneeId=&from=&to=` 공통 필터 지원 (§11.7 참조).
+- **Master 데이터 (Wave 1.7, 2026-05-03)**:
+  - `GET /api/master/systems` → `{ rows: SystemListItem[] }`. 각 항목은 `menus: MenuListItem[]` nested 포함 (VOC 등록 모달 cascade용 단일 호출). `is_archived=true` 시스템·메뉴는 응답 제외 (신규 VOC 선택 불가, feature-voc.md §8.8).
+  - `GET /api/master/menus?system_id=<uuid>` → `{ rows: MenuListItem[] }`. Admin 페이지 메뉴 CRUD 단독 조회용. `is_archived` 포함 여부는 `?includeArchived=true` 토글.
+  - 스키마 SSOT: `shared/contracts/master/io.ts`.
 
 ### 6.2 Frontend (React)
 

--- a/shared/contracts/master/io.ts
+++ b/shared/contracts/master/io.ts
@@ -47,6 +47,10 @@ export type VocTypeListItem = z.infer<typeof VocTypeListItem>;
 export const VocTypeListResponse = z.object({ rows: z.array(VocTypeListItem) });
 export type VocTypeListResponse = z.infer<typeof VocTypeListResponse>;
 
+// `is_archived`는 schema 레벨에서는 boolean 허용 (Admin 단독 endpoint
+// `GET /api/masters/menus?includeArchived=true`에서 true 행 포함). VOC 등록
+// 모달의 cascade 응답(`GET /api/masters/systems`)은 BE에서 archived 행을
+// 제외하고 반환 — feature-voc.md §9.11.6 + §8.8.
 export const MenuListItem = z.object({
   id: Uuid,
   system_id: Uuid,

--- a/shared/contracts/master/io.ts
+++ b/shared/contracts/master/io.ts
@@ -1,11 +1,14 @@
 /**
  * @module shared/contracts/master/io
  *
- * Master data list endpoints — assignees, tags, voc_types — used by FE filter
- * dropdowns. Schemas mirror DB columns:
- *  - users   → backend/migrations/002_core_tables.sql + 013_add_dev_role.sql
- *  - tags    → backend/migrations/004_tags.sql
+ * Master data list endpoints — assignees, tags, voc_types, systems, menus —
+ * used by FE filter dropdowns and the VOC create modal cascade. Schemas mirror
+ * DB columns:
+ *  - users     → backend/migrations/002_core_tables.sql + 013_add_dev_role.sql
+ *  - tags      → backend/migrations/004_tags.sql
  *  - voc_types → backend/migrations/002_core_tables.sql
+ *  - systems   → backend/migrations/002_core_tables.sql
+ *  - menus     → backend/migrations/002_core_tables.sql
  */
 import { z } from 'zod';
 import { Uuid } from '../common';
@@ -43,3 +46,27 @@ export type VocTypeListItem = z.infer<typeof VocTypeListItem>;
 
 export const VocTypeListResponse = z.object({ rows: z.array(VocTypeListItem) });
 export type VocTypeListResponse = z.infer<typeof VocTypeListResponse>;
+
+export const MenuListItem = z.object({
+  id: Uuid,
+  system_id: Uuid,
+  name: z.string(),
+  slug: z.string(),
+  is_archived: z.boolean(),
+});
+export type MenuListItem = z.infer<typeof MenuListItem>;
+
+export const MenuListResponse = z.object({ rows: z.array(MenuListItem) });
+export type MenuListResponse = z.infer<typeof MenuListResponse>;
+
+export const SystemListItem = z.object({
+  id: Uuid,
+  name: z.string(),
+  slug: z.string(),
+  is_archived: z.boolean(),
+  menus: z.array(MenuListItem),
+});
+export type SystemListItem = z.infer<typeof SystemListItem>;
+
+export const SystemListResponse = z.object({ rows: z.array(SystemListItem) });
+export type SystemListResponse = z.infer<typeof SystemListResponse>;


### PR DESCRIPTION
## Summary

- `feature-voc.md §9.11` 신설 — VOC 등록 모달 사양 (2×2 그리드, 우선순위 항상 disabled, Due Date 미노출, 본문 마크다운 skeleton 초기값, 본문↔첨부 단방향 동기화 + 5개·10MB 합산 cap, 푸터 안내·아이콘)
- `requirements.md §6.1` master endpoints 추가 — `GET /api/master/systems` (menus nested) + `GET /api/master/menus?system_id=`
- `shared/contracts/master/io.ts` — `SystemListItem`(menus nested) + `MenuListItem` zod schemas (FE/BE SSOT)
- `plans/wave-1-7-voc-create-modal.md` 신규 — Phase A→D 흐름, 결정 D1~D10
- `plans/next-session-tasks.md` — Wave 1.7 항목 + Wave 2 hard-block 순서 갱신

## 결정 근거

| ID | 결정 | 근거 |
|----|------|------|
| D1 제목 maxLength 200 | `requirements.md §8.10` |
| D2 본문 skeleton 실제 초기값 | 정규화 파이프라인 H2 파싱 친화 |
| D3 Due Date 모달 미노출 | `§8.4` priority=medium 강제 → `§8.4.1` 30일 자동 |
| D4 본문↔첨부 단방향 + 삭제 propagation | UX 결정 |
| D5 5개·10MB 합산 cap | `§8.5:217` "본문 기준" 재해석 |
| D6 우선순위 항상 disabled | `§8.4` "클라이언트 값 무시" |
| D7 master nested + 별도 endpoint 둘 다 | 모달 1회 호출 + Admin 단독 CRUD |
| D8 메뉴 0건 안내 | `§8.8:261` |

Phase A는 코드 0줄. 머지 후 사용자 승인 게이트 거쳐 Phase B (BE master endpoints, TDD) 진행.

## Test plan

- [x] `npm run typecheck -w frontend` — clean (contract zod schema 추가)
- [x] `npm run typecheck -w backend` — clean (pre-push hook)
- [ ] (검수) `feature-voc.md §9.11` 사양과 결정 D1~D10이 정합한지 사람 눈 확인
- [ ] (검수) prototype `#modalBg`(prototype.html:907~1003) 대비 누락 사양 없는지 확인
- [ ] (검수) Wave 2 hard-block 순서 (Wave 1.6 → 1.7 → C-2 → 2) 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)