### PR TITLE
docs(claude-md): fix FE test batch — `-- --run` + English

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,11 +7,11 @@
 - Use `limit=30` (or similar) when reading progress/state files
 - Check `git diff` for changes instead of re-reading full files
 - Reference external docs via links (don't duplicate into context)
-- **Test batch** — 검증은 워크스페이스별 단일 호출:
-  - FE: `npm run typecheck -w frontend && npm run test -w frontend | tail -20`
+- **Test batch** — verify per workspace in a single call:
+  - FE: `npm run typecheck -w frontend && npm run test -w frontend -- --run | tail -20`
   - BE: `npm run typecheck -w backend && npm run test -w backend | tail -20`
-  - 양쪽 touched면 두 명령을 같은 message에서 parallel bash로 (root §"Parallel tool calls" 룰 적용).
-  - tsc/vitest 별도 split 금지. (backend lint script 미정의 — 추후 추가 시 lint도 동일 패턴)
+  - If both sides touched, run the two commands as parallel bash in one message (root §"Parallel tool calls").
+  - Do not split tsc and vitest into separate calls.
 
 ## Pointers
 


### PR DESCRIPTION
## Summary
- FE test command was hanging because vitest entered watch mode in TTY; `--run` must come after `--` so npm passes it through.
- Translates the Test batch block in `.claude/CLAUDE.md` to English and trims a stale backend-lint aside.

## Test plan
- [x] `npm run typecheck` (FE + BE) clean via husky pre-commit.
- [ ] Confirm `npm run test -w frontend -- --run | tail -20` exits without watch mode in next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)