### PR TITLE
feat(.claude): Read/Edit guard hooks to cut token waste

### DIFF
--- a/.claude/hooks/_session-jsonl.sh
+++ b/.claude/hooks/_session-jsonl.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Resolve the current session's JSONL path. Picks the most recently modified
+# JSONL under ~/.claude/projects/<encoded-cwd>/ which corresponds to the
+# active session for this project.
+proj_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+encoded=$(echo "$proj_dir" | sed 's|/|-|g')
+JSONL_DIR="$HOME/.claude/projects/$encoded"
+ls -t "$JSONL_DIR"/*.jsonl 2>/dev/null | head -1

--- a/.claude/hooks/block-blind-edit.sh
+++ b/.claude/hooks/block-blind-edit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse Edit: block Edit on a >80-line file that has never been
+# Read/Edit/Write'd in this session. Suggests the minimal Read range
+# by locating the first line of old_string in the target file.
+set -u
+f=$(jq -r '.file_path // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+old=$(jq -r '.old_string // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+[ -z "$f" ] || [ ! -f "$f" ] && exit 0
+lines=$(wc -l < "$f" 2>/dev/null | tr -d ' ' || echo 0)
+[ "${lines:-0}" -le 80 ] && exit 0
+
+jsonl=$(bash "$(dirname "$0")/_session-jsonl.sh")
+[ -z "$jsonl" ] || [ ! -f "$jsonl" ] && exit 0
+
+# any tool_use of this file_path anywhere in this session?
+seen=$(grep -c -F "\"file_path\":\"$f\"" "$jsonl" 2>/dev/null || echo 0)
+[ "${seen:-0}" -gt 0 ] && exit 0
+
+first_line=$(printf '%s\n' "$old" | head -1)
+locs=""
+if [ -n "$first_line" ]; then
+  locs=$(rg -n -F -- "$first_line" "$f" 2>/dev/null | head -3 | cut -d: -f1 | paste -sd, -)
+fi
+
+if [ -n "$locs" ]; then
+  first=$(echo "$locs" | cut -d, -f1)
+  off=$((first > 5 ? first - 5 : 1))
+  echo "🚫 Blind Edit on $f ($lines lines, never Read in session). old_string matches at lines: $locs. Run: Read('$f', offset=$off, limit=20) before Edit." >&2
+else
+  echo "🚫 Blind Edit on $f ($lines lines, never Read in session). old_string not found — Edit will fail anyway. Read the file first with explicit offset+limit." >&2
+fi
+exit 2

--- a/.claude/hooks/block-read-after-edit.sh
+++ b/.claude/hooks/block-read-after-edit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PreToolUse Read: block full re-read of a file that has been Edit/Write'd
+# in this session. Suggests git diff or bounded Read instead.
+set -u
+f=$(jq -r '.file_path // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+lim=$(jq -r '.limit // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+[ -z "$f" ] || [ ! -f "$f" ] && exit 0
+[ -n "$lim" ] && exit 0
+
+jsonl=$(bash "$(dirname "$0")/_session-jsonl.sh")
+[ -z "$jsonl" ] || [ ! -f "$jsonl" ] && exit 0
+
+last=$(grep -F "\"file_path\":\"$f\"" "$jsonl" 2>/dev/null \
+  | tail -50 \
+  | grep -oE '"name":"(Read|Edit|Write|MultiEdit|NotebookEdit)"' \
+  | tail -1 \
+  | sed 's/.*"name":"\([^"]*\)".*/\1/')
+
+case "$last" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    echo "🚫 Full Read after $last on $f. Use: Bash('git diff -- $f') for changes, or Read with offset+limit for a region." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/.claude/hooks/block-reread.sh
+++ b/.claude/hooks/block-reread.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PreToolUse Read: block re-read of a file already Read in this session,
+# unless an Edit/Write occurred since.
+set -u
+f=$(jq -r '.file_path // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+[ -z "$f" ] && exit 0
+jsonl=$(bash "$(dirname "$0")/_session-jsonl.sh")
+[ -z "$jsonl" ] || [ ! -f "$jsonl" ] && exit 0
+
+# last tool_use entry mentioning this exact file_path
+last=$(grep -F "\"file_path\":\"$f\"" "$jsonl" 2>/dev/null \
+  | tail -50 \
+  | grep -oE '"name":"(Read|Edit|Write|MultiEdit|NotebookEdit)"' \
+  | tail -1 \
+  | sed 's/.*"name":"\([^"]*\)".*/\1/')
+
+if [ "$last" = "Read" ]; then
+  echo "🚫 Re-read blocked: $f already Read this session with no Edit/Write since. Reuse existing context, or use offset+limit if you need a different region." >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/check-read.sh
+++ b/.claude/hooks/check-read.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse Read: TS/TSX full-file read → block (80-line threshold).
+# Other large files (>200 lines) → soft warning (preserve existing behavior).
+set -u
+f=$(jq -r '.file_path // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+lim=$(jq -r '.limit // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+[ -z "$f" ] || [ ! -f "$f" ] && exit 0
+[ -n "$lim" ] && exit 0
+lines=$(wc -l < "$f" 2>/dev/null | tr -d ' ' || echo 0)
+case "$f" in
+  *.ts|*.tsx)
+    if [ "${lines:-0}" -gt 80 ]; then
+      echo "🚫 TS/TSX full read blocked: $f ($lines lines). Use Serena (find_symbol/get_symbols_overview) or Read with offset+limit." >&2
+      exit 2
+    fi
+    ;;
+  *)
+    if [ "${lines:-0}" -gt 200 ]; then
+      echo "Large file ($lines lines): use offset+limit"
+    fi
+    ;;
+esac
+exit 0

--- a/.claude/hooks/remind-rename-read.sh
+++ b/.claude/hooks/remind-rename-read.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PostToolUse Bash: detect git mv / single-file mv and remind to Read the
+# new path once before any Edit (Edit-tool internal tracker is path-keyed
+# and won't recognize the renamed file otherwise).
+set -u
+cmd=$(jq -r '.command // empty' <<< "$CLAUDE_TOOL_INPUT" 2>/dev/null)
+[ -z "$cmd" ] && exit 0
+
+new_path=""
+if [[ "$cmd" =~ git[[:space:]]+mv[[:space:]]+([^[:space:]]+)[[:space:]]+([^[:space:]]+) ]]; then
+  new_path="${BASH_REMATCH[2]}"
+elif [[ "$cmd" =~ ^[[:space:]]*mv[[:space:]]+([^[:space:]\-][^[:space:]]*)[[:space:]]+([^[:space:]]+)[[:space:]]*$ ]]; then
+  new_path="${BASH_REMATCH[2]}"
+fi
+
+[ -z "$new_path" ] && exit 0
+[ -d "$new_path" ] && exit 0
+
+echo "🔔 Renamed → $new_path. Edit on this path will fail until you Read it. Run: Read('$new_path', limit=1) before any Edit."
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.command // empty' | grep -q 'gh pr merge' && graphify update . || true"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/remind-rename-read.sh"
           }
         ]
       }
@@ -22,11 +26,28 @@
         ]
       },
       {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-blind-edit.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Read",
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.file_path // empty'); lim=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.limit // empty'); [ -n \"$f\" ] && [ -f \"$f\" ] && [ -z \"$lim\" ] && lines=$(wc -l < \"$f\" 2>/dev/null || echo 0) && [ \"$lines\" -gt 200 ] && echo \"Large file ($lines lines): use offset+limit\""
+            "command": ".claude/hooks/check-read.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-reread.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-read-after-edit.sh"
           }
         ]
       },
@@ -78,7 +99,7 @@
   },
   "enabledPlugins": {
     "dev-browser@dev-browser-marketplace": false,
-    "claude-mem@thedotmack": true,
+    "claude-mem@thedotmack": false,
     "superpowers@superpowers-marketplace": true,
     "ralph-loop@claude-plugins-official": false,
     "hookify@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

세션 47ccb5e0 토큰 낭비 분석에서 도출한 5개 훅 신설 — TS/TSX 전체 read, 동일 파일 재read, blind edit, rename 후 Edit 차단 마찰을 LLM 자율에 의존하지 않고 훅으로 차단.

## 변경

**신설 스크립트** (`.claude/hooks/`)
- `check-read.sh` — TS/TSX >80 lines + limit 미지정 Read **block**
- `block-reread.sh` — 동일 파일 Read 직후 Edit/Write 없는 재Read **block**
- `block-blind-edit.sh` — >80 lines 파일에 세션 이력 없는 Edit **block** + `old_string` 매치 라인 기반 권장 Read 범위 제시
- `block-read-after-edit.sh` — Edit/Write 후 같은 파일 전체 Read **block** (git diff or bounded Read 권장)
- `remind-rename-read.sh` — `git mv` / 단일 `mv` 직후 `Read(new_path, limit=1)` 알림 (Edit 차단 마찰 사전 회복)
- `_session-jsonl.sh` — 헬퍼: 현재 세션 JSONL 경로 해결

**`.claude/settings.json`**
- PreToolUse Read: echo-warn 1종 → 3-step block chain
- PreToolUse Edit|MultiEdit: 신규 matcher (blind-edit)
- PostToolUse Bash: rename 알림 추가

기존 hookify 5종 (git workflow), serena-hooks remind/auto-approve, graphify update 모두 유지.

## 동기

| 발견 | 비용 |
|---|---|
| VocReviewTabs.tsx (164줄) 전체 read 2회 (21초 간격) | 기존 200줄 hook 임계 미달 → 무방어 통과 |
| VocReviewDrawer.test.tsx (217줄) 전체 read | echo-warn만이라 LLM 무시 |
| rename 직후 신규 경로 Edit 차단 → "뭐야" 마찰 | 50 calls / 8.6M tokens 1턴 폭발 |

## Test plan
- [x] `jq . .claude/settings.json` valid
- [x] 5개 스크립트 `bash -n` syntax 통과
- [x] check-read: TSX 182줄 무제한 → exit 2 / `limit=20` → exit 0 / 80줄 미만 → exit 0
- [x] remind-rename-read: `git mv foo.tsx bar.tsx` → 알림 출력
- [x] `_session-jsonl.sh` → 현재 세션 JSONL 경로 정확 해결
- [ ] 실세션에서 block-reread / block-read-after-edit 실제 차단 동작 확인 (다음 세션에서 자연 검증)
- [ ] rename 시나리오 end-to-end (git mv → 알림 → Read → Edit 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)