### PR TITLE
feat(w16-c14): VocCommentList — public 댓글 섹션 (stub data)

### DIFF
--- a/frontend/src/features/voc/components/VocCommentList.tsx
+++ b/frontend/src/features/voc/components/VocCommentList.tsx
@@ -35,7 +35,11 @@ export function VocCommentList({
   const [editBody, setEditBody] = useState('');
 
   return (
-    <section data-testid="drawer-comments" className="flex flex-col gap-2">
+    <section
+      data-testid="drawer-comments"
+      className="flex flex-col gap-2"
+      aria-labelledby="voc-comments-heading"
+    >
       <h3
         id="voc-comments-heading"
         className="text-xs font-medium"
@@ -48,7 +52,7 @@ export function VocCommentList({
           아직 작성된 댓글이 없습니다.
         </p>
       ) : (
-        <ul className="flex flex-col gap-2" aria-labelledby="voc-comments-heading">
+        <ul className="flex flex-col gap-2">
           {comments.map((c) => {
             const isOwn = c.author_id === currentUserId;
             const isEditing = editingId === c.id;
@@ -113,7 +117,7 @@ export function VocCommentList({
                     <Textarea
                       value={editBody}
                       onChange={(e) => setEditBody(e.target.value)}
-                      aria-label={`edit comment ${c.id}`}
+                      aria-label="댓글 수정"
                     />
                     <div className="flex gap-2">
                       <Button type="submit" size="sm" disabled={pending || !editBody.trim()}>
@@ -152,7 +156,17 @@ export function VocCommentList({
           <Textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            placeholder="댓글을 입력하세요"
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const next = draft.trim();
+                if (next) {
+                  onAdd(next);
+                  setDraft('');
+                }
+              }
+            }}
+            placeholder="댓글을 입력하세요 (Ctrl+Enter로 등록)"
             aria-label="new comment"
           />
           <Button type="submit" size="sm" disabled={pending || !draft.trim()}>

--- a/frontend/src/features/voc/components/VocCommentList.tsx
+++ b/frontend/src/features/voc/components/VocCommentList.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Textarea } from '../../../components/ui/textarea';
+
+export interface Comment {
+  id: string;
+  voc_id: string;
+  author_id: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Props {
+  comments: Comment[];
+  currentUserId: string;
+  canWrite: boolean;
+  pending: boolean;
+  onAdd: (body: string) => void;
+  onEdit: (id: string, body: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function VocCommentList({
+  comments,
+  currentUserId,
+  canWrite,
+  pending,
+  onAdd,
+  onEdit,
+  onDelete,
+}: Props) {
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editBody, setEditBody] = useState('');
+
+  return (
+    <section data-testid="drawer-comments" className="flex flex-col gap-2">
+      <h3
+        id="voc-comments-heading"
+        className="text-xs font-medium"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        댓글 {comments.length}개
+      </h3>
+      {comments.length === 0 ? (
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          아직 작성된 댓글이 없습니다.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2" aria-labelledby="voc-comments-heading">
+          {comments.map((c) => {
+            const isOwn = c.author_id === currentUserId;
+            const isEditing = editingId === c.id;
+            const edited = c.updated_at !== c.created_at;
+            return (
+              <li
+                key={c.id}
+                className="rounded border p-2 text-sm"
+                style={{
+                  borderColor: 'var(--border-standard)',
+                  background: 'var(--bg-elevated)',
+                }}
+              >
+                <div
+                  className="flex items-center justify-between text-[11px]"
+                  style={{ color: 'var(--text-secondary)' }}
+                >
+                  <span>
+                    {c.created_at.slice(0, 16).replace('T', ' ')}
+                    {edited && <span className="ml-1">(수정됨)</span>}
+                  </span>
+                  {isOwn && !isEditing && (
+                    <span className="flex gap-1">
+                      <button
+                        type="button"
+                        data-testid={`comment-edit-${c.id}`}
+                        aria-label="수정"
+                        className="text-[11px]"
+                        style={{ color: 'var(--text-secondary)' }}
+                        onClick={() => {
+                          setEditingId(c.id);
+                          setEditBody(c.body);
+                        }}
+                      >
+                        수정
+                      </button>
+                      <button
+                        type="button"
+                        data-testid={`comment-delete-${c.id}`}
+                        aria-label="삭제"
+                        className="text-[11px]"
+                        style={{ color: 'var(--text-secondary)' }}
+                        onClick={() => onDelete(c.id)}
+                      >
+                        삭제
+                      </button>
+                    </span>
+                  )}
+                </div>
+                {isEditing ? (
+                  <form
+                    className="mt-1 flex flex-col gap-2"
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      const next = editBody.trim();
+                      if (next) {
+                        onEdit(c.id, next);
+                        setEditingId(null);
+                      }
+                    }}
+                  >
+                    <Textarea
+                      value={editBody}
+                      onChange={(e) => setEditBody(e.target.value)}
+                      aria-label={`edit comment ${c.id}`}
+                    />
+                    <div className="flex gap-2">
+                      <Button type="submit" size="sm" disabled={pending || !editBody.trim()}>
+                        저장
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setEditingId(null)}
+                      >
+                        취소
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <div style={{ color: 'var(--text-primary)' }}>{c.body}</div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {canWrite && (
+        <form
+          className="mt-1 flex flex-col gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const next = draft.trim();
+            if (next) {
+              onAdd(next);
+              setDraft('');
+            }
+          }}
+        >
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="댓글을 입력하세요"
+            aria-label="new comment"
+          />
+          <Button type="submit" size="sm" disabled={pending || !draft.trim()}>
+            저장
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -34,6 +34,7 @@ export function VocDrawerSections({
 }: Props) {
   return (
     <div className="flex flex-col gap-4" data-pcomp="voc-review-sections">
+      {/* TODO(FU): wire api/comments + react-query mutations. C-14 ships UI only. */}
       <VocCommentList
         comments={[]}
         currentUserId={currentUserId}

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -1,0 +1,57 @@
+import type { InternalNote, VocHistoryEntry } from '../../../../../shared/contracts/voc';
+import {
+  VocCommentsPanel,
+  VocAttachmentsPanel,
+  VocHistoryPanel,
+  type AttachmentItem,
+} from './VocReviewSections';
+import { VocCommentList } from './VocCommentList';
+
+interface Props {
+  currentUserId: string;
+  canWrite: boolean;
+  canUpload: boolean;
+  pending: boolean;
+  notes: InternalNote[] | undefined;
+  notesLoading: boolean;
+  attachments: AttachmentItem[];
+  historyEntries: VocHistoryEntry[] | undefined;
+  historyLoading: boolean;
+  onAddNote: (body: string) => void;
+}
+
+export function VocDrawerSections({
+  currentUserId,
+  canWrite,
+  canUpload,
+  pending,
+  notes,
+  notesLoading,
+  attachments,
+  historyEntries,
+  historyLoading,
+  onAddNote,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-4" data-pcomp="voc-review-sections">
+      <VocCommentList
+        comments={[]}
+        currentUserId={currentUserId}
+        canWrite={canWrite}
+        pending={pending}
+        onAdd={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+      />
+      <VocCommentsPanel
+        notes={notes}
+        notesLoading={notesLoading}
+        canWrite={canWrite}
+        pending={pending}
+        onAdd={onAddNote}
+      />
+      <VocAttachmentsPanel items={attachments} canUpload={canUpload} />
+      <VocHistoryPanel entries={historyEntries} loading={historyLoading} />
+    </div>
+  );
+}

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -15,7 +15,9 @@ import {
 } from '../../../components/ui/select';
 import { vocApi } from '../../../api/voc';
 import { queryKeys } from '../../../api/queryKeys';
+import { useContext } from 'react';
 import { useRole } from '../../../hooks/useRole';
+import { AuthContext } from '../../../contexts/AuthContext';
 import {
   VocStatus,
   VocPriority,
@@ -25,12 +27,8 @@ import {
 import { VocPermissionGate } from '../../../components/voc/VocPermissionGate';
 import { LoadingState } from '../../../components/common/LoadingState';
 import { ErrorState } from '../../../components/common/ErrorState';
-import {
-  VocCommentsPanel,
-  VocAttachmentsPanel,
-  VocHistoryPanel,
-  type AttachmentItem,
-} from './VocReviewSections';
+import { type AttachmentItem } from './VocReviewSections';
+import { VocDrawerSections } from './VocDrawerSections';
 import { VocReviewMetaPanel } from './VocReviewMetaPanel';
 
 const STATUS_LOCK_TITLE = '결과 검토가 승인되어 상태 변경이 잠겨 있습니다.';
@@ -86,6 +84,7 @@ export function VocReviewDrawer({
   const detail = useVocDetail(vocId);
   const history = useVocHistory(vocId);
   const { role } = useRole();
+  const auth = useContext(AuthContext);
   const open = !!vocId;
   const voc = detail.data;
   const canWrite = role !== 'user';
@@ -178,19 +177,18 @@ export function VocReviewDrawer({
                 </Select>
               </label>
             </div>
-            <div className="flex flex-col gap-4" data-pcomp="voc-review-sections">
-              <VocCommentsPanel
-                notes={notes}
-                notesLoading={notesLoading}
-                canWrite={canWrite}
-                pending={pending}
-                onAdd={(body) => {
-                  void onAddNote(voc.id, body);
-                }}
-              />
-              <VocAttachmentsPanel items={attachments} canUpload={canUpload} />
-              <VocHistoryPanel entries={history.data} loading={history.isLoading} />
-            </div>
+            <VocDrawerSections
+              currentUserId={auth?.user?.id ?? ''}
+              canWrite={canWrite}
+              canUpload={canUpload}
+              pending={pending}
+              notes={notes}
+              notesLoading={notesLoading}
+              attachments={attachments}
+              historyEntries={history.data}
+              historyLoading={history.isLoading}
+              onAddNote={(body) => void onAddNote(voc.id, body)}
+            />
           </div>
         )}
       </DialogContent>

--- a/frontend/src/features/voc/components/__tests__/VocCommentList.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocCommentList.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VocCommentList, type Comment } from '../VocCommentList';
+
+const ME = '11111111-1111-4111-8111-111111111111';
+const OTHER = '22222222-2222-4222-8222-222222222222';
+
+const mkComment = (over: Partial<Comment> = {}): Comment => ({
+  id: 'c-1',
+  voc_id: 'v-1',
+  author_id: OTHER,
+  body: '리뷰 부탁드립니다',
+  created_at: '2026-05-04T05:30:00.000Z',
+  updated_at: '2026-05-04T05:30:00.000Z',
+  ...over,
+});
+
+describe('VocCommentList', () => {
+  it('빈 상태 — "댓글 0개" 헤더 + 푸터 textarea 노출', () => {
+    render(
+      <VocCommentList
+        comments={[]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /댓글 0개/ })).toBeInTheDocument();
+    expect(screen.getByLabelText('new comment')).toBeInTheDocument();
+  });
+
+  it('댓글 목록 렌더링 + 카운트', () => {
+    render(
+      <VocCommentList
+        comments={[mkComment(), mkComment({ id: 'c-2', body: '확인했습니다' })]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /댓글 2개/ })).toBeInTheDocument();
+    expect(screen.getByText('리뷰 부탁드립니다')).toBeInTheDocument();
+    expect(screen.getByText('확인했습니다')).toBeInTheDocument();
+  });
+
+  it('편집/삭제 버튼은 본인 댓글에만 노출', () => {
+    render(
+      <VocCommentList
+        comments={[mkComment({ id: 'mine', author_id: ME }), mkComment({ id: 'theirs' })]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('comment-edit-mine')).toBeInTheDocument();
+    expect(screen.getByTestId('comment-delete-mine')).toBeInTheDocument();
+    expect(screen.queryByTestId('comment-edit-theirs')).not.toBeInTheDocument();
+  });
+
+  it('canWrite=false → 푸터 숨김', () => {
+    render(
+      <VocCommentList
+        comments={[mkComment()]}
+        currentUserId={ME}
+        canWrite={false}
+        pending={false}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
+  });
+
+  it('저장 클릭 → onAdd 호출 + textarea 비움', () => {
+    const onAdd = vi.fn();
+    render(
+      <VocCommentList
+        comments={[]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={onAdd}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    const ta = screen.getByLabelText('new comment') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: '새 댓글' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    expect(onAdd).toHaveBeenCalledWith('새 댓글');
+    expect(ta.value).toBe('');
+  });
+});

--- a/frontend/src/features/voc/components/__tests__/VocCommentList.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocCommentList.test.tsx
@@ -81,6 +81,80 @@ describe('VocCommentList', () => {
     expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
   });
 
+  it('편집 → 취소 → 원본 보존 (수정 안됨)', () => {
+    const onEdit = vi.fn();
+    render(
+      <VocCommentList
+        comments={[mkComment({ id: 'mine', author_id: ME, body: '원본 텍스트' })]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={vi.fn()}
+        onEdit={onEdit}
+        onDelete={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('comment-edit-mine'));
+    const ta = screen.getByLabelText('댓글 수정') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: '바뀐 텍스트' } });
+    fireEvent.click(screen.getByRole('button', { name: '취소' }));
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.getByText('원본 텍스트')).toBeInTheDocument();
+    expect(screen.queryByLabelText('댓글 수정')).not.toBeInTheDocument();
+  });
+
+  it('공백만 입력 → 저장 disabled, onAdd 미호출', () => {
+    const onAdd = vi.fn();
+    render(
+      <VocCommentList
+        comments={[]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={onAdd}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('new comment'), { target: { value: '   ' } });
+    expect(screen.getByRole('button', { name: '저장' })).toBeDisabled();
+  });
+
+  it('pending=true → 저장 버튼 disabled', () => {
+    render(
+      <VocCommentList
+        comments={[]}
+        currentUserId={ME}
+        canWrite
+        pending={true}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('new comment'), { target: { value: '본문' } });
+    expect(screen.getByRole('button', { name: '저장' })).toBeDisabled();
+  });
+
+  it('Ctrl+Enter → onAdd 호출', () => {
+    const onAdd = vi.fn();
+    render(
+      <VocCommentList
+        comments={[]}
+        currentUserId={ME}
+        canWrite
+        pending={false}
+        onAdd={onAdd}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    const ta = screen.getByLabelText('new comment');
+    fireEvent.change(ta, { target: { value: '단축키' } });
+    fireEvent.keyDown(ta, { key: 'Enter', ctrlKey: true });
+    expect(onAdd).toHaveBeenCalledWith('단축키');
+  });
+
   it('저장 클릭 → onAdd 호출 + textarea 비움', () => {
     const onAdd = vi.fn();
     render(


### PR DESCRIPTION
## Summary

Wave 1.6 ε batch 1번째 leaf. VocReviewSections children/composition 슬롯에 끼워넣을 신규 컴포넌트 `VocCommentList`. 데이터 레이어는 후속 follow-up 으로 이연 — drawer 는 빈 배열 + no-op stub.

prototype 기준 (`drawer-comments.js`):
- 헤더 "댓글 N개", 빈 상태 메시지, canWrite 시 푸터 textarea, 본인 댓글에만 수정/삭제 메뉴, edited 표시.
- Ctrl/Cmd+Enter 로 새 댓글 등록 (drawer.js:391 동등).

## 주요 변경

- `frontend/src/features/voc/components/VocCommentList.tsx` (신규)
- `frontend/src/features/voc/components/VocDrawerSections.tsx` (신규 — 200줄 max-lines 충돌 해소를 위해 sections 컬럼 분리, `// TODO(FU)` stub 마커 포함)
- `frontend/src/features/voc/components/VocReviewDrawer.tsx`: AuthContext useContext 직접 구독 (테스트 호환), VocCommentList 호출부 추가.
- `frontend/src/features/voc/components/__tests__/VocCommentList.test.tsx` (신규, 9 tests)

기존 mislabeled `VocCommentsPanel`("코멘트" 헤더로 InternalNote 렌더) 은 후속 leaf C-15 (VocInternalNotes) 에서 교체 + 삭제 예정.

## 적대적 리뷰 4명 (FE-arch / 디자인-a11y / 테스트 / prototype-parity) 반영

- aria-labelledby 를 `<ul>` 에서 `<section>` 으로 이동 (랜드마크 미라벨 결함).
- 편집 textarea aria-label "댓글 수정" (이전엔 raw UUID).
- Ctrl/Cmd+Enter 단축키 추가 (prototype 동등).
- VocDrawerSections stub 콜백에 `// TODO(FU)` 마커.

defer: AuthContext leak 픽스 (테스트 인프라 변경 필요), `(수정됨)` 배지 wiring (parent echo 필요), VocReviewSections 리네임 (cosmetic).

## Test plan

- [x] `npm run typecheck -w frontend` 통과
- [x] `npm run test -w frontend -- --run` — 359/359 pass
- [x] `npm run lint -w frontend` 통과
- [ ] `/voc` 드로어 브라우저 검증 — manager 로그인 → 댓글 섹션 노출 + Ctrl+Enter 동작 확인 (수면 후 사용자 검수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)