### PR TITLE
feat(w16-c16): VocSubTaskList — 서브태스크 섹션 (stub data)

### DIFF
--- a/frontend/src/components/voc/__tests__/VocListPage.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListPage.test.tsx
@@ -87,8 +87,9 @@ describe('VocListPage — Wave 1 RTL', () => {
     vi.mocked(vocApi.notes).mockResolvedValue([]);
     renderPage({ initialUrl: `/voc?id=${target.id}`, role: 'user' });
     await waitFor(() => expect(screen.getByTestId('voc-drawer')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
-    expect(screen.queryByLabelText('new note')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
+    expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-internal-notes')).not.toBeInTheDocument();
   });
 
   it('F-T4b manager role contrast: 같은 vocId에서 note form은 노출 (gate 조건이 user 전용임을 증명)', async () => {
@@ -103,7 +104,7 @@ describe('VocListPage — Wave 1 RTL', () => {
     vi.mocked(vocApi.notes).mockResolvedValue([]);
     renderPage({ initialUrl: `/voc?id=${target.id}`, role: 'manager' });
     await waitFor(() => expect(screen.getByTestId('voc-drawer')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByLabelText('new note')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText('new internal note')).toBeInTheDocument());
   });
 
   it('F-T5 drawer Escape 닫힘: URL ?id 제거 — 다음 list query에 stale id 유출 없음', async () => {

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -5,7 +5,6 @@ import { VocCommentList } from './VocCommentList';
 import { VocInternalNotes } from './VocInternalNotes';
 
 interface Props {
-  vocId: string;
   currentUserId: string;
   role: Role;
   isOwner: boolean;
@@ -21,7 +20,6 @@ interface Props {
 }
 
 export function VocDrawerSections({
-  vocId,
   currentUserId,
   role,
   isOwner,
@@ -48,7 +46,6 @@ export function VocDrawerSections({
         onDelete={() => {}}
       />
       <VocInternalNotes
-        vocId={vocId}
         notes={notes}
         notesLoading={notesLoading}
         pending={pending}

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -1,14 +1,14 @@
 import type { InternalNote, VocHistoryEntry } from '../../../../../shared/contracts/voc';
-import {
-  VocCommentsPanel,
-  VocAttachmentsPanel,
-  VocHistoryPanel,
-  type AttachmentItem,
-} from './VocReviewSections';
+import type { Role } from '../../../../../shared/contracts/common';
+import { VocAttachmentsPanel, VocHistoryPanel, type AttachmentItem } from './VocReviewSections';
 import { VocCommentList } from './VocCommentList';
+import { VocInternalNotes } from './VocInternalNotes';
 
 interface Props {
+  vocId: string;
   currentUserId: string;
+  role: Role;
+  isOwner: boolean;
   canWrite: boolean;
   canUpload: boolean;
   pending: boolean;
@@ -21,7 +21,10 @@ interface Props {
 }
 
 export function VocDrawerSections({
+  vocId,
   currentUserId,
+  role,
+  isOwner,
   canWrite,
   canUpload,
   pending,
@@ -44,11 +47,13 @@ export function VocDrawerSections({
         onEdit={() => {}}
         onDelete={() => {}}
       />
-      <VocCommentsPanel
+      <VocInternalNotes
+        vocId={vocId}
         notes={notes}
         notesLoading={notesLoading}
-        canWrite={canWrite}
         pending={pending}
+        role={role}
+        isOwner={isOwner}
         onAdd={onAddNote}
       />
       <VocAttachmentsPanel items={attachments} canUpload={canUpload} />

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -3,8 +3,11 @@ import type { Role } from '../../../../../shared/contracts/common';
 import { VocAttachmentsPanel, VocHistoryPanel, type AttachmentItem } from './VocReviewSections';
 import { VocCommentList } from './VocCommentList';
 import { VocInternalNotes } from './VocInternalNotes';
+import { VocSubTaskList } from './VocSubTaskList';
 
 interface Props {
+  vocId: string;
+  parentIsSubtask: boolean;
   currentUserId: string;
   role: Role;
   isOwner: boolean;
@@ -20,6 +23,8 @@ interface Props {
 }
 
 export function VocDrawerSections({
+  vocId,
+  parentIsSubtask,
   currentUserId,
   role,
   isOwner,
@@ -35,6 +40,25 @@ export function VocDrawerSections({
 }: Props) {
   return (
     <div className="flex flex-col gap-4" data-pcomp="voc-review-sections">
+      <VocHistoryPanel entries={historyEntries} loading={historyLoading} />
+      {/* TODO(FU): wire subtask CRUD + onOpen navigation. C-16 ships UI only. */}
+      <VocSubTaskList
+        parentId={vocId}
+        parentIsSubtask={parentIsSubtask}
+        subs={[]}
+        canAdd={canWrite}
+        onOpen={() => {}}
+        onAdd={() => {}}
+      />
+      <VocAttachmentsPanel items={attachments} canUpload={canUpload} />
+      <VocInternalNotes
+        notes={notes}
+        notesLoading={notesLoading}
+        pending={pending}
+        role={role}
+        isOwner={isOwner}
+        onAdd={onAddNote}
+      />
       {/* TODO(FU): wire api/comments + react-query mutations. C-14 ships UI only. */}
       <VocCommentList
         comments={[]}
@@ -45,16 +69,6 @@ export function VocDrawerSections({
         onEdit={() => {}}
         onDelete={() => {}}
       />
-      <VocInternalNotes
-        notes={notes}
-        notesLoading={notesLoading}
-        pending={pending}
-        role={role}
-        isOwner={isOwner}
-        onAdd={onAddNote}
-      />
-      <VocAttachmentsPanel items={attachments} canUpload={canUpload} />
-      <VocHistoryPanel entries={historyEntries} loading={historyLoading} />
     </div>
   );
 }

--- a/frontend/src/features/voc/components/VocInternalNotes.tsx
+++ b/frontend/src/features/voc/components/VocInternalNotes.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Textarea } from '../../../components/ui/textarea';
+import { LoadingState } from '../../../components/common/LoadingState';
+import type { InternalNote } from '../../../../../shared/contracts/voc';
+import type { Role } from '../../../../../shared/contracts/common';
+
+interface Props {
+  vocId: string;
+  notes: InternalNote[] | undefined;
+  notesLoading: boolean;
+  pending: boolean;
+  role: Role;
+  isOwner: boolean;
+  onAdd: (body: string) => void;
+}
+
+function canViewInternalNotes(role: Role, isOwner: boolean): boolean {
+  if (role === 'admin' || role === 'manager') return true;
+  if (role === 'dev' && isOwner) return true;
+  return false;
+}
+
+export function VocInternalNotes({ notes, notesLoading, pending, role, isOwner, onAdd }: Props) {
+  const [body, setBody] = useState('');
+
+  if (!canViewInternalNotes(role, isOwner)) return null;
+
+  const count = notes?.length ?? 0;
+
+  return (
+    <section
+      data-testid="drawer-internal-notes"
+      className="flex flex-col gap-2 rounded border p-2"
+      style={{
+        borderColor: 'var(--border-standard)',
+        background: 'var(--status-amber-bg, var(--bg-elevated))',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <h3
+          id="voc-internal-notes-heading"
+          className="text-xs font-medium"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          내부 메모 (Internal Notes)
+        </h3>
+        <span
+          data-testid="internal-notes-count"
+          className="rounded-full px-2 text-[11px]"
+          style={{
+            background: 'var(--bg-surface)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {count}
+        </span>
+      </div>
+      {notesLoading && <LoadingState />}
+      {!notesLoading && count === 0 && (
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          등록된 내부 메모가 없습니다.
+        </p>
+      )}
+      {notes && count > 0 && (
+        <ul className="flex flex-col gap-2" aria-labelledby="voc-internal-notes-heading">
+          {notes.map((n) => (
+            <li
+              key={n.id}
+              className="rounded border p-2 text-sm"
+              style={{
+                borderColor: 'var(--border-standard)',
+                background: 'var(--bg-surface)',
+              }}
+            >
+              <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                {n.created_at.slice(0, 16).replace('T', ' ')}
+              </div>
+              <div style={{ color: 'var(--text-primary)' }}>{n.body}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <form
+        className="mt-1 flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const next = body.trim();
+          if (next) {
+            onAdd(next);
+            setBody('');
+          }
+        }}
+      >
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="내부 메모를 입력하세요 (담당자·관리자만 볼 수 있음)"
+          aria-label="new internal note"
+        />
+        <Button type="submit" size="sm" disabled={pending || !body.trim()}>
+          저장
+        </Button>
+        <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+          담당자·관리자에게만 공개. 공개 댓글과 별도 저장.
+        </p>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/features/voc/components/VocInternalNotes.tsx
+++ b/frontend/src/features/voc/components/VocInternalNotes.tsx
@@ -6,7 +6,6 @@ import type { InternalNote } from '../../../../../shared/contracts/voc';
 import type { Role } from '../../../../../shared/contracts/common';
 
 interface Props {
-  vocId: string;
   notes: InternalNote[] | undefined;
   notesLoading: boolean;
   pending: boolean;
@@ -34,28 +33,21 @@ export function VocInternalNotes({ notes, notesLoading, pending, role, isOwner, 
       className="flex flex-col gap-2 rounded border p-2"
       style={{
         borderColor: 'var(--border-standard)',
-        background: 'var(--status-amber-bg, var(--bg-elevated))',
+        background: 'var(--status-amber-bg)',
       }}
     >
-      <div className="flex items-center gap-2">
-        <h3
-          id="voc-internal-notes-heading"
-          className="text-xs font-medium"
-          style={{ color: 'var(--text-secondary)' }}
-        >
-          내부 메모 (Internal Notes)
-        </h3>
-        <span
-          data-testid="internal-notes-count"
-          className="rounded-full px-2 text-[11px]"
-          style={{
-            background: 'var(--bg-surface)',
-            color: 'var(--text-secondary)',
-          }}
-        >
-          {count}
-        </span>
-      </div>
+      <h3
+        id="voc-internal-notes-heading"
+        className="text-xs font-medium"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        내부 메모
+        {count > 0 && (
+          <span data-testid="internal-notes-count" className="ml-1">
+            {count}개
+          </span>
+        )}
+      </h3>
       {notesLoading && <LoadingState />}
       {!notesLoading && count === 0 && (
         <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -178,7 +178,6 @@ export function VocReviewDrawer({
               </label>
             </div>
             <VocDrawerSections
-              vocId={voc.id}
               currentUserId={auth?.user?.id ?? ''}
               role={role}
               isOwner={!!auth?.user?.id && voc.assignee_id === auth.user.id}

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -178,7 +178,10 @@ export function VocReviewDrawer({
               </label>
             </div>
             <VocDrawerSections
+              vocId={voc.id}
               currentUserId={auth?.user?.id ?? ''}
+              role={role}
+              isOwner={!!auth?.user?.id && voc.assignee_id === auth.user.id}
               canWrite={canWrite}
               canUpload={canUpload}
               pending={pending}

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -178,6 +178,8 @@ export function VocReviewDrawer({
               </label>
             </div>
             <VocDrawerSections
+              vocId={voc.id}
+              parentIsSubtask={voc.parent_id !== null}
               currentUserId={auth?.user?.id ?? ''}
               role={role}
               isOwner={!!auth?.user?.id && voc.assignee_id === auth.user.id}

--- a/frontend/src/features/voc/components/VocReviewSections.tsx
+++ b/frontend/src/features/voc/components/VocReviewSections.tsx
@@ -1,83 +1,12 @@
-import { useState } from 'react';
 import { Button } from '../../../components/ui/button';
-import { Textarea } from '../../../components/ui/textarea';
 import { LoadingState } from '../../../components/common/LoadingState';
-import type { InternalNote, VocHistoryEntry } from '../../../../../shared/contracts/voc';
+import type { VocHistoryEntry } from '../../../../../shared/contracts/voc';
 
 export interface AttachmentItem {
   id: string;
   name: string;
   size: number;
   href: string;
-}
-
-interface CommentsPanelProps {
-  notes: InternalNote[] | undefined;
-  notesLoading: boolean;
-  canWrite: boolean;
-  pending: boolean;
-  onAdd: (body: string) => void;
-}
-
-export function VocCommentsPanel({
-  notes,
-  notesLoading,
-  canWrite,
-  pending,
-  onAdd,
-}: CommentsPanelProps) {
-  const [body, setBody] = useState('');
-  return (
-    <section data-testid="drawer-notes" className="flex flex-col gap-2">
-      <h3 className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-        코멘트
-      </h3>
-      {notesLoading && <LoadingState />}
-      {!notesLoading && notes && notes.length === 0 && (
-        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-          아직 작성된 코멘트가 없습니다.
-        </p>
-      )}
-      {notes && notes.length > 0 && (
-        <ul className="flex flex-col gap-2">
-          {notes.map((n) => (
-            <li
-              key={n.id}
-              className="rounded border p-2 text-sm"
-              style={{ borderColor: 'var(--border-standard)' }}
-            >
-              <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
-                {n.created_at.slice(0, 16).replace('T', ' ')}
-              </div>
-              {n.body}
-            </li>
-          ))}
-        </ul>
-      )}
-      {canWrite && (
-        <form
-          className="mt-1 flex flex-col gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (body.trim()) {
-              onAdd(body.trim());
-              setBody('');
-            }
-          }}
-        >
-          <Textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="코멘트를 입력하세요"
-            aria-label="new note"
-          />
-          <Button type="submit" disabled={pending || !body.trim()} size="sm">
-            저장
-          </Button>
-        </form>
-      )}
-    </section>
-  );
 }
 
 interface AttachmentsPanelProps {

--- a/frontend/src/features/voc/components/VocSubTaskList.tsx
+++ b/frontend/src/features/voc/components/VocSubTaskList.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Input } from '../../../components/ui/input';
+import type { VocStatus } from '../../../../../shared/contracts/voc';
+
+export interface SubTaskItem {
+  id: string;
+  title: string;
+  status: VocStatus;
+}
+
+interface Props {
+  parentId: string;
+  parentIsSubtask: boolean;
+  subs: SubTaskItem[];
+  canAdd: boolean;
+  onOpen: (id: string) => void;
+  onAdd: (title: string) => void;
+}
+
+export function VocSubTaskList({ parentIsSubtask, subs, canAdd, onOpen, onAdd }: Props) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const showAddButton = canAdd && !parentIsSubtask && !formOpen;
+
+  return (
+    <section data-testid="drawer-subtasks" className="flex flex-col gap-2">
+      <h3
+        id="voc-subtasks-heading"
+        className="text-xs font-medium"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        서브태스크 {subs.length}개
+      </h3>
+      {subs.length === 0 ? (
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          서브태스크가 없습니다.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1" aria-labelledby="voc-subtasks-heading">
+          {subs.map((s) => (
+            <li
+              key={s.id}
+              className="flex items-center gap-2 rounded border p-2 text-sm"
+              style={{
+                borderColor: 'var(--border-standard)',
+                background: 'var(--bg-elevated)',
+              }}
+            >
+              <span
+                className="rounded px-2 py-0.5 text-[11px]"
+                style={{
+                  background: 'var(--bg-surface)',
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                {s.status}
+              </span>
+              <button
+                type="button"
+                className="flex-1 text-left"
+                style={{ color: 'var(--text-primary)' }}
+                onClick={() => onOpen(s.id)}
+              >
+                {s.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {parentIsSubtask && (
+        <p
+          className="text-[11px]"
+          style={{ color: 'var(--text-quaternary, var(--text-secondary))' }}
+        >
+          서브태스크 추가 불가 (최대 1레벨)
+        </p>
+      )}
+      {showAddButton && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="self-start"
+          onClick={() => setFormOpen(true)}
+        >
+          서브태스크 추가
+        </Button>
+      )}
+      {formOpen && (
+        <form
+          className="flex gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const next = title.trim();
+            if (next) {
+              onAdd(next);
+              setTitle('');
+              setFormOpen(false);
+            }
+          }}
+        >
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="서브태스크 제목 입력..."
+            aria-label="new subtask title"
+            autoFocus
+          />
+          <Button type="submit" size="sm" disabled={!title.trim()}>
+            저장
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => {
+              setFormOpen(false);
+              setTitle('');
+            }}
+          >
+            취소
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/voc/components/VocSubTaskList.tsx
+++ b/frontend/src/features/voc/components/VocSubTaskList.tsx
@@ -18,13 +18,18 @@ interface Props {
   onAdd: (title: string) => void;
 }
 
-export function VocSubTaskList({ parentIsSubtask, subs, canAdd, onOpen, onAdd }: Props) {
+export function VocSubTaskList({ parentId, parentIsSubtask, subs, canAdd, onOpen, onAdd }: Props) {
   const [formOpen, setFormOpen] = useState(false);
   const [title, setTitle] = useState('');
   const showAddButton = canAdd && !parentIsSubtask && !formOpen;
 
   return (
-    <section data-testid="drawer-subtasks" className="flex flex-col gap-2">
+    <section
+      data-testid="drawer-subtasks"
+      data-parent-id={parentId}
+      className="flex flex-col gap-2"
+      aria-labelledby="voc-subtasks-heading"
+    >
       <h3
         id="voc-subtasks-heading"
         className="text-xs font-medium"
@@ -41,38 +46,37 @@ export function VocSubTaskList({ parentIsSubtask, subs, canAdd, onOpen, onAdd }:
           {subs.map((s) => (
             <li
               key={s.id}
-              className="flex items-center gap-2 rounded border p-2 text-sm"
+              className="rounded border text-sm"
               style={{
                 borderColor: 'var(--border-standard)',
                 background: 'var(--bg-elevated)',
               }}
             >
-              <span
-                className="rounded px-2 py-0.5 text-[11px]"
-                style={{
-                  background: 'var(--bg-surface)',
-                  color: 'var(--text-secondary)',
-                }}
-              >
-                {s.status}
-              </span>
               <button
                 type="button"
-                className="flex-1 text-left"
+                className="flex w-full items-center gap-2 p-2 text-left"
                 style={{ color: 'var(--text-primary)' }}
+                aria-label={`${s.status} ${s.title}`}
                 onClick={() => onOpen(s.id)}
               >
-                {s.title}
+                <span
+                  aria-hidden="true"
+                  className="rounded px-2 py-0.5 text-[11px]"
+                  style={{
+                    background: 'var(--bg-surface)',
+                    color: 'var(--text-secondary)',
+                  }}
+                >
+                  {s.status}
+                </span>
+                <span className="flex-1">{s.title}</span>
               </button>
             </li>
           ))}
         </ul>
       )}
       {parentIsSubtask && (
-        <p
-          className="text-[11px]"
-          style={{ color: 'var(--text-quaternary, var(--text-secondary))' }}
-        >
+        <p className="text-[11px]" style={{ color: 'var(--text-quaternary)' }}>
           서브태스크 추가 불가 (최대 1레벨)
         </p>
       )}

--- a/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VocInternalNotes } from '../VocInternalNotes';
+import type { InternalNote } from '../../../../../../shared/contracts/voc';
+import type { Role } from '../../../../../../shared/contracts/common';
+
+const note = (over: Partial<InternalNote> = {}): InternalNote => ({
+  id: 'n-1',
+  voc_id: 'v-1',
+  author_id: 'u-1',
+  body: '내부 검토 결과 정상',
+  created_at: '2026-05-04T05:00:00.000Z',
+  updated_at: '2026-05-04T05:00:00.000Z',
+  ...over,
+});
+
+const baseProps = {
+  vocId: 'v-1',
+  notes: [] as InternalNote[],
+  notesLoading: false,
+  pending: false,
+  onAdd: vi.fn(),
+};
+
+describe('VocInternalNotes — role gate', () => {
+  it('user 역할 → 렌더하지 않음 (null 반환)', () => {
+    const { container } = render(
+      <VocInternalNotes {...baseProps} role={'user' as Role} isOwner={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dev + isOwner=false → 렌더하지 않음', () => {
+    const { container } = render(
+      <VocInternalNotes {...baseProps} role={'dev' as Role} isOwner={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dev + isOwner=true → 렌더함', () => {
+    render(<VocInternalNotes {...baseProps} role={'dev' as Role} isOwner={true} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+
+  it('admin → 항상 렌더', () => {
+    render(<VocInternalNotes {...baseProps} role={'admin' as Role} isOwner={false} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+
+  it('manager → 항상 렌더', () => {
+    render(<VocInternalNotes {...baseProps} role={'manager' as Role} isOwner={false} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+});
+
+describe('VocInternalNotes — content', () => {
+  it('카운트 배지 + 내용 렌더', () => {
+    render(
+      <VocInternalNotes
+        {...baseProps}
+        notes={[note(), note({ id: 'n-2', body: '두번째 메모' })]}
+        role={'admin' as Role}
+        isOwner={false}
+      />,
+    );
+    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2');
+    expect(screen.getByText('내부 검토 결과 정상')).toBeInTheDocument();
+    expect(screen.getByText('두번째 메모')).toBeInTheDocument();
+  });
+
+  it('빈 상태 메시지', () => {
+    render(<VocInternalNotes {...baseProps} notes={[]} role={'admin' as Role} isOwner={false} />);
+    expect(screen.getByText('등록된 내부 메모가 없습니다.')).toBeInTheDocument();
+  });
+
+  it('저장 → onAdd 호출 + textarea 비움', () => {
+    const onAdd = vi.fn();
+    render(
+      <VocInternalNotes {...baseProps} onAdd={onAdd} role={'admin' as Role} isOwner={false} />,
+    );
+    const ta = screen.getByLabelText('new internal note') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: '비공개 메모' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    expect(onAdd).toHaveBeenCalledWith('비공개 메모');
+    expect(ta.value).toBe('');
+  });
+});

--- a/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
@@ -15,7 +15,6 @@ const note = (over: Partial<InternalNote> = {}): InternalNote => ({
 });
 
 const baseProps = {
-  vocId: 'v-1',
   notes: [] as InternalNote[],
   notesLoading: false,
   pending: false,
@@ -63,14 +62,28 @@ describe('VocInternalNotes — content', () => {
         isOwner={false}
       />,
     );
-    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2개');
     expect(screen.getByText('내부 검토 결과 정상')).toBeInTheDocument();
     expect(screen.getByText('두번째 메모')).toBeInTheDocument();
   });
 
-  it('빈 상태 메시지', () => {
+  it('빈 상태 메시지 + 카운트 배지 미노출 (count===0)', () => {
     render(<VocInternalNotes {...baseProps} notes={[]} role={'admin' as Role} isOwner={false} />);
     expect(screen.getByText('등록된 내부 메모가 없습니다.')).toBeInTheDocument();
+    expect(screen.queryByTestId('internal-notes-count')).not.toBeInTheDocument();
+  });
+
+  it('notesLoading=true → LoadingState 노출 + 빈 메시지 미노출', () => {
+    render(
+      <VocInternalNotes
+        {...baseProps}
+        notes={undefined}
+        notesLoading={true}
+        role={'admin' as Role}
+        isOwner={false}
+      />,
+    );
+    expect(screen.queryByText('등록된 내부 메모가 없습니다.')).not.toBeInTheDocument();
   });
 
   it('저장 → onAdd 호출 + textarea 비움', () => {

--- a/frontend/src/features/voc/components/__tests__/VocReviewDrawer.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocReviewDrawer.test.tsx
@@ -74,27 +74,31 @@ describe('VocReviewDrawer — Wave 1.6 C-13 (flat sections)', () => {
 
   const target = VOC_FIXTURES.find((r) => r.deleted_at === null)!;
 
-  it('탭 UI 없이 3개 섹션(코멘트/첨부/변경이력) 동시 노출', async () => {
+  it('탭 UI 없이 4개 섹션(댓글/내부메모/첨부/변경이력) 동시 노출 (manager)', async () => {
     renderDrawer('manager', target.id);
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('tab')).toHaveLength(0);
-    expect(screen.getByTestId('drawer-notes')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-comments')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-internal-notes')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-attachments')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-history')).toBeInTheDocument();
   });
 
-  it('role=user → 코멘트 작성 form 미노출 + 첨부 업로드 button 미노출', async () => {
+  it('role=user → 댓글 작성 form 미노출 + 내부메모 섹션 미노출 + 첨부 업로드 button 미노출', async () => {
     renderDrawer('user', target.id);
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
-    expect(screen.queryByLabelText('new note')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
+    expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-internal-notes')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('첨부 업로드')).not.toBeInTheDocument();
   });
 
-  it('role=manager → 3 섹션 모두 가시 + 작성 form 노출', async () => {
+  it('role=manager → 4 섹션 모두 가시 + 작성 form 노출', async () => {
     renderDrawer('manager', target.id);
-    await waitFor(() => expect(screen.getByLabelText('new note')).toBeInTheDocument());
-    expect(screen.getByTestId('drawer-notes')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('new comment')).toBeInTheDocument());
+    expect(screen.getByLabelText('new internal note')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-comments')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-internal-notes')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-attachments')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-history')).toBeInTheDocument();
   });
@@ -103,8 +107,7 @@ describe('VocReviewDrawer — Wave 1.6 C-13 (flat sections)', () => {
     renderDrawer('manager', target.id, { deleted: true });
     await waitFor(() => expect(screen.getByTestId('voc-permission-gate')).toBeInTheDocument());
     expect(screen.getByText(/삭제된 항목/)).toBeInTheDocument();
-    // 게이트가 본문 자체를 막아야 한다.
-    expect(screen.queryByTestId('drawer-notes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-comments')).not.toBeInTheDocument();
   });
 
   it('변경이력 섹션에 timeline listitem 즉시 노출 (탭 클릭 불필요)', async () => {

--- a/frontend/src/features/voc/components/__tests__/VocSubTaskList.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocSubTaskList.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VocSubTaskList, type SubTaskItem } from '../VocSubTaskList';
+
+const item = (over: Partial<SubTaskItem> = {}): SubTaskItem => ({
+  id: 's-1',
+  title: '하위 작업 1',
+  status: '접수',
+  ...over,
+});
+
+const baseProps = {
+  parentId: 'v-parent',
+  parentIsSubtask: false,
+  subs: [] as SubTaskItem[],
+  canAdd: true,
+  onOpen: vi.fn(),
+  onAdd: vi.fn(),
+};
+
+describe('VocSubTaskList', () => {
+  it('빈 상태 — "서브태스크 0개" 헤더 + 추가 버튼', () => {
+    render(<VocSubTaskList {...baseProps} />);
+    expect(screen.getByRole('heading', { name: /서브태스크 0개/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '서브태스크 추가' })).toBeInTheDocument();
+  });
+
+  it('서브태스크 목록 렌더 + 카운트', () => {
+    render(<VocSubTaskList {...baseProps} subs={[item(), item({ id: 's-2', title: '두번째' })]} />);
+    expect(screen.getByRole('heading', { name: /서브태스크 2개/ })).toBeInTheDocument();
+    expect(screen.getByText('하위 작업 1')).toBeInTheDocument();
+    expect(screen.getByText('두번째')).toBeInTheDocument();
+  });
+
+  it('parent가 이미 subtask → 추가 disabled + 안내 메시지', () => {
+    render(<VocSubTaskList {...baseProps} parentIsSubtask />);
+    expect(screen.queryByRole('button', { name: '서브태스크 추가' })).not.toBeInTheDocument();
+    expect(screen.getByText(/최대 1레벨/)).toBeInTheDocument();
+  });
+
+  it('canAdd=false → 추가 버튼 미노출', () => {
+    render(<VocSubTaskList {...baseProps} canAdd={false} />);
+    expect(screen.queryByRole('button', { name: '서브태스크 추가' })).not.toBeInTheDocument();
+  });
+
+  it('서브태스크 행 클릭 → onOpen(id)', () => {
+    const onOpen = vi.fn();
+    render(<VocSubTaskList {...baseProps} subs={[item()]} onOpen={onOpen} />);
+    fireEvent.click(screen.getByText('하위 작업 1'));
+    expect(onOpen).toHaveBeenCalledWith('s-1');
+  });
+
+  it('추가 버튼 → 인라인 form, 제목 입력 후 저장 → onAdd 호출', () => {
+    const onAdd = vi.fn();
+    render(<VocSubTaskList {...baseProps} onAdd={onAdd} />);
+    fireEvent.click(screen.getByRole('button', { name: '서브태스크 추가' }));
+    const input = screen.getByLabelText('new subtask title') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '신규 서브' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    expect(onAdd).toHaveBeenCalledWith('신규 서브');
+  });
+});

--- a/frontend/src/features/voc/components/__tests__/VocSubTaskList.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocSubTaskList.test.tsx
@@ -38,15 +38,22 @@ describe('VocSubTaskList', () => {
     expect(screen.getByText(/최대 1레벨/)).toBeInTheDocument();
   });
 
+  it('parentIsSubtask=true + canAdd=true → parentIsSubtask 가 우선 (추가 버튼 미노출)', () => {
+    render(<VocSubTaskList {...baseProps} parentIsSubtask canAdd />);
+    expect(screen.queryByRole('button', { name: '서브태스크 추가' })).not.toBeInTheDocument();
+    expect(screen.getByText(/최대 1레벨/)).toBeInTheDocument();
+  });
+
   it('canAdd=false → 추가 버튼 미노출', () => {
     render(<VocSubTaskList {...baseProps} canAdd={false} />);
     expect(screen.queryByRole('button', { name: '서브태스크 추가' })).not.toBeInTheDocument();
   });
 
-  it('서브태스크 행 클릭 → onOpen(id)', () => {
+  it('서브태스크 행 클릭 → onOpen(id), 버튼 accessible name = "{status} {title}"', () => {
     const onOpen = vi.fn();
     render(<VocSubTaskList {...baseProps} subs={[item()]} onOpen={onOpen} />);
-    fireEvent.click(screen.getByText('하위 작업 1'));
+    const btn = screen.getByRole('button', { name: '접수 하위 작업 1' });
+    fireEvent.click(btn);
     expect(onOpen).toHaveBeenCalledWith('s-1');
   });
 


### PR DESCRIPTION
## Summary

Wave 1.6 ε batch 마지막 leaf. VocReviewSections children/composition 슬롯에 서브태스크 섹션 추가 + 섹션 순서 prototype 정렬.

> 🔗 stacked PR: base = #195 (C-15). C-14·C-15 머지 후 base=main 으로 자동 전환.

prototype 기준 (`drawer-core.js`):
- 헤더 "서브태스크 N개", 빈 상태 메시지, 행 클릭 → onOpen(id), 추가 버튼 → 인라인 form (제목 input + 저장/취소).
- max 1레벨 정책: parentIsSubtask=true 면 추가 버튼 미노출 + "최대 1레벨" 안내.
- canAdd=false 면 추가 버튼 미노출.

## 주요 변경

- `frontend/src/features/voc/components/VocSubTaskList.tsx` (신규)
- `frontend/src/features/voc/components/VocDrawerSections.tsx`: VocSubTaskList 호출부 추가 + **섹션 순서를 prototype `drawer.js` 와 정렬: 변경이력 → 서브태스크 → 첨부 → 내부메모 → 댓글**.
- `frontend/src/features/voc/components/VocReviewDrawer.tsx`: parentIsSubtask = `voc.parent_id !== null` 전달.
- `frontend/src/features/voc/components/__tests__/VocSubTaskList.test.tsx` (신규, 7 tests)

데이터/엔드포인트 (subtask CRUD)는 후속 follow-up 으로 이연 — drawer 는 빈 배열 + no-op 콜백 stub. `// TODO(FU)` 마커 포함.

## 적대적 리뷰 반영

- 서브태스크 행: status 배지가 button 외부 sibling 이라 SR 사용자가 status 인식 못 하던 결함 (BLOCK 디자인-a11y) — badge + title 을 단일 `<button aria-label="{status} {title}">` 안에 합치고 배지를 `aria-hidden`.
- 섹션에 aria-labelledby 추가 (랜드마크 라벨링).
- parentId prop 미사용 NIT 해소: `data-parent-id` attribute 로 노출.
- `var(--text-quaternary, ...)` dead fallback 제거.
- **섹션 순서 prototype 정렬 (BLOCK prototype-parity)**.
- parentIsSubtask=true + canAdd=true 충돌 우선순위 테스트 추가.

## Test plan

- [x] `npm run typecheck -w frontend` 통과
- [x] `npm run test -w frontend -- --run` — 375/375 pass
- [x] `npm run lint -w frontend` 통과
- [ ] 드로어 섹션 순서 prototype 비교 + 서브태스크 행 SR 음성 검증 (수면 후 사용자 검수)

## 스크린샷

수면 후 사용자가 dev 서버 기동하여 캡처 예정 — 본 PR 단계에선 시각 검증 없이 코드만 확정. visual-diff harness 는 Phase D 종합 검증 단계에서 일괄 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)