### PR TITLE
feat(w16-c15): VocInternalNotes — role-gated 내부 메모 + 기존 mislabel 정리

### DIFF
--- a/frontend/src/components/voc/__tests__/VocListPage.test.tsx
+++ b/frontend/src/components/voc/__tests__/VocListPage.test.tsx
@@ -87,8 +87,9 @@ describe('VocListPage — Wave 1 RTL', () => {
     vi.mocked(vocApi.notes).mockResolvedValue([]);
     renderPage({ initialUrl: `/voc?id=${target.id}`, role: 'user' });
     await waitFor(() => expect(screen.getByTestId('voc-drawer')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
-    expect(screen.queryByLabelText('new note')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
+    expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-internal-notes')).not.toBeInTheDocument();
   });
 
   it('F-T4b manager role contrast: 같은 vocId에서 note form은 노출 (gate 조건이 user 전용임을 증명)', async () => {
@@ -103,7 +104,7 @@ describe('VocListPage — Wave 1 RTL', () => {
     vi.mocked(vocApi.notes).mockResolvedValue([]);
     renderPage({ initialUrl: `/voc?id=${target.id}`, role: 'manager' });
     await waitFor(() => expect(screen.getByTestId('voc-drawer')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByLabelText('new note')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText('new internal note')).toBeInTheDocument());
   });
 
   it('F-T5 drawer Escape 닫힘: URL ?id 제거 — 다음 list query에 stale id 유출 없음', async () => {

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -5,7 +5,6 @@ import { VocCommentList } from './VocCommentList';
 import { VocInternalNotes } from './VocInternalNotes';
 
 interface Props {
-  vocId: string;
   currentUserId: string;
   role: Role;
   isOwner: boolean;
@@ -21,7 +20,6 @@ interface Props {
 }
 
 export function VocDrawerSections({
-  vocId,
   currentUserId,
   role,
   isOwner,
@@ -48,7 +46,6 @@ export function VocDrawerSections({
         onDelete={() => {}}
       />
       <VocInternalNotes
-        vocId={vocId}
         notes={notes}
         notesLoading={notesLoading}
         pending={pending}

--- a/frontend/src/features/voc/components/VocDrawerSections.tsx
+++ b/frontend/src/features/voc/components/VocDrawerSections.tsx
@@ -1,14 +1,14 @@
 import type { InternalNote, VocHistoryEntry } from '../../../../../shared/contracts/voc';
-import {
-  VocCommentsPanel,
-  VocAttachmentsPanel,
-  VocHistoryPanel,
-  type AttachmentItem,
-} from './VocReviewSections';
+import type { Role } from '../../../../../shared/contracts/common';
+import { VocAttachmentsPanel, VocHistoryPanel, type AttachmentItem } from './VocReviewSections';
 import { VocCommentList } from './VocCommentList';
+import { VocInternalNotes } from './VocInternalNotes';
 
 interface Props {
+  vocId: string;
   currentUserId: string;
+  role: Role;
+  isOwner: boolean;
   canWrite: boolean;
   canUpload: boolean;
   pending: boolean;
@@ -21,7 +21,10 @@ interface Props {
 }
 
 export function VocDrawerSections({
+  vocId,
   currentUserId,
+  role,
+  isOwner,
   canWrite,
   canUpload,
   pending,
@@ -44,11 +47,13 @@ export function VocDrawerSections({
         onEdit={() => {}}
         onDelete={() => {}}
       />
-      <VocCommentsPanel
+      <VocInternalNotes
+        vocId={vocId}
         notes={notes}
         notesLoading={notesLoading}
-        canWrite={canWrite}
         pending={pending}
+        role={role}
+        isOwner={isOwner}
         onAdd={onAddNote}
       />
       <VocAttachmentsPanel items={attachments} canUpload={canUpload} />

--- a/frontend/src/features/voc/components/VocInternalNotes.tsx
+++ b/frontend/src/features/voc/components/VocInternalNotes.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Button } from '../../../components/ui/button';
+import { Textarea } from '../../../components/ui/textarea';
+import { LoadingState } from '../../../components/common/LoadingState';
+import type { InternalNote } from '../../../../../shared/contracts/voc';
+import type { Role } from '../../../../../shared/contracts/common';
+
+interface Props {
+  vocId: string;
+  notes: InternalNote[] | undefined;
+  notesLoading: boolean;
+  pending: boolean;
+  role: Role;
+  isOwner: boolean;
+  onAdd: (body: string) => void;
+}
+
+function canViewInternalNotes(role: Role, isOwner: boolean): boolean {
+  if (role === 'admin' || role === 'manager') return true;
+  if (role === 'dev' && isOwner) return true;
+  return false;
+}
+
+export function VocInternalNotes({ notes, notesLoading, pending, role, isOwner, onAdd }: Props) {
+  const [body, setBody] = useState('');
+
+  if (!canViewInternalNotes(role, isOwner)) return null;
+
+  const count = notes?.length ?? 0;
+
+  return (
+    <section
+      data-testid="drawer-internal-notes"
+      className="flex flex-col gap-2 rounded border p-2"
+      style={{
+        borderColor: 'var(--border-standard)',
+        background: 'var(--status-amber-bg, var(--bg-elevated))',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <h3
+          id="voc-internal-notes-heading"
+          className="text-xs font-medium"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          내부 메모 (Internal Notes)
+        </h3>
+        <span
+          data-testid="internal-notes-count"
+          className="rounded-full px-2 text-[11px]"
+          style={{
+            background: 'var(--bg-surface)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {count}
+        </span>
+      </div>
+      {notesLoading && <LoadingState />}
+      {!notesLoading && count === 0 && (
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          등록된 내부 메모가 없습니다.
+        </p>
+      )}
+      {notes && count > 0 && (
+        <ul className="flex flex-col gap-2" aria-labelledby="voc-internal-notes-heading">
+          {notes.map((n) => (
+            <li
+              key={n.id}
+              className="rounded border p-2 text-sm"
+              style={{
+                borderColor: 'var(--border-standard)',
+                background: 'var(--bg-surface)',
+              }}
+            >
+              <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                {n.created_at.slice(0, 16).replace('T', ' ')}
+              </div>
+              <div style={{ color: 'var(--text-primary)' }}>{n.body}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <form
+        className="mt-1 flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const next = body.trim();
+          if (next) {
+            onAdd(next);
+            setBody('');
+          }
+        }}
+      >
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="내부 메모를 입력하세요 (담당자·관리자만 볼 수 있음)"
+          aria-label="new internal note"
+        />
+        <Button type="submit" size="sm" disabled={pending || !body.trim()}>
+          저장
+        </Button>
+        <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+          담당자·관리자에게만 공개. 공개 댓글과 별도 저장.
+        </p>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/features/voc/components/VocInternalNotes.tsx
+++ b/frontend/src/features/voc/components/VocInternalNotes.tsx
@@ -6,7 +6,6 @@ import type { InternalNote } from '../../../../../shared/contracts/voc';
 import type { Role } from '../../../../../shared/contracts/common';
 
 interface Props {
-  vocId: string;
   notes: InternalNote[] | undefined;
   notesLoading: boolean;
   pending: boolean;
@@ -34,28 +33,21 @@ export function VocInternalNotes({ notes, notesLoading, pending, role, isOwner, 
       className="flex flex-col gap-2 rounded border p-2"
       style={{
         borderColor: 'var(--border-standard)',
-        background: 'var(--status-amber-bg, var(--bg-elevated))',
+        background: 'var(--status-amber-bg)',
       }}
     >
-      <div className="flex items-center gap-2">
-        <h3
-          id="voc-internal-notes-heading"
-          className="text-xs font-medium"
-          style={{ color: 'var(--text-secondary)' }}
-        >
-          내부 메모 (Internal Notes)
-        </h3>
-        <span
-          data-testid="internal-notes-count"
-          className="rounded-full px-2 text-[11px]"
-          style={{
-            background: 'var(--bg-surface)',
-            color: 'var(--text-secondary)',
-          }}
-        >
-          {count}
-        </span>
-      </div>
+      <h3
+        id="voc-internal-notes-heading"
+        className="text-xs font-medium"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        내부 메모
+        {count > 0 && (
+          <span data-testid="internal-notes-count" className="ml-1">
+            {count}개
+          </span>
+        )}
+      </h3>
       {notesLoading && <LoadingState />}
       {!notesLoading && count === 0 && (
         <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -178,7 +178,6 @@ export function VocReviewDrawer({
               </label>
             </div>
             <VocDrawerSections
-              vocId={voc.id}
               currentUserId={auth?.user?.id ?? ''}
               role={role}
               isOwner={!!auth?.user?.id && voc.assignee_id === auth.user.id}

--- a/frontend/src/features/voc/components/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/components/VocReviewDrawer.tsx
@@ -178,7 +178,10 @@ export function VocReviewDrawer({
               </label>
             </div>
             <VocDrawerSections
+              vocId={voc.id}
               currentUserId={auth?.user?.id ?? ''}
+              role={role}
+              isOwner={!!auth?.user?.id && voc.assignee_id === auth.user.id}
               canWrite={canWrite}
               canUpload={canUpload}
               pending={pending}

--- a/frontend/src/features/voc/components/VocReviewSections.tsx
+++ b/frontend/src/features/voc/components/VocReviewSections.tsx
@@ -1,83 +1,12 @@
-import { useState } from 'react';
 import { Button } from '../../../components/ui/button';
-import { Textarea } from '../../../components/ui/textarea';
 import { LoadingState } from '../../../components/common/LoadingState';
-import type { InternalNote, VocHistoryEntry } from '../../../../../shared/contracts/voc';
+import type { VocHistoryEntry } from '../../../../../shared/contracts/voc';
 
 export interface AttachmentItem {
   id: string;
   name: string;
   size: number;
   href: string;
-}
-
-interface CommentsPanelProps {
-  notes: InternalNote[] | undefined;
-  notesLoading: boolean;
-  canWrite: boolean;
-  pending: boolean;
-  onAdd: (body: string) => void;
-}
-
-export function VocCommentsPanel({
-  notes,
-  notesLoading,
-  canWrite,
-  pending,
-  onAdd,
-}: CommentsPanelProps) {
-  const [body, setBody] = useState('');
-  return (
-    <section data-testid="drawer-notes" className="flex flex-col gap-2">
-      <h3 className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-        코멘트
-      </h3>
-      {notesLoading && <LoadingState />}
-      {!notesLoading && notes && notes.length === 0 && (
-        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-          아직 작성된 코멘트가 없습니다.
-        </p>
-      )}
-      {notes && notes.length > 0 && (
-        <ul className="flex flex-col gap-2">
-          {notes.map((n) => (
-            <li
-              key={n.id}
-              className="rounded border p-2 text-sm"
-              style={{ borderColor: 'var(--border-standard)' }}
-            >
-              <div className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
-                {n.created_at.slice(0, 16).replace('T', ' ')}
-              </div>
-              {n.body}
-            </li>
-          ))}
-        </ul>
-      )}
-      {canWrite && (
-        <form
-          className="mt-1 flex flex-col gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (body.trim()) {
-              onAdd(body.trim());
-              setBody('');
-            }
-          }}
-        >
-          <Textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="코멘트를 입력하세요"
-            aria-label="new note"
-          />
-          <Button type="submit" disabled={pending || !body.trim()} size="sm">
-            저장
-          </Button>
-        </form>
-      )}
-    </section>
-  );
 }
 
 interface AttachmentsPanelProps {

--- a/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VocInternalNotes } from '../VocInternalNotes';
+import type { InternalNote } from '../../../../../../shared/contracts/voc';
+import type { Role } from '../../../../../../shared/contracts/common';
+
+const note = (over: Partial<InternalNote> = {}): InternalNote => ({
+  id: 'n-1',
+  voc_id: 'v-1',
+  author_id: 'u-1',
+  body: '내부 검토 결과 정상',
+  created_at: '2026-05-04T05:00:00.000Z',
+  updated_at: '2026-05-04T05:00:00.000Z',
+  ...over,
+});
+
+const baseProps = {
+  vocId: 'v-1',
+  notes: [] as InternalNote[],
+  notesLoading: false,
+  pending: false,
+  onAdd: vi.fn(),
+};
+
+describe('VocInternalNotes — role gate', () => {
+  it('user 역할 → 렌더하지 않음 (null 반환)', () => {
+    const { container } = render(
+      <VocInternalNotes {...baseProps} role={'user' as Role} isOwner={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dev + isOwner=false → 렌더하지 않음', () => {
+    const { container } = render(
+      <VocInternalNotes {...baseProps} role={'dev' as Role} isOwner={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dev + isOwner=true → 렌더함', () => {
+    render(<VocInternalNotes {...baseProps} role={'dev' as Role} isOwner={true} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+
+  it('admin → 항상 렌더', () => {
+    render(<VocInternalNotes {...baseProps} role={'admin' as Role} isOwner={false} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+
+  it('manager → 항상 렌더', () => {
+    render(<VocInternalNotes {...baseProps} role={'manager' as Role} isOwner={false} />);
+    expect(screen.getByRole('heading', { name: /내부 메모/ })).toBeInTheDocument();
+  });
+});
+
+describe('VocInternalNotes — content', () => {
+  it('카운트 배지 + 내용 렌더', () => {
+    render(
+      <VocInternalNotes
+        {...baseProps}
+        notes={[note(), note({ id: 'n-2', body: '두번째 메모' })]}
+        role={'admin' as Role}
+        isOwner={false}
+      />,
+    );
+    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2');
+    expect(screen.getByText('내부 검토 결과 정상')).toBeInTheDocument();
+    expect(screen.getByText('두번째 메모')).toBeInTheDocument();
+  });
+
+  it('빈 상태 메시지', () => {
+    render(<VocInternalNotes {...baseProps} notes={[]} role={'admin' as Role} isOwner={false} />);
+    expect(screen.getByText('등록된 내부 메모가 없습니다.')).toBeInTheDocument();
+  });
+
+  it('저장 → onAdd 호출 + textarea 비움', () => {
+    const onAdd = vi.fn();
+    render(
+      <VocInternalNotes {...baseProps} onAdd={onAdd} role={'admin' as Role} isOwner={false} />,
+    );
+    const ta = screen.getByLabelText('new internal note') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: '비공개 메모' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    expect(onAdd).toHaveBeenCalledWith('비공개 메모');
+    expect(ta.value).toBe('');
+  });
+});

--- a/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocInternalNotes.test.tsx
@@ -15,7 +15,6 @@ const note = (over: Partial<InternalNote> = {}): InternalNote => ({
 });
 
 const baseProps = {
-  vocId: 'v-1',
   notes: [] as InternalNote[],
   notesLoading: false,
   pending: false,
@@ -63,14 +62,28 @@ describe('VocInternalNotes — content', () => {
         isOwner={false}
       />,
     );
-    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('internal-notes-count')).toHaveTextContent('2개');
     expect(screen.getByText('내부 검토 결과 정상')).toBeInTheDocument();
     expect(screen.getByText('두번째 메모')).toBeInTheDocument();
   });
 
-  it('빈 상태 메시지', () => {
+  it('빈 상태 메시지 + 카운트 배지 미노출 (count===0)', () => {
     render(<VocInternalNotes {...baseProps} notes={[]} role={'admin' as Role} isOwner={false} />);
     expect(screen.getByText('등록된 내부 메모가 없습니다.')).toBeInTheDocument();
+    expect(screen.queryByTestId('internal-notes-count')).not.toBeInTheDocument();
+  });
+
+  it('notesLoading=true → LoadingState 노출 + 빈 메시지 미노출', () => {
+    render(
+      <VocInternalNotes
+        {...baseProps}
+        notes={undefined}
+        notesLoading={true}
+        role={'admin' as Role}
+        isOwner={false}
+      />,
+    );
+    expect(screen.queryByText('등록된 내부 메모가 없습니다.')).not.toBeInTheDocument();
   });
 
   it('저장 → onAdd 호출 + textarea 비움', () => {

--- a/frontend/src/features/voc/components/__tests__/VocReviewDrawer.test.tsx
+++ b/frontend/src/features/voc/components/__tests__/VocReviewDrawer.test.tsx
@@ -74,27 +74,31 @@ describe('VocReviewDrawer — Wave 1.6 C-13 (flat sections)', () => {
 
   const target = VOC_FIXTURES.find((r) => r.deleted_at === null)!;
 
-  it('탭 UI 없이 3개 섹션(코멘트/첨부/변경이력) 동시 노출', async () => {
+  it('탭 UI 없이 4개 섹션(댓글/내부메모/첨부/변경이력) 동시 노출 (manager)', async () => {
     renderDrawer('manager', target.id);
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('tab')).toHaveLength(0);
-    expect(screen.getByTestId('drawer-notes')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-comments')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-internal-notes')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-attachments')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-history')).toBeInTheDocument();
   });
 
-  it('role=user → 코멘트 작성 form 미노출 + 첨부 업로드 button 미노출', async () => {
+  it('role=user → 댓글 작성 form 미노출 + 내부메모 섹션 미노출 + 첨부 업로드 button 미노출', async () => {
     renderDrawer('user', target.id);
-    await waitFor(() => expect(screen.getByTestId('drawer-notes')).toBeInTheDocument());
-    expect(screen.queryByLabelText('new note')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('drawer-comments')).toBeInTheDocument());
+    expect(screen.queryByLabelText('new comment')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-internal-notes')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('첨부 업로드')).not.toBeInTheDocument();
   });
 
-  it('role=manager → 3 섹션 모두 가시 + 작성 form 노출', async () => {
+  it('role=manager → 4 섹션 모두 가시 + 작성 form 노출', async () => {
     renderDrawer('manager', target.id);
-    await waitFor(() => expect(screen.getByLabelText('new note')).toBeInTheDocument());
-    expect(screen.getByTestId('drawer-notes')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('new comment')).toBeInTheDocument());
+    expect(screen.getByLabelText('new internal note')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-comments')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-internal-notes')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-attachments')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-history')).toBeInTheDocument();
   });
@@ -103,8 +107,7 @@ describe('VocReviewDrawer — Wave 1.6 C-13 (flat sections)', () => {
     renderDrawer('manager', target.id, { deleted: true });
     await waitFor(() => expect(screen.getByTestId('voc-permission-gate')).toBeInTheDocument());
     expect(screen.getByText(/삭제된 항목/)).toBeInTheDocument();
-    // 게이트가 본문 자체를 막아야 한다.
-    expect(screen.queryByTestId('drawer-notes')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('drawer-comments')).not.toBeInTheDocument();
   });
 
   it('변경이력 섹션에 timeline listitem 즉시 노출 (탭 클릭 불필요)', async () => {


### PR DESCRIPTION
Re-opened after #195 auto-closed when stacked base branch was deleted on #194 merge.

## Summary
- VocInternalNotes role-gated 내부 메모 섹션 추가
- 기존 mislabel 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)