### PR TITLE
fix(backend): load root .env in dev script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file=../.env src/index.ts",
     "build": "tsc",
     "start": "node dist/backend/src/index.js",
     "test": "jest --runInBand",


### PR DESCRIPTION
## Summary
- `npm run dev` at repo root crashed BE with `Invalid AUTH_MODE: "undefined"` because `tsx watch` never loaded `.env`.
- Add `--env-file=../.env` to backend dev script so root env (AUTH_MODE, DATABASE_URL, SESSION_SECRET 등) loads without docker compose.

## Test plan
- [x] `npm run dev` 한 번에 FE(5173) + BE(3000) 정상 기동 확인
- [x] `Backend running on port 3000` 로그 확인 (AUTH_MODE 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)