### PR TITLE
chore(audit): promote R2 + strengthen parallel tool call rule

### DIFF
--- a/.claude/audit/registry.json
+++ b/.claude/audit/registry.json
@@ -45,8 +45,16 @@
     }
   },
   "promotion_rules": {
-    "promoted": { "min_sessions": 5, "min_lifetime_confidence": 0.4, "min_work_types": 2 },
-    "scoped": { "min_sessions": 5, "min_lifetime_confidence": 0.7, "min_work_types": 1 },
+    "promoted": {
+      "min_sessions": 5,
+      "min_lifetime_confidence": 0.4,
+      "min_work_types": 2
+    },
+    "scoped": {
+      "min_sessions": 5,
+      "min_lifetime_confidence": 0.7,
+      "min_work_types": 1
+    },
     "remediated": {
       "min_post_fix_sessions": 5,
       "max_post_fix_confidence": 0.1,
@@ -66,8 +74,14 @@
     "accepted_residual": {
       "trigger_when": "regressed AND no stronger fix_type available in allowed_fix_types"
     },
-    "retired": { "max_lifetime_confidence": 0.1, "min_sessions": 5 },
-    "detection_review": { "min_precision_records": 3, "max_precision": 0.5 }
+    "retired": {
+      "max_lifetime_confidence": 0.1,
+      "min_sessions": 5
+    },
+    "detection_review": {
+      "min_precision_records": 3,
+      "max_precision": 0.5
+    }
   },
   "hawthorne_correction": {
     "audit_density_window_sessions": 30,
@@ -98,8 +112,15 @@
       "detection": "연속 assistant 턴 각 tool 1개·의존 없음",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
-      "status": "candidate",
-      "fix_history": [],
+      "status": "claude_md_added",
+      "fix_history": [
+        {
+          "fix_type": "claude_md",
+          "reference": "file:CLAUDE.md",
+          "applied_at": "2026-05-04T17:22:23.397758+00:00",
+          "note": "Strengthened parallel tool call rule with explicit violation patterns and examples"
+        }
+      ],
       "regression_count": 0,
       "reactivation_count": 0,
       "baseline_hooked": false
@@ -208,7 +229,6 @@
       "reactivation_count": 0,
       "baseline_hooked": false
     },
-
     {
       "id": "R11",
       "category": "rule_violation",
@@ -274,7 +294,6 @@
       "reactivation_count": 0,
       "baseline_hooked": false
     },
-
     {
       "id": "C1",
       "category": "cost_anomaly",
@@ -366,7 +385,6 @@
       "reactivation_count": 0,
       "baseline_hooked": false
     },
-
     {
       "id": "P1",
       "category": "behavior_pattern",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Arc
   - Known small range or tight cluster needing imports+body together → **`Read`** with `offset`/`limit` (or `sed -n 'A,Bp'`)
   - Architecture map / dependency graph / UI→API→DB flow / "what connects to X" → **Graphify** — required at least once before a wide refactor or first entry into an unfamiliar feature; details below
   - **Never** `cat <file>` to dump source, **never** `Read` a whole TS/TSX file you could `find_symbol` instead, **never** re-read a file already in context. Exception: config/JSON under ~1KB.
-- **Parallel tool calls** — independent tool calls go in one message, not sequential (bash·Read chains 포함; sequential chain 식별 시 즉시 batch 전환 — reviewer audit 대상)
+- **Parallel tool calls** — independent tool calls MUST go in one single message, never sequential. Common violations: (1) typecheck + test as separate Bash calls (use `&&` instead); (2) consecutive Read calls on unrelated files; (3) consecutive Bash greps. Identify and batch immediately — retroactive grouping after execution is not allowed.
 - **No re-read** — never re-read a file already in session context (exception: modified files)
 - **Tail test output** — pipe through `| tail -20`; never print full traces
 - **No Read before delete** — files being deleted must never be Read first; just `rm`


### PR DESCRIPTION
## Summary

- **R2** (Sequential 가능했던 parallel): `candidate → claude_md_added` — 5/5 sessions detected, conf=0.95, post-fix measurement window now open
- **CLAUDE.md** parallel tool calls rule rewritten in English with explicit violation patterns: typecheck+test split Bash calls, consecutive Read, consecutive grep
- Audit session `247db5a5` recorded (13 findings, 7 TP verdicts)

## Test plan

- [x] FE: 375 tests passed
- [x] BE: 93 tests passed
- [x] Lint + token checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)