### PR TITLE
feat(opt-prompt): add opt-prompt-feedback skill + Tier 0 integration

### DIFF
--- a/.claude/skills/opt-prompt-eval/SKILL.md
+++ b/.claude/skills/opt-prompt-eval/SKILL.md
@@ -37,6 +37,17 @@ Sister skill to `opt-prompt` (normalize). This skill handles the **post-task ret
 
 Read the log, join `decided` ↔ `retro` rows by `decision_id`, exclude `status:"void"`. Then report:
 
+**Tier 0 — User-Mandated Proposals (always first):**
+
+Read `~/.claude/opt-prompt/feedback.jsonl`. Group all entries by `id`; for each `id`, take the **latest entry** (by line order, last wins). Entries with `resolved: true` in their latest row are excluded. Surface all remaining (`resolved: false`) as Tier 0, regardless of sample size thresholds.
+
+- If the file does not exist or has no unresolved entries after deduplication, skip Tier 0 silently.
+- If a line fails JSON parsing, skip that line with a warning (`[warn] skipped malformed line N in feedback.jsonl`) and continue — never abort the review.
+- List each unresolved entry as: `[<category>] <id> — <feedback>`
+- After the list, remind the user: "Run `/opt-prompt-feedback --resolve <id>` after each proposal is accepted and the skill is updated."
+
+Tier 0 proposals are **user-mandated** — they appear before any cohort analysis and are never suppressed by sample size gates.
+
 **Tier 1 — qualitative cohorts (always):**
 
 - **Global**: hit rate (`correct` / non-void total). Require ≥5 non-void entries before any proposal is emitted.

--- a/.claude/skills/opt-prompt-feedback/SKILL.md
+++ b/.claude/skills/opt-prompt-feedback/SKILL.md
@@ -1,0 +1,143 @@
+# opt-prompt-feedback
+
+Sister skill to `opt-prompt` and `opt-prompt-eval`. Captures free-form human feedback about opt-prompt skill behavior for incorporation during `/opt-prompt-eval --review`.
+
+## When to use
+
+- User explicitly invokes `/opt-prompt-feedback [inline feedback]`
+- Use anytime opt-prompt or opt-prompt-eval behavior was unexpected or wrong
+- Use when a retro `note` field was insufficient for the full observation
+
+## Storage
+
+`~/.claude/opt-prompt/feedback.jsonl` — append-only, one JSON object per line.
+Parent dir auto-created on first write.
+
+## Schema
+
+**Creation entry:**
+
+```json
+{
+  "id": "fb-{compactISO}-{6-char-md5-slug}",
+  "ts": "<ISO UTC>",
+  "category": "<category vocab>",
+  "feedback": "<free-form text>",
+  "related_decision_id": "opt-...-slug | null",
+  "resolved": false
+}
+```
+
+**Resolve tombstone** (appended by `--resolve`, never overwrites):
+
+```json
+{
+  "id": "<same id as creation entry>",
+  "ts": "<ISO UTC of resolution>",
+  "resolved": true,
+  "resolved_ts": "<ISO UTC>"
+}
+```
+
+Analysis always takes the **latest entry per `id`**. A tombstone with `resolved: true` supersedes the creation entry.
+
+**Category vocab:** `rubric` | `directive-parsing` | `gate` | `output-format` | `workflow` | `other:<tag>`
+
+## Workflow
+
+### Standard mode — `/opt-prompt-feedback [inline text]`
+
+1. If inline text is provided after the command, use it as `FEEDBACK_TEXT` and skip the feedback prompt. Ask only for category (and related_id if not obvious from context). Otherwise ask:
+   - "피드백 내용? (한 단락)"
+2. Ask: "카테고리? (rubric / directive-parsing / gate / output-format / workflow / other:<tag>)"
+   - Infer from inline text if obvious: mentions "Phase" or "normalized prompt structure" → `output-format`; mentions "\*\*필수사항" or "directive" or "instruction" → `directive-parsing`; mentions "gate" or "added/skipped" → `gate`; mentions "retro" or "feedback" or "note field" → `workflow`; mentions "rubric" or "scope" or "sizing" → `rubric`. When ambiguous, ask.
+3. Ask: "관련 decision_id? (opt-... 또는 Enter로 생략)"
+4. Write entry using the env-var python3 block below.
+5. Confirm: `Feedback recorded: <id>`
+
+### Resolve mode — `/opt-prompt-feedback --resolve <id>`
+
+Append a tombstone entry with the same `id` and `"resolved": true`. Never edit existing entries.
+
+```bash
+FEEDBACK_ID="<id to resolve>" python3 << 'PYEOF'
+import json, datetime, os
+
+fb_id = os.environ["FEEDBACK_ID"]
+ts = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+tombstone = {
+    "id": fb_id,
+    "ts": ts,
+    "resolved": True,
+    "resolved_ts": ts
+}
+log_path = os.path.expanduser("~/.claude/opt-prompt/feedback.jsonl")
+with open(log_path, "a", encoding="utf-8") as f:
+    f.write(json.dumps(tombstone, ensure_ascii=False) + "\n")
+print(f"Resolved: {fb_id}")
+PYEOF
+```
+
+### List mode — `/opt-prompt-feedback --list`
+
+Print all unresolved entries (latest per id, `resolved: false`) as a numbered table.
+If no unresolved entries exist (or the file is missing/empty), print: `"No unresolved feedback entries. Run /opt-prompt-eval --review to see resolved history."`
+
+```
+1. [directive-parsing] fb-20260504T184423-ee41a7 — 사용자가 프롬프트 뒤에 **필수사항...
+2. [output-format]     fb-20260504T184423-5c7fa6 — large scope + planning 동사...
+
+Run /opt-prompt-eval --review to see these as Tier 0 proposals.
+```
+
+## Writing the entry
+
+Use env-var injection for JSON safety (handles Korean, quotes, special chars without shell escaping):
+
+```bash
+FEEDBACK_CATEGORY="directive-parsing" \
+FEEDBACK_TEXT="피드백 내용 여기에" \
+FEEDBACK_RELATED="opt-20260504T183535Z-fe-convention-refactor" \
+python3 << 'PYEOF'
+import json, datetime, hashlib, os
+
+category = os.environ["FEEDBACK_CATEGORY"]
+feedback_text = os.environ["FEEDBACK_TEXT"]
+related_id = os.environ.get("FEEDBACK_RELATED", "")
+
+ts = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+slug = hashlib.md5(feedback_text.encode()).hexdigest()[:6]
+entry = {
+    "id": f"fb-{ts.replace('-','').replace(':','').replace('Z','')}-{slug}",
+    "ts": ts,
+    "category": category,
+    "feedback": feedback_text,
+    "related_decision_id": related_id if related_id else None,
+    "resolved": False
+}
+log_path = os.path.expanduser("~/.claude/opt-prompt/feedback.jsonl")
+os.makedirs(os.path.dirname(log_path), exist_ok=True)
+with open(log_path, "a", encoding="utf-8") as f:
+    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+print(entry["id"])
+PYEOF
+```
+
+## Integration with --review
+
+`/opt-prompt-eval --review` reads `feedback.jsonl`, groups by `id`, takes the latest entry per id, and surfaces all with `resolved: false` as **Tier 0 — User-Mandated Proposals** before Tier 1 cohort analysis.
+
+To see your recorded feedback surface as proposals, run: **`/opt-prompt-eval --review`**
+
+After a Tier 0 proposal is accepted and the skill is updated, mark it resolved:
+
+```
+/opt-prompt-feedback --resolve fb-20260504T184423-ee41a7
+```
+
+## Anti-patterns
+
+- Don't use this skill to normalize or evaluate a prompt — those belong to `/opt-prompt` and `/opt-prompt-eval`.
+- Don't hand-roll entries with `echo >>` — use the python3 env-var block for JSON safety.
+- Don't resolve an entry by editing the file — append a tombstone via `--resolve`.
+- Don't pass feedback text as a shell argument with unescaped quotes — use the env-var pattern.

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,11 +2,15 @@
 
 ## 다음 세션 시작점
 
-→ **다음: PR #201 머지 → VocReview 피드백 계속** (body 4섹션 재구성 완료 — 메타데이터/본문/첨부파일/활동탭, VocStatusPriorityGrid 제거).
-   그 후 Wave 1.6 ζ-batch C-17 SidebarUserSwitcher 진입.
-   **[다음 세션 선행 작업]** `features/voc/components/` 폴더 구조 정리 — shared/drawer/table/modal/notifications 5개 하위 폴더로 분리 + VocReviewSections.tsx를 VocAttachmentSection.tsx·VocHistorySection.tsx로 분리. 상세 구조: 이전 대화 참고.
+→ **다음: 폴더 구조 + 네이밍룰 + 코딩컨벤션 정리 (Wave 1.6 ζ 진입 전 선행 필수)**
+   PR #202 머지 완료 (feat/voc-drawer-header-fix — body 4섹션 재구성 + rename consistency).
+   **[세션 시작 시 첫 번째 작업]** 아래 3가지를 문서화 + 리팩토링으로 정리:
+   1. `features/voc/components/` 폴더 분류 — drawer/table/modal/shared/notifications 하위 폴더로 분리
+   2. 컴포넌트 네이밍룰 확정 — `Voc` prefix 정책, Section suffix 기준 등
+   3. 코딩컨벤션 문서화 — props 타입 위치, export 방식, 컴포넌트 구성 순서
+   정리 완료 후 → Wave 1.6 ζ-batch C-17 SidebarUserSwitcher 진입.
    §7.2 batch 순서: ~~α(C-2~C-7)~~ → ~~β(C-8~C-10 + F-bundle)~~ → ~~γ(C-11)~~ →
-   ~~δ(C-12, C-13)~~ → ~~ε(C-14∥C-15∥C-16)~~ → **[VocReview 피드백]** → ζ(C-17 → C-18∥C-19) → η(C-20∥C-21∥C-22∥C-23) → Phase D.
+   ~~δ(C-12, C-13)~~ → ~~ε(C-14∥C-15∥C-16)~~ → ~~[VocReview 피드백 + PR #202]~~ → **[폴더/네이밍/컨벤션 정리]** → ζ(C-17 → C-18∥C-19) → η(C-20∥C-21∥C-22∥C-23) → Phase D.
    룰북: `docs/specs/plans/wave-1-6-phase-c-precedent.md`.
    정본 plan: `docs/specs/plans/wave-1-6-voc-parity.md`.
 


### PR DESCRIPTION
## Summary
- `opt-prompt-feedback` 스킬 신설: opt-prompt 시스템 자체에 대한 자유형 피드백을 `~/.claude/opt-prompt/feedback.jsonl`에 append-only 기록
  - standard / `--resolve` / `--list` 3개 모드
  - env-var 기반 python3 블록으로 JSON-safe 쓰기 (Korean, 따옴표, 특수문자 안전)
  - tombstone 방식 resolution (파일 편집 없이 append로 resolved 처리)
- `opt-prompt-eval --review` Tier 0 추가: feedback.jsonl의 미해결 항목을 Tier 1 코호트 분석 전에 User-Mandated Proposals로 항상 출력
  - latest-per-id deduplication (line order, last wins)
  - malformed JSON line skip-and-warn (리뷰 중단 없이 계속)

## Test plan
- [ ] `opt-prompt-feedback` SKILL.md 구조 확인 (adversarial 서브에이전트 리뷰 완료, Critical 3건 + Important 5건 수정)
- [ ] `feedback.jsonl` 실제 쓰기 동작 확인 (이번 세션 피드백 5건 기록됨)
- [ ] `opt-prompt-eval` Tier 0 섹션 삽입 위치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)