### PR TITLE
feat(skills): add opt-prompt-improve, remove --review from opt-prompt-eval

### DIFF
--- a/.claude/skills/opt-prompt-eval/SKILL.md
+++ b/.claude/skills/opt-prompt-eval/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: opt-prompt-eval
-description: Internal helper invoked ONLY when the user types the literal command /opt-prompt-eval (optionally with --review). Records a one-line retro JSONL row for a previously normalized /opt-prompt task, or runs pattern analysis across the log. Do NOT auto-load on keywords like "eval", "retro", "review" — only on the explicit /opt-prompt-eval command. Normalization/sizing belongs to the separate /opt-prompt skill; never run sizing here.
+description: Internal helper invoked ONLY when the user types the literal command /opt-prompt-eval. Records a retro JSONL row for a previously normalized /opt-prompt task. Do NOT auto-load on keywords like "eval", "retro", "review" — only on the explicit /opt-prompt-eval command. Normalization/sizing belongs to /opt-prompt; skill improvement analysis belongs to /opt-prompt-improve.
 ---
 
 # opt-prompt-eval
 
-Sister skill to `opt-prompt` (normalize). This skill handles the **post-task retro** flow: writing a `phase:"retro"` JSONL row keyed to the `decision_id` minted by `/opt-prompt`, and (with `--review`) running pattern analysis across the log.
+Sister skill to `opt-prompt` (normalize) and `opt-prompt-improve` (skill analysis). This skill handles the **post-task retro** flow: writing a `phase:"retro"` JSONL row keyed to the `decision_id` minted by `/opt-prompt`.
+
+> **스킬 개선 분석은 `/opt-prompt-improve`를 사용하세요.** 이 스킬은 retro 로그 기록만 담당합니다.
 
 ## When to use
 
 - User explicitly invokes `/opt-prompt-eval <decision_id>` after a normalized task closed (PR merged or abandoned).
-- User invokes `/opt-prompt-eval --review` for pattern analysis across the log.
 - Do **not** auto-trigger on `eval` / `retro` / `review` keywords.
 - Do **not** size or normalize here — that is the `/opt-prompt` skill's job. If user passes a fresh prompt, refuse and redirect to `/opt-prompt`.
+- Do **not** run pattern analysis or generate proposals here — that is the `/opt-prompt-improve` skill's job. If user passes `--review`, redirect to `/opt-prompt-improve`.
 
 ## Hard rule (read before anything else)
 
@@ -32,51 +34,6 @@ Sister skill to `opt-prompt` (normalize). This skill handles the **post-task ret
 6. On success, surface the appended row's `decision_id` and `verdict` to the user. STOP — do not analyze.
 
 **When does `--exec-sid` matter?** If you ran `/opt-prompt`, then did the work, then `/clear`'d, then opened a fresh session for eval — the helper's auto-fallback (C) only works if the original transcript file still exists at `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/<sid>.jsonl`. It usually does (Claude Code keeps transcripts), so most of the time you can omit `--exec-sid` and trust auto-fallback. Pass it explicitly when (a) you want to be unambiguous about which session reflects the task, (b) the task ran in a different session from `/opt-prompt` (rare — e.g., decision in session A, but actual implementation in session B because you context-switched).
-
-### Review mode — `/opt-prompt-eval --review`
-
-Read the log, join `decided` ↔ `retro` rows by `decision_id`, exclude `status:"void"`. Then report:
-
-**Tier 0 — User-Mandated Proposals (always first):**
-
-Read `~/.claude/opt-prompt/feedback.jsonl`. Group all entries by `id`; for each `id`, take the **latest entry** (by line order, last wins). Entries with `resolved: true` in their latest row are excluded. Surface all remaining (`resolved: false`) as Tier 0, regardless of sample size thresholds.
-
-- If the file does not exist or has no unresolved entries after deduplication, skip Tier 0 silently.
-- If a line fails JSON parsing, skip that line with a warning (`[warn] skipped malformed line N in feedback.jsonl`) and continue — never abort the review.
-- List each unresolved entry as: `[<category>] <id> — <feedback>`
-- After the list, remind the user: "Run `/opt-prompt-feedback --resolve <id>` after each proposal is accepted and the skill is updated."
-
-Tier 0 proposals are **user-mandated** — they appear before any cohort analysis and are never suppressed by sample size gates.
-
-**Tier 1 — qualitative cohorts (always):**
-
-- **Global**: hit rate (`correct` / non-void total). Require ≥5 non-void entries before any proposal is emitted.
-- **Per scope**: hit rate per `scope_decided`. Require ≥5 entries **for that scope** before flagging it. Scopes below threshold → counts only, no proposal.
-- **Per-scope flag**: scope with ≥5 entries AND wrong-rate ≥40% → "needs revision"; propose specific signal/threshold changes referencing the dominant verdict (e.g., recurring `undersized` → add a signal; recurring `oversized` → remove a gate).
-- **Top 3 recurring `missed_gates`** (across all entries) → candidate additions to the normalize skill's Expand list.
-- **Top 3 recurring `unnecessary_gates`** → candidate removals from the rubric.
-- **Mis-routed cluster**: if `mis-routed` ≥3 entries, separate diagnosis — the rubric is fine, the tool selection logic isn't.
-
-**Tier 2 — quantitative cohorts from `session_summary` (when ≥5 retros have non-null `session_summary`):**
-
-Compare median values per verdict cohort. Require N≥5 in the cohort before reporting. Read directly from the JSONL row's `session_summary` — no sidecar load needed for these.
-
-- `tokens.grand_total` — `oversized` should not exceed `correct`; if it does, gates being added are paying for themselves in surprises elsewhere (or rubric is mis-classifying).
-- `cache_invalidation_events` — `undersized` cohort should be elevated (scope creep ⇒ context churn).
-- `subagent_calls` — same: elevated `subagent_calls` in `undersized`/`mis-routed` cohorts is a signal that the rubric under-allocated the workflow tier.
-- `bash_failures` — elevated in any cohort = pre-flight check candidate (e.g., `npm run lint` before commit).
-- `top3_tools` — recurring tool across cohorts (e.g., `Read` dominating across all `oversized` cases) suggests a routing rule violation worth surfacing.
-- `claudemd_reads` — high count across many tasks → CLAUDE.md slimming candidate (cache invalidation magnifier).
-
-**Tier 3 — sidecar deep-dive (only when Tier 2 flags a cohort):**
-
-When a Tier 2 metric flags a cohort, read the per-row `~/.claude/opt-prompt/snapshots/<id>.{decided,retro}.json` for the affected ids and look at fields not in `session_summary`: `by_prompt[]` for which user prompts dominated tokens, `tool_use_details.read.top_files` for which files were over-read, `subagents.agents[]` for which subagent type/prompt drove cost, `pause_distribution` for human-in-the-loop gaps. Use these to make the proposal **specific** ("rubric should down-weight tasks where top read file is `frontend/CLAUDE.md` ×N").
-
-**Cross-session caveat**: when `session_id_decided != session_id_retro`, `tokens_delta` is `null` and Tier-2 token comparisons are invalid for that row. Other Tier-2 metrics (counts, tool patterns) still reflect the retro session and are usable, but flag the cohort as cross-session-mixed in the report.
-
-**Backwards-compat for legacy rows**: rows written before this scheme have no `session_summary` — fall back to top-level `tokens_at_decision`/`tokens_at_retro`/`tokens_delta` if present, else exclude from Tier-2.
-
-Output is **proposals only**. Never edit the normalize SKILL.md automatically. The user reviews and accepts changes manually.
 
 ## Eval questions (ask in order, one line each)
 
@@ -271,4 +228,4 @@ Evaluated in order; first match wins:
 - Don't size, normalize, or rewrite a fresh prompt here — that is the `/opt-prompt` skill's job. Refuse and redirect.
 - Don't auto-trigger on `eval` / `retro` / `review` keywords; only on explicit `/opt-prompt-eval`.
 - **`/clear` between task and eval gives bogus retro stats** — if you `/clear`'d and the new session can't reach the original task transcript, retro `session_summary` will reflect only the eval session (tiny `api_calls`, near-zero deltas), `tokens_delta` will be `null`, and the row's `session_id` won't match the decided `session_id`. Recovery: `append.sh void <id> retro 'wrong session captured'` then `/opt-prompt-eval <id> --exec-sid <original-task-sid>`. Find the original sid via `ls -t ~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/*.jsonl`. Confirm by comparing the row's `session_id` against decided's.
-- **Don't run `/opt-prompt-eval --review` while tasks are mid-flight** — before analysis, count active `decided` rows with no matching active `retro`. If >0, print `WARNING: N tasks in-flight (no retro yet) — excluded from cohort analysis` and list their `decision_id`s, then proceed with the rest. Mid-flight rows are not voided, just excluded from this run's cohort math.
+- Don't redirect to `--review` — pattern analysis and skill improvement belong to `/opt-prompt-improve`.

--- a/.claude/skills/opt-prompt-eval/SKILL.md
+++ b/.claude/skills/opt-prompt-eval/SKILL.md
@@ -228,4 +228,4 @@ Evaluated in order; first match wins:
 - Don't size, normalize, or rewrite a fresh prompt here — that is the `/opt-prompt` skill's job. Refuse and redirect.
 - Don't auto-trigger on `eval` / `retro` / `review` keywords; only on explicit `/opt-prompt-eval`.
 - **`/clear` between task and eval gives bogus retro stats** — if you `/clear`'d and the new session can't reach the original task transcript, retro `session_summary` will reflect only the eval session (tiny `api_calls`, near-zero deltas), `tokens_delta` will be `null`, and the row's `session_id` won't match the decided `session_id`. Recovery: `append.sh void <id> retro 'wrong session captured'` then `/opt-prompt-eval <id> --exec-sid <original-task-sid>`. Find the original sid via `ls -t ~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/*.jsonl`. Confirm by comparing the row's `session_id` against decided's.
-- Don't redirect to `--review` — pattern analysis and skill improvement belong to `/opt-prompt-improve`.
+- Don't tell users to use the legacy `--review` flag — it no longer exists. Direct them to `/opt-prompt-improve` as a separate command.

--- a/.claude/skills/opt-prompt-feedback/SKILL.md
+++ b/.claude/skills/opt-prompt-feedback/SKILL.md
@@ -1,6 +1,6 @@
 # opt-prompt-feedback
 
-Sister skill to `opt-prompt` and `opt-prompt-eval`. Captures free-form human feedback about opt-prompt skill behavior for incorporation during `/opt-prompt-eval --review`.
+Sister skill to `opt-prompt`, `opt-prompt-eval`, and `opt-prompt-improve`. Captures free-form human feedback about opt-prompt skill behavior for incorporation during `/opt-prompt-improve`.
 
 ## When to use
 
@@ -81,13 +81,13 @@ PYEOF
 ### List mode — `/opt-prompt-feedback --list`
 
 Print all unresolved entries (latest per id, `resolved: false`) as a numbered table.
-If no unresolved entries exist (or the file is missing/empty), print: `"No unresolved feedback entries. Run /opt-prompt-eval --review to see resolved history."`
+If no unresolved entries exist (or the file is missing/empty), print: `"No unresolved feedback entries. Run /opt-prompt-improve to see full analysis."`
 
 ```
 1. [directive-parsing] fb-20260504T184423-ee41a7 — 사용자가 프롬프트 뒤에 **필수사항...
 2. [output-format]     fb-20260504T184423-5c7fa6 — large scope + planning 동사...
 
-Run /opt-prompt-eval --review to see these as Tier 0 proposals.
+Run /opt-prompt-improve to see these as Tier 0 proposals.
 ```
 
 ## Writing the entry
@@ -123,11 +123,11 @@ print(entry["id"])
 PYEOF
 ```
 
-## Integration with --review
+## Integration with /opt-prompt-improve
 
-`/opt-prompt-eval --review` reads `feedback.jsonl`, groups by `id`, takes the latest entry per id, and surfaces all with `resolved: false` as **Tier 0 — User-Mandated Proposals** before Tier 1 cohort analysis.
+`/opt-prompt-improve` reads `feedback.jsonl`, groups by `id`, takes the latest entry per id, and surfaces all with `resolved: false` as **Tier 0 — User-Mandated Proposals** before Tier 1 cohort analysis.
 
-To see your recorded feedback surface as proposals, run: **`/opt-prompt-eval --review`**
+To see your recorded feedback surface as proposals, run: **`/opt-prompt-improve`**
 
 After a Tier 0 proposal is accepted and the skill is updated, mark it resolved:
 

--- a/.claude/skills/opt-prompt-improve/SKILL.md
+++ b/.claude/skills/opt-prompt-improve/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: opt-prompt-improve
+description: Internal helper invoked ONLY when the user types /opt-prompt-improve. Analyzes opt-prompt-log.jsonl and feedback.jsonl across Tier 0-3, presents numbered proposals, and applies approved changes directly to skill files with user confirmation. Do NOT auto-trigger on keywords like "improve", "review", "analyze", or "feedback" — only on explicit /opt-prompt-improve.
+---
+
+# opt-prompt-improve
+
+Sister skill to `opt-prompt` (normalize) and `opt-prompt-eval` (retro). This skill handles **skill improvement**: analyzing the log + feedback to generate proposals, getting user approval, and editing skill files.
+
+## When to use
+
+- User explicitly invokes `/opt-prompt-improve`.
+- Do **not** auto-trigger on any keyword.
+- Do **not** write retro rows or normalize prompts here — those belong to `opt-prompt-eval` and `opt-prompt` respectively.
+
+## In-flight guard (run before any analysis)
+
+Count active `decided` rows with no matching active `retro`:
+
+```bash
+python3 - <<'EOF'
+import json, collections
+log = open(f"{__import__('os').path.expanduser('~')}/.claude/opt-prompt/opt-prompt-log.jsonl").readlines()
+rows = [json.loads(l) for l in log if l.strip()]
+latest = {}
+for r in rows:
+    key = (r["decision_id"], r["phase"])
+    latest[key] = r
+decided = {did for (did, ph), r in latest.items() if ph == "decided" and r.get("status") == "active"}
+retrod  = {did for (did, ph), r in latest.items() if ph == "retro"   and r.get("status") == "active"}
+inflight = decided - retrod
+if inflight:
+    print(f"WARNING: {len(inflight)} task(s) in-flight (no retro yet) — excluded from cohort analysis:")
+    for did in sorted(inflight): print(f"  {did}")
+EOF
+```
+
+Print the warning if any in-flight tasks exist, then proceed with the rest of the analysis using only fully-closed decisions.
+
+## Workflow
+
+### Step 1 — Tier 0: User-Mandated Proposals
+
+Read `~/.claude/opt-prompt/feedback.jsonl`. Group all entries by `id`; for each `id`, take the **latest entry** (last line wins). Exclude entries where the latest row has `resolved: true`.
+
+- If the file does not exist or all entries are resolved, skip Tier 0 silently.
+- If a line fails JSON parsing, emit `[warn] skipped malformed line N in feedback.jsonl` and continue.
+- List each unresolved entry as: `[<category>] <id> — <feedback>`
+
+Tier 0 proposals are **user-mandated** — they always appear first and are never suppressed by sample-size gates.
+
+### Step 2 — Tier 1: Qualitative Cohorts
+
+Read `~/.claude/opt-prompt/opt-prompt-log.jsonl`. Join `decided` ↔ `retro` rows by `decision_id`. Exclude `status:"void"` rows and in-flight decisions (decided but no retro yet).
+
+- **Global hit rate** (`correct` / non-void total). Require ≥5 non-void entries before emitting any proposal.
+- **Per scope**: hit rate per `scope_decided`. Require ≥5 entries **for that scope** before flagging. Scopes below threshold → counts only, no proposal.
+- **Per-scope flag**: scope with ≥5 entries AND wrong-rate ≥40% → "needs revision"; propose specific signal/threshold changes referencing the dominant verdict (e.g., recurring `undersized` → add a signal; recurring `oversized` → remove a gate).
+- **Top 3 recurring `missed_gates`** → candidate additions to opt-prompt's Expand list.
+- **Top 3 recurring `unnecessary_gates`** → candidate removals from the rubric.
+- **Mis-routed cluster**: if `mis-routed` ≥3 entries, separate diagnosis — rubric scope was right, tool selection logic wasn't.
+
+### Step 3 — Tier 2: Quantitative Cohorts
+
+Require ≥5 retros with non-null `session_summary`. Read directly from the JSONL row's `session_summary` — no sidecar load needed.
+
+Compare median values per verdict cohort (require N≥5 per cohort before reporting):
+
+- `tokens.grand_total` — `oversized` cohort should not exceed `correct`; if it does, added gates are not paying for themselves.
+- `cache_invalidation_events` — elevated in `undersized` cohort = scope creep causing context churn.
+- `subagent_calls` — elevated in `undersized`/`mis-routed` = rubric under-allocated workflow tier.
+- `bash_failures` — elevated in any cohort = pre-flight check candidate.
+- `top3_tools` — recurring tool dominating `oversized` cases = routing rule violation.
+- `claudemd_reads` — high count across many tasks → CLAUDE.md slimming candidate.
+
+**Cross-session caveat**: when `session_id_decided != session_id_retro`, `tokens_delta` is `null` — exclude from token cost comparisons. Other Tier-2 metrics (counts, tool patterns) are still valid. Flag the cohort as cross-session-mixed in the report.
+
+**Legacy rows**: rows without `session_summary` → fall back to top-level `tokens_at_decision`/`tokens_at_retro`/`tokens_delta` if present (mapping old `cache_creation` → `cache_create`, old `input` → `input_uncached`), else exclude from Tier-2.
+
+**Token-delta methodology**:
+
+- Cost metric: `tokens_delta.input_uncached + tokens_delta.cache_create` (exclude `cache_read` — ~10% price, largely shared).
+- Discard rows where `input_uncached` or `cache_create` is negative (compaction contamination).
+- Require N≥5 non-null, non-outlier rows before computing median + IQR.
+
+### Step 4 — Tier 3: Sidecar Deep-Dive
+
+Only when Tier 2 flags a cohort. Read `~/.claude/opt-prompt/snapshots/<id>.{decided,retro}.json` for the flagged ids. Look at fields absent from `session_summary`:
+
+- `by_prompt[]` — which user prompts dominated tokens
+- `tool_use_details.read.top_files` — which files were over-read
+- `subagents.agents[]` — which subagent type/prompt drove cost
+- `pause_distribution` — human-in-the-loop gaps
+
+Use these to make proposals **specific** (e.g., "rubric should down-weight tasks where top read file is `frontend/CLAUDE.md` ×N").
+
+### Step 5 — Numbered Proposal List
+
+After all tiers, emit a consolidated numbered list:
+
+```
+Proposals
+─────────
+[T0] #1  [output-format] fb-20260504T184423-5c7fa6
+         Phase 필드가 '설계 결과물'이 아닌 '탐색 순서'여야 함.
+         → opt-prompt/SKILL.md §Phase output format 수정
+
+[T1] #2  scope=medium wrong-rate 60% (3/5), dominant: undersized
+         → opt-prompt/SKILL.md Expand list에 `contract-test` gate 추가
+
+[T2] #3  oversized cohort median tokens > correct cohort (+40%)
+         → opt-prompt/SKILL.md Trim list에서 `post-PR codex review` 조건 완화
+
+none     샘플 부족으로 Tier-2 추가 제안 없음 (N<5)
+```
+
+If no proposals exist at any tier, emit: `제안 없음 — 현재 로그/피드백으로는 충분한 패턴이 없습니다.` and STOP.
+
+### Step 6 — User Approval Gate
+
+After the proposal list, ask exactly:
+
+> 적용할 제안 번호? (전체 / 1,3 / none)
+
+Wait for the user's response. Map:
+
+- `전체` or `all` → apply all proposals
+- `1,3` (comma-separated numbers) → apply only those
+- `none` or empty → STOP without editing
+
+### Step 7 — Apply
+
+For each approved proposal, edit the target SKILL.md using the `Edit` tool. Rules:
+
+- **One edit per proposal** — do not batch unrelated proposals into a single `Edit` call.
+- **Surgical changes only** — change only the exact lines the proposal targets; do not reformat surrounding text.
+- **Never delete the `## Anti-patterns` section** of any skill.
+- If the edit would conflict with another approved proposal (overlapping lines), apply in numbered order and re-read the file between edits.
+- If the target location is ambiguous (e.g., section no longer exists as described), pause and ask the user: "제안 #N의 대상 위치를 찾지 못했습니다. 수동 편집하시겠어요?"
+
+After all edits, show a summary:
+
+```
+적용 완료
+─────────
+#1 → opt-prompt/SKILL.md 수정됨
+#2 → opt-prompt/SKILL.md 수정됨
+건너뜀: #3 (위치 모호)
+```
+
+### Step 8 — Resolve Feedback
+
+For each **applied** Tier 0 proposal (linked to a `fb-*` id), append a resolve tombstone by running the `/opt-prompt-feedback --resolve <id>` skill inline (do NOT hand-roll the tombstone).
+
+Do NOT resolve feedback entries for Tier 1/2/3 proposals — those are derived from log analysis, not user-submitted feedback.
+
+## Analysis join
+
+Group rows by `decision_id`. For each group, take the **latest row per (decision_id, phase)**. If that latest row has `status:"void"`, exclude that phase. A decision is fully active iff its latest `decided` AND latest `retro` are both `status:"active"`.
+
+Legacy rows (before unique decision_id scheme) may share an id across tasks — additionally filter by `task` when grouping.
+
+## Verdict derivation (for Tier 1 cohort assignment)
+
+Evaluated in order; first match wins:
+
+1. `status === "void"` → excluded.
+2. `outcome === "expanded"` AND `tool_swapped === true` → `mis-routed`.
+3. `outcome === "expanded"` AND `missed_gates.length > 0` → `undersized`.
+4. `outcome === "expanded"` AND `missed_gates.length === 0` → `scope-creep`.
+5. `outcome === "as-planned"` AND `unnecessary_gates.length > 0` AND not in `preserved` → `oversized`.
+6. otherwise → `correct`.
+
+## Anti-patterns
+
+- Don't auto-trigger on keywords — only on explicit `/opt-prompt-improve`.
+- Don't skip the in-flight guard — proposals derived from incomplete retros are noise.
+- Don't batch multiple proposal edits into one `Edit` call — each proposal is an independent surgical change.
+- Don't resolve Tier 1/2/3 feedback via `--resolve` — only Tier 0 entries (user-submitted, linked to a `fb-*` id) get resolved on apply.
+- Don't hand-roll resolve tombstones — always invoke `/opt-prompt-feedback --resolve <id>` so the tombstone format stays consistent.
+- Don't emit proposals when sample size is below threshold — counts-only output is correct when N < 5.
+- Don't edit any skill file without user approval — the gate in Step 6 is mandatory.
+- Don't run while tasks are mid-flight if you want complete Tier-2 metrics — in-flight rows are excluded from cohort math but their absence may skew medians; mention this if ≥3 tasks are in-flight.

--- a/.claude/skills/opt-prompt-improve/SKILL.md
+++ b/.claude/skills/opt-prompt-improve/SKILL.md
@@ -19,13 +19,22 @@ Count active `decided` rows with no matching active `retro`:
 
 ```bash
 python3 - <<'EOF'
-import json, collections
-log = open(f"{__import__('os').path.expanduser('~')}/.claude/opt-prompt/opt-prompt-log.jsonl").readlines()
-rows = [json.loads(l) for l in log if l.strip()]
+import json, os
+log_path = os.path.expanduser("~/.claude/opt-prompt/opt-prompt-log.jsonl")
+if not os.path.exists(log_path):
+    print("INFO: opt-prompt-log.jsonl not found — no retro data yet. Skipping Tier 1-3.")
+    exit(0)
 latest = {}
-for r in rows:
-    key = (r["decision_id"], r["phase"])
-    latest[key] = r
+for i, line in enumerate(open(log_path), 1):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        r = json.loads(line)
+        key = (r.get("decision_id", ""), r.get("phase", ""))
+        latest[key] = r
+    except json.JSONDecodeError:
+        print(f"[warn] skipped malformed line {i} in opt-prompt-log.jsonl")
 decided = {did for (did, ph), r in latest.items() if ph == "decided" and r.get("status") == "active"}
 retrod  = {did for (did, ph), r in latest.items() if ph == "retro"   and r.get("status") == "active"}
 inflight = decided - retrod
@@ -35,7 +44,7 @@ if inflight:
 EOF
 ```
 
-Print the warning if any in-flight tasks exist, then proceed with the rest of the analysis using only fully-closed decisions.
+If the log file does not exist, emit `INFO: opt-prompt-log.jsonl not found` and skip Tier 1–3 (Tier 0 still runs from `feedback.jsonl`). Print in-flight warnings if any tasks are unretro'd, then proceed with only fully-closed decisions.
 
 ## Workflow
 
@@ -122,11 +131,12 @@ After the proposal list, ask exactly:
 
 > 적용할 제안 번호? (전체 / 1,3 / none)
 
-Wait for the user's response. Map:
+Wait for the user's response. Parse:
 
 - `전체` or `all` → apply all proposals
-- `1,3` (comma-separated numbers) → apply only those
-- `none` or empty → STOP without editing
+- Digits / commas / spaces → extract all integers with `re.findall(r'\d+', response)`, deduplicate, sort
+  - If any extracted number exceeds the proposal count, ask once: "다음 번호는 무효합니다: [X]. 다시 입력해주세요."
+- `none`, `취소`, `x`, or empty response → STOP without editing
 
 ### Step 7 — Apply
 
@@ -136,7 +146,8 @@ For each approved proposal, edit the target SKILL.md using the `Edit` tool. Rule
 - **Surgical changes only** — change only the exact lines the proposal targets; do not reformat surrounding text.
 - **Never delete the `## Anti-patterns` section** of any skill.
 - If the edit would conflict with another approved proposal (overlapping lines), apply in numbered order and re-read the file between edits.
-- If the target location is ambiguous (e.g., section no longer exists as described), pause and ask the user: "제안 #N의 대상 위치를 찾지 못했습니다. 수동 편집하시겠어요?"
+- **"Ambiguous"** means: (a) the proposal describes only intent without enough text to form a unique `old_string` for the `Edit` tool, or (b) the `Edit` tool returns a mismatch/not-found error. In either case, pause and ask: "제안 #N의 대상 위치를 찾지 못했습니다. 수동 편집하시겠어요?" Do NOT mark the proposal as applied.
+- **"Applied"** means the `Edit` tool returned success with no error. Skipped (ambiguous) proposals are NOT applied regardless of user approval.
 
 After all edits, show a summary:
 
@@ -145,12 +156,27 @@ After all edits, show a summary:
 ─────────
 #1 → opt-prompt/SKILL.md 수정됨
 #2 → opt-prompt/SKILL.md 수정됨
-건너뜀: #3 (위치 모호)
+건너뜀: #3 (위치 모호 — 수동 편집 필요)
 ```
 
 ### Step 8 — Resolve Feedback
 
-For each **applied** Tier 0 proposal (linked to a `fb-*` id), append a resolve tombstone by running the `/opt-prompt-feedback --resolve <id>` skill inline (do NOT hand-roll the tombstone).
+For each **applied** (Edit tool success) Tier 0 proposal linked to a `fb-*` id, append a resolve tombstone using the python3 block below. Run once per id — do NOT hand-roll JSON.
+
+```bash
+FEEDBACK_ID="<fb-id>" python3 << 'PYEOF'
+import json, datetime, os
+fb_id = os.environ["FEEDBACK_ID"]
+ts = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+tombstone = {"id": fb_id, "ts": ts, "resolved": True, "resolved_ts": ts}
+log_path = os.path.expanduser("~/.claude/opt-prompt/feedback.jsonl")
+with open(log_path, "a", encoding="utf-8") as f:
+    f.write(json.dumps(tombstone, ensure_ascii=False) + "\n")
+print(f"Resolved: {fb_id}")
+PYEOF
+```
+
+**Skipped proposals are never resolved** — if Step 7 marked a proposal as skipped (ambiguous), do not run the resolve block for its `fb-*` id. It remains unresolved and will reappear in the next `/opt-prompt-improve` run.
 
 Do NOT resolve feedback entries for Tier 1/2/3 proposals — those are derived from log analysis, not user-submitted feedback.
 


### PR DESCRIPTION
## Summary

- `opt-prompt-improve` 신설 — Tier 0-3 분석 + 사용자 승인 게이트 + SKILL.md 직접 편집 + feedback resolve 전담
- `opt-prompt-eval --review` 삭제 — retro 로그 기록만 담당하도록 역할 축소
- `opt-prompt-feedback` — `--review` 참조 5곳을 `/opt-prompt-improve`로 일괄 교체

## 적대적 리뷰 반영 (BLOCK×3, MAJOR×4)

- **BLOCK-1**: Step 8 inline skill 호출 → python3 resolve block으로 교체
- **BLOCK-2**: log 파일 부재 시 FileNotFoundError → graceful skip 처리
- **BLOCK-3**: "applied" 정의 명시 (Edit tool success만 해당; skipped ≠ applied)
- **MAJOR-1**: opt-prompt-eval anti-pattern 모순 문구 수정
- **MAJOR-2**: opt-prompt-feedback의 `--review` 잔재 4곳 교체
- **MAJOR-3**: Step 7 "ambiguous" 정의 명시
- **MAJOR-4**: in-flight guard JSON 파싱 오류 + missing key 방어 처리
- **MAJOR-5**: Step 6 잘못된 번호 입력 시 재질문 로직 추가

## Test plan

- [ ] FE 374 tests ✅, BE 100 tests ✅ (skill-only 변경, 코드 무관)
- [ ] `opt-prompt-improve` 스킬 목록에 정상 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)