### PR TITLE
refactor(fsd): Step 1 — tsconfig + vite path alias setup

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,45 @@
+# ── Build / dependency artifacts ──────────────────────────────────
+node_modules/
+dist/
+build/
+*.js.map
+*.d.ts
+*.tsbuildinfo
+
+# ── Lock files (no signal for the graph) ──────────────────────────
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# ── Auto-generated / tool state ───────────────────────────────────
+graphify-out/
+.git/
+.claude/
+.omc/
+.external_brainstorming/
+utils/
+
+# ── Test artifacts ────────────────────────────────────────────────
+frontend/test-results/
+frontend/playwright-report/
+coverage/
+
+# ── Font / static binary assets ───────────────────────────────────
+frontend/public/fonts/
+*.woff
+*.woff2
+*.ttf
+*.otf
+
+# ── Prototype HTML (large single-file, too noisy) ─────────────────
+# prototype/prototype.html
+
+# ── Archive plans are superseded — include only if doing history work
+# docs/specs/archive/
+
+# ── Config files with no architectural signal ─────────────────────
+*.env
+*.env.*
+.eslintrc*
+.prettierrc*
+tsconfig.base.json

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -13,6 +13,7 @@ pnpm-lock.yaml
 
 # ── Auto-generated / tool state ───────────────────────────────────
 graphify-out/
+**/graphify-out/
 .git/
 .claude/
 .omc/

--- a/docs/specs/plans/fsd-migration.md
+++ b/docs/specs/plans/fsd-migration.md
@@ -59,7 +59,7 @@ app → pages → widgets → features → entities → shared
 | Step | Branch                         | 내용                                          | 상태          |
 | ---- | ------------------------------ | --------------------------------------------- | ------------- |
 | 0    | —                              | Convention 문서 작성 (사전 작업)              | ✅ 2026-05-05 |
-| 1    | `refactor/fsd-path-alias`      | tsconfig + vite alias 설정                    | ⬜ 미착수     |
+| 1    | `refactor/fsd-path-alias`      | tsconfig + vite alias 설정                    | 🟡 진행 중    |
 | 2    | `refactor/fsd-shared-layer`    | shared/ui, api, lib, hooks, styles, config    | ⬜ 미착수     |
 | 3    | `refactor/fsd-entities-layer`  | entities/voc, user, notification, master      | ⬜ 미착수     |
 | 4    | `refactor/fsd-features-layer`  | features/auth, voc-list-filter, voc-create 등 | ⬜ 미착수     |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,7 +7,17 @@
     "jsx": "react-jsx",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "types": ["vite/client", "vitest/globals"]
+    "types": ["vite/client", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./src/app/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@widgets/*": ["./src/widgets/*"],
+      "@features/*": ["./src/features/*"],
+      "@entities/*": ["./src/entities/*"],
+      "@shared/*": ["./src/shared/*"],
+      "@contracts/*": ["../shared/contracts/*"]
+    }
   },
   "include": ["src"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@app': path.resolve(__dirname, 'src/app'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@widgets': path.resolve(__dirname, 'src/widgets'),
+      '@features': path.resolve(__dirname, 'src/features'),
+      '@entities': path.resolve(__dirname, 'src/entities'),
+      '@shared': path.resolve(__dirname, 'src/shared'),
+      '@contracts': path.resolve(__dirname, '../shared/contracts'),
+    },
+  },
   server: {
     port: 5173,
     host: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^25.6.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -117,6 +118,23 @@
         "vite": "^5.2.10",
         "vitest": "^1.5.0"
       }
+    },
+    "frontend/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "frontend/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",


### PR DESCRIPTION
## Summary

- `frontend/tsconfig.json`에 `baseUrl` + FSD 7개 path alias (`@app`, `@pages`, `@widgets`, `@features`, `@entities`, `@shared`, `@contracts`) 추가
- `frontend/vite.config.ts`에 `resolve.alias` 동일 7개 추가 (vitest도 공유)
- `@types/node` devDependency 추가 (path 모듈 타입)
- `.graphifyignore` 추가 — node_modules, lock files, .claude/.omc 등 노이즈 제외
- `docs/specs/plans/fsd-migration.md` Step 1 상태 ⬜ → 🟡

## Verification

- `npm run typecheck -w frontend` ✅ pass
- `npm run test -w frontend -- --run` ✅ 44 files, 374 tests pass
- `graphify update .` ✅ 완료 (1261 nodes, 1758 edges)

## Next

Step 2: `refactor/fsd-shared-layer` — shared/ui, api, lib, hooks, styles 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)