### PR TITLE
refactor(skills): opt-prompt 3-skill improvements + EN translation

### DIFF
--- a/.claude/skills/opt-prompt-eval/SKILL.md
+++ b/.claude/skills/opt-prompt-eval/SKILL.md
@@ -7,7 +7,7 @@ description: Internal helper invoked ONLY when the user types the literal comman
 
 Sister skill to `opt-prompt` (normalize) and `opt-prompt-improve` (skill analysis). This skill handles the **post-task retro** flow: writing a `phase:"retro"` JSONL row keyed to the `decision_id` minted by `/opt-prompt`.
 
-> **스킬 개선 분석은 `/opt-prompt-improve`를 사용하세요.** 이 스킬은 retro 로그 기록만 담당합니다.
+> **For skill improvement analysis, use `/opt-prompt-improve`.** This skill only handles retro log recording.
 
 ## When to use
 
@@ -26,11 +26,11 @@ Sister skill to `opt-prompt` (normalize) and `opt-prompt-improve` (skill analysi
 
 ### Retro mode — `/opt-prompt-eval <decision_id> [--exec-sid <sid>]`
 
-> **`/tmp/retro.json` anti-pattern**: If `/tmp/retro.json` already exists in the environment (e.g., loaded via system-reminder from a previous session), **IGNORE it entirely.** It is stale from a prior task. Always ask the 8 questions fresh — never silently reuse a temp file. The task slug in the old file will not match the current `decision_id`.
+> **`/tmp/retro.json` anti-pattern**: If `/tmp/retro.json` already exists in the environment (e.g., loaded via system-reminder from a previous session), **IGNORE it entirely.** It is stale from a prior task. Always re-derive retro fields from current task context — never silently reuse a temp file. The task slug in the old file will not match the current `decision_id`.
 
 1. Confirm `<decision_id>` is provided. If missing, ask the user once: "Which decision_id? (format `opt-{compactISO}-{task-slug}`)". Never guess.
 2. Parse optional `--exec-sid <session_id>` from the user's prompt. Pass it through to the helper unchanged. If the user typed it inside the literal command line (e.g., `/opt-prompt-eval opt-...-foo --exec-sid abc-123`), forward verbatim. Don't fabricate a sid if the user didn't supply one.
-3. Ask the **8 retro questions below**, one line each, in order. **Do not skip this step even if a `/tmp/retro.json` or any pre-existing JSON blob is in context.**
+3. **Auto-collect** the 8 retro fields from available context — `git log`, PR description, commit diff stats, and conversation history — and draft a JSON response. Do not ask the user each question individually. For fields that cannot be determined from context, use `"?"` as the placeholder value. Present the drafted JSON in a single block and ask: "Review the draft below and reply with a corrected JSON block, or 'ok' to confirm." Apply any corrections, then proceed to step 4. **Do not re-derive from a stale `/tmp/retro.json` or pre-existing JSON blob** — always re-derive from current task context.
 4. Build a JSON `<fields>` object from the answers.
 5. Write the fields to `/tmp/retro-<decision_id>.json` (decision_id-scoped filename avoids cross-task collision), then invoke `.claude/skills/opt-prompt/append.sh retro <decision_id> @/tmp/retro-<decision_id>.json [--exec-sid <sid>]` (use `@/tmp/file.json` or stdin `-` for fields containing single quotes / Korean / multiline). The helper resolves the snapshot session by precedence: **(B) explicit `--exec-sid`** > **(C) `decided.session_id`** if its transcript still exists > **current latest session**. Then runs `utils/session-stats.sh <resolved_sid>` to write `~/.claude/opt-prompt/snapshots/<decision_id>.retro.json`, and embeds the slim `session_summary` (tokens + 7 metrics) + `tokens_delta` (only when resolved sid matches decided sid; `null` otherwise) into the row.
 6. On success, surface the appended row's `decision_id` and `verdict` to the user. STOP — do not analyze.

--- a/.claude/skills/opt-prompt-improve/SKILL.md
+++ b/.claude/skills/opt-prompt-improve/SKILL.md
@@ -105,38 +105,42 @@ Use these to make proposals **specific** (e.g., "rubric should down-weight tasks
 
 ### Step 5 — Numbered Proposal List
 
+> **Proposal scope rule**: Prefer rubric/workflow-level proposals (e.g., adjusting a tier threshold, restructuring a phase, changing a gate trigger condition) over micro-fixes (single gate add/remove). Emit micro-fix proposals only when the same gate pattern recurs N≥5 times across closed decisions. _Example — micro-fix: "add `contract-test` to Expand list"; rubric-level: "raise small scope LOC ceiling from 100 to 150 LOC"._
+
+> **Dedup check before numbering**: For each candidate proposal, read the target SKILL.md to verify it does not already reflect the fix (e.g., gate already in Trim list, threshold already matches the suggestion). If already reflected, exclude from the numbered list — append as `(already applied — verify effectiveness)` without a number, below the main list.
+
 After all tiers, emit a consolidated numbered list:
 
 ```
 Proposals
 ─────────
 [T0] #1  [output-format] fb-20260504T184423-5c7fa6
-         Phase 필드가 '설계 결과물'이 아닌 '탐색 순서'여야 함.
-         → opt-prompt/SKILL.md §Phase output format 수정
+         Phase fields should describe exploration order, not design deliverables.
+         → opt-prompt/SKILL.md §Phase output format: revise rule
 
 [T1] #2  scope=medium wrong-rate 60% (3/5), dominant: undersized
-         → opt-prompt/SKILL.md Expand list에 `contract-test` gate 추가
+         → opt-prompt/SKILL.md Expand list: add `contract-test` gate
 
 [T2] #3  oversized cohort median tokens > correct cohort (+40%)
-         → opt-prompt/SKILL.md Trim list에서 `post-PR codex review` 조건 완화
+         → opt-prompt/SKILL.md Trim list: relax `post-PR codex review` condition
 
-none     샘플 부족으로 Tier-2 추가 제안 없음 (N<5)
+none     Insufficient sample for additional Tier-2 proposals (N<5)
 ```
 
-If no proposals exist at any tier, emit: `제안 없음 — 현재 로그/피드백으로는 충분한 패턴이 없습니다.` and STOP.
+If no proposals exist at any tier, emit: `No proposals — insufficient pattern data in current log/feedback.` and STOP.
 
 ### Step 6 — User Approval Gate
 
 After the proposal list, ask exactly:
 
-> 적용할 제안 번호? (전체 / 1,3 / none)
+> Which proposals to apply? (all / 1,3 / none)
 
 Wait for the user's response. Parse:
 
-- `전체` or `all` → apply all proposals
+- `all` → apply all proposals
 - Digits / commas / spaces → extract all integers with `re.findall(r'\d+', response)`, deduplicate, sort
-  - If any extracted number exceeds the proposal count, ask once: "다음 번호는 무효합니다: [X]. 다시 입력해주세요."
-- `none`, `취소`, `x`, or empty response → STOP without editing
+  - If any extracted number exceeds the proposal count, ask once: "The following numbers are invalid: [X]. Please re-enter."
+- `none`, `cancel`, `x`, or empty response → STOP without editing
 
 ### Step 7 — Apply
 
@@ -146,17 +150,17 @@ For each approved proposal, edit the target SKILL.md using the `Edit` tool. Rule
 - **Surgical changes only** — change only the exact lines the proposal targets; do not reformat surrounding text.
 - **Never delete the `## Anti-patterns` section** of any skill.
 - If the edit would conflict with another approved proposal (overlapping lines), apply in numbered order and re-read the file between edits.
-- **"Ambiguous"** means: (a) the proposal describes only intent without enough text to form a unique `old_string` for the `Edit` tool, or (b) the `Edit` tool returns a mismatch/not-found error. In either case, pause and ask: "제안 #N의 대상 위치를 찾지 못했습니다. 수동 편집하시겠어요?" Do NOT mark the proposal as applied.
+- **"Ambiguous"** means: (a) the proposal describes only intent without enough text to form a unique `old_string` for the `Edit` tool, or (b) the `Edit` tool returns a mismatch/not-found error. In either case, pause and ask: "Could not locate the target for proposal #N. Edit manually?" Do NOT mark the proposal as applied.
 - **"Applied"** means the `Edit` tool returned success with no error. Skipped (ambiguous) proposals are NOT applied regardless of user approval.
 
 After all edits, show a summary:
 
 ```
-적용 완료
-─────────
-#1 → opt-prompt/SKILL.md 수정됨
-#2 → opt-prompt/SKILL.md 수정됨
-건너뜀: #3 (위치 모호 — 수동 편집 필요)
+Applied
+───────
+#1 → opt-prompt/SKILL.md updated
+#2 → opt-prompt/SKILL.md updated
+Skipped: #3 (target location ambiguous — manual edit required)
 ```
 
 ### Step 8 — Resolve Feedback

--- a/.claude/skills/opt-prompt/SKILL.md
+++ b/.claude/skills/opt-prompt/SKILL.md
@@ -334,6 +334,7 @@ Fix off-by-one in /api/admin/users pagination at backend/src/routes/admin.ts:142
 - Don't silently drop malformed markers — surface every unparsed/invalid marker in `[skipped]` so the user sees their intent didn't land.
 - Don't run `/opt-prompt --eval` or `--review` here — those routes belong to the separate `/opt-prompt-eval` skill. If the user passes `--eval` / `--review`, redirect them to `/opt-prompt-eval`.
 - Don't emit `[directives]` when no `--guide` flags were passed — the line is conditional, not a constant output slot.
+- Don't proceed to execution after emitting the `>>>` block — opt-prompt's role ends when the normalized prompt is output. STOP and wait for explicit user confirmation; do not start execution, design, or codebase exploration.
 
 ## Closing reminder (emit at end of normalize output)
 
@@ -346,3 +347,5 @@ After the `>>>` block, append a **2-line reminder** showing both eval forms — 
 ```
 
 Substitute the actual `decision_id` from Step 1. The `--exec-sid` form is for when the task ran in a session that's no longer the latest (e.g., `/clear`'d between task and eval) — pass the original task-execution sid so retro stats reflect the actual work, not the eval-only session. If unsure, omit `--exec-sid` and the helper auto-falls-back to `decided.session_id` when its transcript still exists, else the current session.
+
+> **STOP after `>>>`**: opt-prompt's job ends when the normalized prompt block is emitted. Do not proceed to execution, design, or codebase exploration until the user explicitly confirms the normalized prompt. Refine the prompt in response to follow-up questions; never start executing. **Explicit confirmation** = a user message containing `go`, `start`, `proceed`, `yes`, or equivalent with no further refinement questions.

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,10 +2,9 @@
 
 ## 다음 세션 시작점
 
-→ **현재: FSD 리팩토링 진행 중** (진행 문서: `docs/specs/plans/fsd-migration.md`)
-   Step 0 ✅ / Step 1 ✅ (PR #207) / Step 2 ✅ (PR #208) / Step 3 ✅ (PR #211) / Step 4 ✅ (PR #213 + #215) / Step 5 ✅ (PR #216) / Step 6 ✅ (PR #219) / Step 7 🟡 PR 검토 중
-   **[세션 시작 시]** Step 7 PR 머지 후 → Wave 1.6 ζ-batch C-17 진입.
-   완료 후 → Wave 1.6 ζ-batch C-17 진입.
+→ **현재: Wave 1.6 ζ-batch C-17 진입** (FSD 리팩토링 전 단계 완료)
+   Step 0 ✅ / Step 1 ✅ (PR #207) / Step 2 ✅ (PR #208) / Step 3 ✅ (PR #211) / Step 4 ✅ (PR #213 + #215) / Step 5 ✅ (PR #216) / Step 6 ✅ (PR #219) / Step 7 ✅ (PR #220)
+   **다음:** Wave 1.6 ζ-batch C-17 진입.
    §7.2 batch 순서: ~~α(C-2~C-7)~~ → ~~β(C-8~C-10 + F-bundle)~~ → ~~γ(C-11)~~ →
    ~~δ(C-12, C-13)~~ → ~~ε(C-14∥C-15∥C-16)~~ → ~~[VocReview 피드백 + PR #202]~~ → **[폴더/네이밍/컨벤션 정리]** → ζ(C-17 → C-18∥C-19) → η(C-20∥C-21∥C-22∥C-23) → Phase D.
    룰북: `docs/specs/plans/wave-1-6-phase-c-precedent.md`.

--- a/docs/specs/plans/fsd-migration.md
+++ b/docs/specs/plans/fsd-migration.md
@@ -65,7 +65,7 @@ app → pages → widgets → features → entities → shared
 | 4    | `refactor/fsd-features-layer`  | features/auth, voc-list-filter, voc-create 등 | ✅ 2026-05-05 (PR #213 + #215) |
 | 5    | `refactor/fsd-widgets-layer`   | widgets/app-shell, voc-workspace              | ✅ 2026-05-05 (PR #216)        |
 | 6    | `refactor/fsd-app-pages-layer` | app/providers, pages 정리                     | ✅ 2026-05-05 (PR #219)        |
-| 7    | `refactor/fsd-cleanup`         | 구 디렉토리 삭제 + 검증                       | 🟡 PR 검토 중 (2026-05-05)     |
+| 7    | `refactor/fsd-cleanup`         | 구 디렉토리 삭제 + 검증                       | ✅ 2026-05-05 (PR #220)        |
 
 범례: ✅ 완료 / 🟡 진행 중 / ⬜ 미착수
 


### PR DESCRIPTION
## Summary

- **opt-prompt**: STOP-after-`>>>` gate added — explicit confirmation signal defined (`go`/`start`/`proceed`/`yes`); duplicate entry in Anti-patterns section
- **opt-prompt-improve**: Step 5 proposal scope rule (rubric-level > micro-fix, N≥5 threshold aligned with Tier 1); dedup check moved Step 2 → Step 5 (SKILL.md content-based check at numbering time)
- **opt-prompt-eval**: Step 3 rewritten — auto-collect from git/PR context replaces 8-question interactive flow; `"?"` placeholder for unknown fields; confirmation UX changed to corrected JSON or `ok`; anti-pattern text updated (`re-derive` not `ask fresh`)
- Full English translation of Korean UI strings across all three skill files

## Changes driven by

- `/opt-prompt-improve` Tier 0 feedback: 7 unresolved entries (all resolved)
- Adversarial 3-reviewer panel (Prompt Engineering + DX + Synthesis) post-apply

## Test plan

- [ ] `opt-prompt`: after emitting `>>>`, skill must not proceed until user sends `go`/`start`/`proceed`/`yes`
- [ ] `opt-prompt-improve`: micro-fix proposals suppressed below N=5; dedup verified by reading target SKILL.md before numbering
- [ ] `opt-prompt-eval`: retro fields auto-collected from git log; `?` used for missing fields; user confirms with `ok` or corrected JSON block

🤖 Generated with [Claude Code](https://claude.com/claude-code)