### PR TITLE
docs(audit): translate registry/checklist to English + v2 SOP improvements

### DIFF
--- a/.claude/audit/checklist.md
+++ b/.claude/audit/checklist.md
@@ -1,129 +1,144 @@
 # Session Audit Checklist v2
 
-> **Blind 원칙**: expert agent는 이 파일·`registry.json`·`stats.json`·`sessions/*.json` 절대 읽지 않음. 자유 발견 → mapper expert가 사후 매핑.
-> 본 문서는 사람이 라이프사이클·운영 규칙을 훑기 위한 reference. 정본은 `registry.json`.
+> **Blind principle**: expert agents must never read this file, `registry.json`, `stats.json`, or `sessions/*.json`. Free-discovery only — the mapper expert handles post-hoc mapping.
+> This document is a human-readable reference for lifecycle and operating rules. Source of truth is `registry.json`.
 
-## 운영 규칙 v2
+## Operating Rules v2
 
-- **신뢰도 산식**: read-time 계산. `confidence = sessions_occurred / sessions_total`. `displayed_confidence = raw_confidence * max(0, 1 - audit_density * 0.3)` (Hawthorne 보정)
-- **stats 저장**: `(sum, sum_sq, count)` tuple만. mean·variance는 read-time 계산. 부동소수점 drift 방지
-- **Idempotency**: 동일 sessionId 재분석 시 prior contribution을 빼고 새 contribution 더함 (delta)
-- **Append-only**: registry items 절대 삭제 금지. status flag만 토글
-- **Versioning**: `registry_version` mismatch 시 hard stop (마이그레이션 도구 없으면 warn-and-continue + suspend 권고)
-- **Hawthorne**: `audit_density = audit된 세션 / 최근 30일 세션`. 0.3 초과 시 displayed_confidence에 산식 적용 + 경고
+- **Confidence formula**: computed at read time. `confidence = sessions_occurred / sessions_total`. `displayed_confidence = raw_confidence * max(0, 1 - audit_density * 0.3)` (Hawthorne correction)
+- **Stats storage**: `(sum, sum_sq, count)` tuples only. Mean/variance computed at read time. Prevents floating-point drift.
+- **Idempotency**: when re-auditing the same sessionId, subtract the prior contribution then add the new one (delta).
+- **Append-only**: never delete registry items. Toggle status flags only.
+- **Versioning**: hard stop on `registry_version` mismatch (warn-and-continue + suspend recommendation until migration tool exists).
+- **Hawthorne**: `audit_density = audited sessions / last-30-day sessions`. If >0.3, apply the formula to displayed_confidence and surface a warning.
 
-## 라이프사이클
+## Lifecycle
 
 ```
 candidate
-  ├──→ promoted (5세션, conf≥0.4, ≥2 work_types)
-  ├──→ scoped   (5세션, conf≥0.7, 1 work_type)
-  ├──→ retired  (5세션, conf<0.1)              ← 부활 시 regressed로
-  └──→ detection_review (precision<0.5, ≥3 verdict)
+  ├──→ promoted (5 sessions, conf≥0.4, ≥2 work_types)
+  ├──→ scoped   (5 sessions, conf≥0.7, 1 work_type)
+  ├──→ retired  (5 sessions, conf<0.1)              ← re-detection triggers regressed
+  └──→ detection_review (precision<0.5, ≥3 verdicts)
 
 promoted/scoped
   ├──→ claude_md_queued ──→ claude_md_added ──→ under_remediation
   ├──→ hookify_queued   ──→ hookified       ──→ under_remediation
   ├──→ spec_queued      ──→ spec_added      ──→ under_remediation
-  └──→ under_remediation (직접 관찰만, fix 없음)
+  └──→ under_remediation (observation only, no fix)
 
 under_remediation
-  ├──→ remediated  (post_fix 5세션, post_fix_conf<0.1, work_type 매칭 ≥3)
-  ├──→ regressed   (post_fix 중 occurred)
-  └──→ remediation_inconclusive (post_fix 5세션, work_type 매칭 <3)
+  ├──→ remediated              (post_fix 5 sessions, post_fix_conf<0.1, work_type matches ≥3)
+  ├──→ regressed               (re-occurred during post_fix)
+  └──→ remediation_inconclusive (post_fix 5 sessions, work_type matches <3)
 
 regressed
-  ├──→ under_remediation       (같은 fix 유지, 재관찰)
-  ├──→ {claude_md|hookify|spec}_queued (escalate, allowed_fix_types 안에서)
-  └──→ accepted_residual       (allowed_fix_types 소진)
+  ├──→ under_remediation       (keep same fix, re-observe)
+  ├──→ {claude_md|hookify|spec}_queued  (escalate within allowed_fix_types)
+  └──→ accepted_residual       (allowed_fix_types exhausted)
 
-accepted_residual ─ TERMINAL (stats 가산 제외, 분기 1회 review 알림만)
-retired ──→ regressed (re-detection 시, reactivation_count 별도 카운터)
+accepted_residual ─ TERMINAL (excluded from stats, quarterly review notice only)
+retired ──→ regressed (on re-detection; reactivation_count tracked separately)
 ```
 
-**Escalation 트리거** (둘 중 하나):
+**Escalation triggers** (either condition):
 
 - `regression_rate = regression_count / matching_work_type_post_fix_sessions ≥ 0.4`
-- `reactivation_count ≥ 1` (retired였다 부활)
+- `reactivation_count ≥ 1` (retired item re-detected)
 
-자동 적용 금지. 모든 전이는 `/session-audit-act` 통해 사용자 승인 후.
+No auto-apply. All transitions go through `/session-audit-act` after explicit user approval.
 
-## fix_type 강도 서열 (강함 → 약함)
+## Fix Type Strength (strongest → weakest)
 
-| fix_type    | 강함 이유                                 | 한계                          |
-| ----------- | ----------------------------------------- | ----------------------------- |
-| `hookify`   | 자동 차단·경고, runtime 강제              | hookify_feasible 항목만 가능  |
-| `claude_md` | 매 세션 명시적 컨텍스트                   | 모델이 무시 가능              |
-| `spec`      | `docs/specs/` 룰화, PR 리뷰 시점에도 잡힘 | 장기, 사람 검토 의존          |
-| `manual`    | 추적용 placeholder                        | 강제력 없음, 사용자 행동 의존 |
+| fix_type    | Why stronger                                    | Limitation                                 |
+| ----------- | ----------------------------------------------- | ------------------------------------------ |
+| `hookify`   | Runtime enforcement, automatic block/warn       | Only feasible for hookify-compatible items |
+| `claude_md` | Injected into every session as explicit context | Model can still ignore                     |
+| `spec`      | Codified in `docs/specs/`, caught at PR review  | Long-cycle, depends on human review        |
+| `manual`    | Tracking placeholder only                       | No enforcement, user-behavior only         |
 
-각 항목의 `allowed_fix_types` 안에서만 escalate. 위가 없으면 `accepted_residual`.
+Escalate only within an item's `allowed_fix_types`. If no stronger option exists → `accepted_residual`.
 
-## 카테고리 (정리됨)
+## Categories
 
-- `rule_violation` — 코드 위반 (Read·Bash·Edit 패턴)
-- `process_violation` — 프로세스 위반 (review·lint·git workflow·agent 위임·docs 동기화)
-- `cost_anomaly` — 토큰 지표 이상 (cache·attachment·spike)
-- `behavior_pattern` — 표현·습관 (사과·narration·추측·미요청 작업)
+- `rule_violation` — code-level violations (Read/Bash/Edit patterns)
+- `process_violation` — process violations (review, lint, git workflow, agent delegation, docs sync)
+- `cost_anomaly` — token metric anomalies (cache, attachment, spike) — **model-controllable only**
+- `behavior_pattern` — expression and habit patterns (apology, narration, guessing, unrequested work)
+- `infra_noise` — **model-uncontrollable** infrastructure metrics (HTTP retry duplicate_request_ids, client-injected attachments, etc.). Excluded from stats. Fix queue forbidden. On reclassification, retroactively zero the stats contribution.
 
-기존 v1의 R7/R10/C7가 process_violation으로 이동 (cost_anomaly는 토큰 지표 전용).
+**infra_noise test**: "Would a CLAUDE.md rule or hookify reduce this pattern?" → If No, it is an infra_noise candidate. Flag with `infra_noise_candidate: true` in registry. (Formal `/session-audit-act reclassify` command is v2 deferred — use manual flag for now.)
 
-## 항목 (24개 → 28개로 확장)
+## Fast-Track Rules (core violation priority)
 
-상세는 `registry.json`. 추가된 4개:
+Certain conditions shorten or bypass the 5-session observation gate:
 
-- R11: Design token 위반 (hex/raw OKLCH)
-- R12: TDD 위반 (테스트 없이 구현)
-- R13: Git workflow 위반 (이미 hookify로 부분 baseline_hooked)
-- R14: Graphify 미사용 (광범위 refactor)
-- R15: Docs 동기화 누락 (wave-index/followup-bucket)
+- An item with `fast_track: true` AND `occ ≥ 5` → surface as **[FAST TRACK]** in audit report, recommend immediate promote.
+- **Core CLAUDE.md violations** (TDD, git workflow, review delegation): attach `fast_track: true` at `occ ≥ 4`. At `occ = 5`: immediately promote + queue hookify first.
+- **R2 quarterly hookify re-evaluation**: even as `accepted_residual`, items with `quarterly_review_note` must be re-assessed for hookify feasibility at the review date. A warn-only hook has near-zero false-positive cost and warrants reconsideration.
 
-P4/P5 의미 중복 — mapper에서 P4로 통합 매핑하도록 표시.
+## Deferred Item Rules
 
-## work_type 라벨 (자동 판정)
+Items with a recorded `defer_reason`:
 
-`pattern` expert가 jsonl touched_paths 기반 판정. multi-label 허용 (top-2까지).
+- On next re-detection, surface at the top of the audit report as "previously deferred, re-detected."
+- `defer_review_trigger: next_session_redetect` → reassess promotion immediately on re-detection.
+- A `promoted` item with no fix queued for 3+ sessions triggers a `stale_promoted` warning.
 
-- `fe_componentization` — `frontend/src/**` 신규 .tsx 多
+## Items (31 total)
+
+Details in `registry.json`. Categories:
+
+- **R1–R17**: rule_violation / process_violation
+- **C1–C7**: cost_anomaly (C5 flagged as infra_noise candidate)
+- **P1–P7**: behavior_pattern (P4/P5 semantic overlap — mapper unifies into P4)
+
+## work_type Labels (auto-classified)
+
+Classified from `touched_paths`. Multi-label allowed (top-2).
+
+- `fe_componentization` — many new `.tsx` files under `frontend/src/**`
 - `fe_prototype_parity` — `prototype/**` Read + `frontend/src/**` Edit
-- `fe_feature` — `frontend/src/**` Edit, prototype 무관
-- `be_api` — `backend/src/routes/**`·`backend/src/services/**`
-- `be_db` — `backend/migrations/**`·`shared/contracts/**`
-- `docs_only` — 변경 100% `docs/**` 또는 `*.md`
-- `refactor` — `git mv` 또는 import-only 다수
-- `infra` — `.claude/**`·`scripts/**`·`package.json`·`vite.config.*`
+- `fe_feature` — `frontend/src/**` Edit, unrelated to prototype
+- `be_api` — `backend/src/routes/**` or `backend/src/services/**`
+- `be_db` — `backend/migrations/**` or `shared/contracts/**`
+- `docs_only` — 100% changes under `docs/**` or `*.md`
+- `refactor` — `git mv` or majority import-only changes
+- `infra` — `.claude/**`, `scripts/**`, `package.json`, `vite.config.*`
 
-매칭(remediation/escalation 정규화용): set intersection ≥ 1.
+Matching for remediation/escalation normalization: set intersection ≥ 1.
 
-## False positive 추적
+## False Positive Tracking
 
-- session findings에 `user_verdict: tp|fp|unknown` (default unknown)
+- Per-finding `user_verdict: tp|fp|unknown` (default: unknown)
 - `/session-audit-act mark_fp <session_id> <item_id>`
-- 30일 미판정 unknown → tp 추정 (보수적, verdict_aging 룰)
-- precision = TP / (TP + FP). <0.5 + ≥3 verdict → status=`detection_review`
+- Unknown verdicts older than 30 days → assumed tp (conservative, verdict_aging rule)
+- precision = TP / (TP + FP). If precision < 0.5 with ≥ 3 verdicts → `detection_review`
 
 ## Cost ROI
 
-- session.json에 `audit_cost_tokens` (4 expert + 메인 합산)
-- `detected_waste_tokens` = 결정론 계산만 (expert 추정 금지) — 중복 tool call·redundant Read 등 raw 카운트
-- ROI = `detected_waste_cumulative / audit_cost_cumulative`. <1.5 누적 5세션이면 출력 끝에 audit suspension 권고
+- `audit_cost_tokens` per session.json (4 experts + main total)
+- `detected_waste_tokens` = deterministic count only (no expert estimates) — duplicate tool calls, redundant reads, etc.
+- ROI = `detected_waste_cumulative / audit_cost_cumulative`. If < 1.5 over the last 5 sessions → append audit suspension recommendation.
+- **Marginal ROI** (single-session detected_waste / audit_cost) tracked separately. Warning if marginal ROI < 2.0 for 2+ consecutive sessions.
 
-## Detection drift 골든 샘플 (필수)
+## Detection Drift / Golden Samples
 
-`.claude/audit/golden/` 에 박제 jsonl 5개 + `expected_findings.json`. 매 N=10 세션마다 회귀 실행 — recall<0.7 또는 false_positive_rate>0.3이면 audit suspend. 골든 샘플이 없으면 모든 metric은 `drift_unverified` 마킹.
+`.claude/audit/golden/` — 5 frozen jsonl files + `expected_findings.json`. Regression run every N=10 sessions. If recall < 0.7 or false_positive_rate > 0.3 → suspend audit. Missing golden samples → all metrics marked `drift_unverified`.
 
-## Deferred (v2 미구현, 운영 후 검토)
+## Deferred (v2 not yet implemented)
 
-- `opt-prompt-eval` 통합 (별도 시스템, 직교)
-- `claude-md-management` 핸드오프 (수동 우회 가능)
-- `digest` 명령 (월간 일괄 결정)
-- `fix_batch_id` (동시 다중 fix 분리)
-- 마이그레이션 도구 (`/session-audit-migrate`)
+- `opt-prompt-eval` integration (separate system, orthogonal)
+- `claude-md-management` handoff (manual workaround available)
+- `digest` command (monthly bulk decisions)
+- `fix_batch_id` (separate concurrent fix tracking)
+- Migration tool (`/session-audit-migrate`)
+- Formal `reclassify` action for infra_noise items
 
-## 누설 차단 (turns_summary)
+## Leakage Prevention (turns_summary)
 
-다음 패턴은 expert에 전달 전 마스킹:
+Mask before passing to experts:
 
-- 경로: `.claude/audit/**`, `.omc/**`, `.claude/scheduled_tasks.lock`
-- 본문 토큰: `/hookify\.[a-z\-]+/`, `/audit_item_[0-9]+/`, `/\.omc\/[^\s]+/`
-- expert 입력 토큰 상한 50KB, 초과 truncate
+- Paths matching `.claude/audit/**`, `.omc/**`, `.claude/scheduled_tasks.lock` → `[REDACTED-INTERNAL]`
+- Body tokens matching `/hookify\.[a-z\-]+/`, `/audit_item_[0-9]+/`, `/\.omc\/[^\s]+/` → `[REDACTED]`
+- Expert input cap: 50 KB; truncate if exceeded

--- a/.claude/audit/registry.json
+++ b/.claude/audit/registry.json
@@ -95,12 +95,18 @@
     {
       "id": "R1",
       "category": "rule_violation",
-      "title": "동일 파일 재-Read",
+      "title": "Same file re-read",
       "detection": "Read tool_use에 같은 path 2회+ (수정 사이 제외)",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
-      "status": "promoted",
-      "fix_history": [],
+      "status": "hookify_queued",
+      "fix_history": [
+        {
+          "fix_type": "hookify",
+          "queued_at": "2026-05-05T07:20:00.000Z",
+          "note": "Queued hookify fix. promoted→hookify_queued. R1 (동일 파일 재-Read) occ=8/9, conf=0.71. Hookify rule to warn/block redundant Read of same file in same session."
+        }
+      ],
       "regression_count": 0,
       "reactivation_count": 0,
       "baseline_hooked": false,
@@ -110,11 +116,11 @@
     {
       "id": "R2",
       "category": "rule_violation",
-      "title": "Sequential 가능했던 parallel",
+      "title": "Sequential calls that could have been parallel",
       "detection": "연속 assistant 턴 각 tool 1개·의존 없음",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
-      "status": "spec_added",
+      "status": "accepted_residual",
       "fix_history": [
         {
           "fix_type": "claude_md",
@@ -134,16 +140,31 @@
           "queued_at": "2026-05-05T04:57:33.106185+00:00",
           "note": "Escalated spec after CLAUDE.md regression. Covers B1-B4 + M1-M3 from adversarial review: argument-writability gate, \"read A first\" trap, same-file Edit tightened, closed exception list, CLAUDE.md pointer added, 10-item rationalization table.",
           "applied_at": "2026-05-05T05:02:29.448521+00:00"
+        },
+        {
+          "fix_type": "transition",
+          "reference": "session:43ef1450-37e0-4637-9d23-cb98bee852c2",
+          "applied_at": "2026-05-05T07:20:00.000Z",
+          "note": "spec_added → under_remediation → regressed: R2 re-fired in fe_componentization+refactor session the same day spec was applied. typecheck/test split (2 turns apart) + code-reviewer agents dispatched sequentially (13s gap). regression_count=2"
+        },
+        {
+          "fix_type": "transition",
+          "reference": "session:43ef1450-37e0-4637-9d23-cb98bee852c2",
+          "applied_at": "2026-05-05T07:22:00.000Z",
+          "note": "regressed → accepted_residual. allowed_fix_types exhausted (claude_md + spec both applied; hookify not in allowed_fix_types). R2 (sequential-when-parallel) requires semantic judgment — not automatable. Accepted as residual."
         }
       ],
-      "regression_count": 1,
+      "regression_count": 2,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "accepted_residual_at": "2026-05-05T07:22:00.000Z",
+      "next_quarterly_review": "2026-08-05",
+      "quarterly_review_note": "2026-08-05: Re-evaluate hookify feasibility. A PreToolUse hook detecting consecutive same-type Agent/Bash calls in one turn is structurally detectable (not purely semantic). If feasible, amend allowed_fix_types to include hookify and reactivate."
     },
     {
       "id": "R3",
       "category": "rule_violation",
-      "title": "TS/TSX 전체 Read",
+      "title": "Full TS/TSX file read",
       "detection": "Read 결과 >300줄 & .ts(x) & Serena 미사용",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -156,7 +177,7 @@
     {
       "id": "R4",
       "category": "rule_violation",
-      "title": "cat <file> 풀덤프",
+      "title": "cat <file> full dump",
       "detection": "Bash command가 cat <소스파일>",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -164,12 +185,15 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Defer until R1 hookify rule is written — same category, learn from that first. Promote when occ reaches 8.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "R5",
       "category": "rule_violation",
-      "title": "Read-before-rm",
+      "title": "Read before delete",
       "detection": "rm 직전 같은 path Read",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -182,7 +206,7 @@
     {
       "id": "R6",
       "category": "rule_violation",
-      "title": "git log 좁게 retry",
+      "title": "Narrow git log retry",
       "detection": "git log --grep 2회+ & 2번째가 더 좁음",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -195,7 +219,7 @@
     {
       "id": "R7",
       "category": "process_violation",
-      "title": "자체 리뷰",
+      "title": "Self-review",
       "detection": "1000줄+ 변경 후 Agent(code-reviewer) 0회",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -208,7 +232,7 @@
     {
       "id": "R8",
       "category": "rule_violation",
-      "title": "사용자 승인 전 완료선언",
+      "title": "Completion claim before user approval",
       "detection": "완료/done/merged 텍스트 직전 user 승인 부재",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -221,7 +245,7 @@
     {
       "id": "R9",
       "category": "rule_violation",
-      "title": "90% 미확정 진행",
+      "title": "Proceeding under 90% uncertainty",
       "detection": "일단/우선/아마 + 즉시 코드 수정",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -234,7 +258,7 @@
     {
       "id": "R10",
       "category": "process_violation",
-      "title": "Lint 누락 commit",
+      "title": "Lint skipped on commit",
       "detection": "git commit 직전 npm run lint Bash 부재",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -247,7 +271,7 @@
     {
       "id": "R11",
       "category": "rule_violation",
-      "title": "Design token 위반 (hex/raw OKLCH)",
+      "title": "Design token violation (hex/raw OKLCH)",
       "detection": "FE diff에 hex 또는 oklch(...) 직접",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -260,7 +284,7 @@
     {
       "id": "R12",
       "category": "rule_violation",
-      "title": "TDD 위반 (테스트 없이 구현)",
+      "title": "TDD violation (implementation without tests)",
       "detection": "test 미수정 commit에 src/ 신규/수정",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -268,12 +292,14 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "fast_track": true,
+      "fast_track_reason": "Core CLAUDE.md violation (TDD-only rule). occ=4/9. At occ=5: immediately promote + queue hookify (PostToolUse on Edit/Write to frontend/src/**/*.tsx — verify corresponding test file exists)."
     },
     {
       "id": "R13",
       "category": "process_violation",
-      "title": "Git workflow 위반",
+      "title": "Git workflow violation",
       "detection": "main 직접 commit 또는 squash/rebase merge",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -286,7 +312,7 @@
     {
       "id": "R14",
       "category": "rule_violation",
-      "title": "Graphify 미사용 (광범위 refactor)",
+      "title": "Graphify skipped on broad refactor",
       "detection": "≥3 모듈 변경 또는 미지 feature 진입에 graphify 호출 0",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -299,7 +325,7 @@
     {
       "id": "R15",
       "category": "process_violation",
-      "title": "Docs 동기화 누락",
+      "title": "Docs sync missing",
       "detection": "wave/phase 닫힘 commit에 wave-index/followup-bucket 미갱신",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
@@ -320,7 +346,10 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Partially infra-level. Defer until attachment burst root cause is better understood.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "C2",
@@ -333,12 +362,15 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Output spike co-occurs with P2 (narration). Fix P2 first, then measure impact.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "C3",
       "category": "cost_anomaly",
-      "title": "턴당 attachment 과다",
+      "title": "High attachment density per turn",
       "detection": "한 턴 attachment > 10",
       "hookify_feasible": false,
       "allowed_fix_types": ["spec", "manual"],
@@ -364,7 +396,7 @@
     {
       "id": "C5",
       "category": "cost_anomaly",
-      "title": "단일 prompt 토큰 점유 과다",
+      "title": "Single-prompt token overload",
       "detection": "한 prompt 토큰이 세션 전체의 50% 초과",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -372,7 +404,12 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "INFRA_NOISE CANDIDATE: duplicate_request_ids is HTTP-layer client retry — model has no control. Reclassify before promoting. Do not queue a model-facing fix.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect",
+      "infra_noise_candidate": true,
+      "infra_noise_note": "duplicate_request_ids is Claude Code client HTTP retry — model has no control. Reclassify to infra_noise. Stats contribution should be zeroed if reclassified."
     },
     {
       "id": "C6",
@@ -390,7 +427,7 @@
     {
       "id": "C7",
       "category": "process_violation",
-      "title": "Agent 위임 부족",
+      "title": "Insufficient agent delegation",
       "detection": "Agent 0 & 변경 LOC > 500",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -403,7 +440,7 @@
     {
       "id": "P1",
       "category": "behavior_pattern",
-      "title": "사과·재시도 루프",
+      "title": "Apology/retry loop",
       "detection": "죄송/다시/aha 3회+",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -416,7 +453,7 @@
     {
       "id": "P2",
       "category": "behavior_pattern",
-      "title": "도구 전 장황 narration",
+      "title": "Verbose narration before tool call",
       "detection": "첫 tool 전 200자+",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -424,12 +461,15 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Defer pending R4 fix — narration and cat-reads often co-occur. Fix R4 first, measure impact on P2.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "P3",
       "category": "behavior_pattern",
-      "title": "추측 fallback",
+      "title": "Guess fallback",
       "detection": "보통/아마/기본값으로 표현",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -442,7 +482,7 @@
     {
       "id": "P4",
       "category": "behavior_pattern",
-      "title": "미요청 작업 (포괄)",
+      "title": "Unrequested work (broad)",
       "detection": "요청 외 파일 수정·생성 (P5는 P4 특수케이스 — 매핑 시 통합)",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -450,12 +490,15 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Low ordinal (avg 1.8). Defer — subagent dispatch without approval is edge case in autonomous workflows.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "P5",
       "category": "behavior_pattern",
-      "title": "미요청 docs/comment 작성",
+      "title": "Unrequested docs/comment writing",
       "detection": ".md 신규생성·docstring 다수 (P4와 중복 — Round 2 후 통합 예정)",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -468,7 +511,7 @@
     {
       "id": "P6",
       "category": "behavior_pattern",
-      "title": "결정 떠넘김",
+      "title": "Decision deferred to user",
       "detection": "사용자에 결정 위임 표현",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -476,12 +519,15 @@
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
-      "baseline_hooked": false
+      "baseline_hooked": false,
+      "defer_reason": "Defer — the '승인 후 구현' (approve-then-implement) gate is intentional per CLAUDE.md. May be a false positive for this project's working style.",
+      "defer_recorded_at": "2026-05-05T07:35:00.000Z",
+      "defer_review_trigger": "next_session_redetect"
     },
     {
       "id": "P7",
       "category": "behavior_pattern",
-      "title": "지연 batch 패턴",
+      "title": "Deferred batch pattern",
       "detection": "한 prompt에 N PR/태스크 묶어 위임",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -494,7 +540,7 @@
     {
       "id": "R16",
       "category": "rule_violation",
-      "title": "Skill 도구를 CLI 내장 명령에 사용",
+      "title": "Skill tool used as CLI built-in command",
       "detection": "Skill tool_use에 compact/clear 등 내장 CLI 커맨드",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
@@ -509,7 +555,7 @@
     {
       "id": "R17",
       "category": "rule_violation",
-      "title": "Doc 파일 Read limit 미지정",
+      "title": "Doc file read without limit",
       "detection": "Read tool_use on .md file without limit param (claude-progress.txt 제외)",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],


### PR DESCRIPTION
## Summary

- Translate all 31 registry item titles and notes to English
- Rewrite `checklist.md` fully in English
- Add `infra_noise` category for model-uncontrollable metrics (C5 flagged as candidate — HTTP retry duplicate_request_ids)
- Add fast-track rules: core CLAUDE.md violations (TDD, git workflow) skip to immediate promote at occ≥5
- Add deferred item rules with re-detection surfacing and stale_promoted warning
- Record `defer_reason` for 7 skipped candidates (R4/C1/C2/C5/P2/P4/P6)
- Add marginal ROI tracking (warn if <2.0 for 2+ consecutive sessions)
- Session 43ef1450 transitions: R1→hookify_queued, R2→accepted_residual, R12 fast_track=true

## Test plan

- [ ] Registry JSON valid (no Korean in titles)
- [ ] Checklist renders correctly in English
- [ ] FE 364 tests pass ✅
- [ ] BE 100 tests pass ✅
- [ ] typecheck clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)