### PR TITLE
feat(ui): underline tab variant + activity panel layout redesign

### DIFF
--- a/docs/specs/plans/wave-1-6-voc-parity.md
+++ b/docs/specs/plans/wave-1-6-voc-parity.md
@@ -9,6 +9,8 @@
 > 머지된 PR들(C-1~C-16, F-1/F-2/F-3, F-bundle minor, Issue #155/#156/#162/#166)의 상세는 `progress-archive.md`로 이동. 본 절은 **다음 작업**만.
 > ε batch (C-14 VocCommentList / C-15 VocInternalNotes / C-16 VocSubTaskList) 완료 ✅.
 > **실행 순서 조정 (2026-05-05)**: VOC 리뷰 페이지 고도화 우선 — η batch(C-20~C-23) 먼저 진행 후 ζ batch(C-17~C-19).
+>
+> **C-14 BE 미연결 (2026-05-06)**: Comment CRUD(`POST/GET/PATCH/DELETE /api/vocs/:id/comments`) BE 라우트·컨트롤러·react-query 훅 미작성. FE UI(`VocComment.tsx`)는 빈 배열 + 빈 핸들러로 stub 상태. spec: `feature-voc.md §8.13`. Wave 1.6 종료 후 별도 태스크로 진입.
 
 | 순서 | Batch | leaf                         | 의존                             | 비고                                                                                 |
 | ---- | ----- | ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |

--- a/docs/specs/requires/feature-voc.md
+++ b/docs/specs/requires/feature-voc.md
@@ -354,12 +354,50 @@ function assertCanManageVoc(
 - 정적 파일 서빙: Express `static` 미들웨어 또는 별도 `/files/:id` 엔드포인트로 인증 후 제공.
 - 운영 환경에서는 volume을 호스트 경로에 마운트하여 백업 대상 포함.
 
-### 8.13 댓글 수정/삭제 정책
+### 8.13 댓글 (공개 Comment)
+
+#### API
+
+| 메서드   | 경로                                | 권한               | 요청 body          | 응답                   | 에러                   |
+| -------- | ----------------------------------- | ------------------ | ------------------ | ---------------------- | ---------------------- |
+| `GET`    | `/api/vocs/:id/comments`            | 조회 권한자 전체   | —                  | `{ rows: Comment[] }`  | 404 VOC_NOT_FOUND      |
+| `POST`   | `/api/vocs/:id/comments`            | canWrite           | `{ body: string }` | `{ comment: Comment }` | 403, 422 BODY_REQUIRED |
+| `PATCH`  | `/api/vocs/:id/comments/:commentId` | 작성자 본인, Admin | `{ body: string }` | `{ comment: Comment }` | 403, 404               |
+| `DELETE` | `/api/vocs/:id/comments/:commentId` | 작성자 본인, Admin | —                  | `{ ok: true }`         | 403, 404               |
+
+`Comment` shape: `{ id, voc_id, author_id, body, created_at, updated_at }`.
+
+- internal note를 **절대 혼입하지 않음** (§8.16 참조).
+- `GET` 응답은 `created_at ASC` 정렬. 페이지네이션 없음 (MVP: 최대 200건).
+
+#### 수정/삭제 정책
 
 - **수정:** 본인이 작성한 댓글만 수정 가능. 수정 시 `updated_at` 갱신 및 UI에 "(수정됨)" 표시.
 - **삭제:** 본인이 작성한 댓글 삭제 가능(Hard Delete). Admin은 모든 댓글 삭제 가능.
   - 댓글은 의도적 Hard Delete — 댓글은 감사 로그 대상이 아니며, VOC 본문·상태·담당자·Priority 변경만 `voc_history`로 추적.
 - VOC 작성자 본인의 댓글에는 수정/삭제 버튼 노출, 타인 댓글에는 미노출.
+
+#### UI 레이아웃 (2026-05-06 확정)
+
+활동 패널 탭(`Comment` / `History` / `Subtask` / `InternalNote`)은 **underline variant** 사용:
+
+- 탭 목록: 배경·박스 없음, 하단 구분선만 (`var(--bg-elevated)` 1px).
+- 활성 탭: 하단 2px 라인 `var(--brand)`, 텍스트 bold + `var(--text-primary)`.
+- 비활성 탭: `var(--text-secondary)`.
+
+댓글 아이템 레이아웃 (박스 없음, `gap-4` 여백):
+
+```
+[Avatar]  author_id (앞 8자) · 시간  [수정 삭제 - 본인만]
+          본문
+```
+
+- Avatar: 이니셜 원형, `var(--brand-bg)` 배경 / `var(--brand)` 텍스트.
+
+#### BE 구현 현황 (2026-05-06)
+
+- FE UI: ✅ 완료 (`VocComment.tsx` — 빈 배열 + 빈 핸들러로 연결)
+- BE CRUD: ⏳ 미구현 — `POST/GET/PATCH/DELETE /api/vocs/:id/comments` 라우트·컨트롤러·react-query 훅 모두 미작성. Wave 1.6 종료 후 별도 태스크로 진입.
 
 ### 8.14 인앱 알림 폴링
 

--- a/docs/specs/requires/uidesign.md
+++ b/docs/specs/requires/uidesign.md
@@ -249,6 +249,35 @@ box-shadow: 0 0 0 1px var(--brand-border); /* double-ring: intentional active si
 - Filterbar height: `44px` — deliberately secondary to topbar's `56px`
 - Filter tab row: `height: 44px; padding: 0 var(--sp-5)` — distinct zone between topbar and list header
 
+### Underline Tab (Activity Panel)
+
+Used in the VOC review drawer activity section (`Comment / History / Subtask / InternalNote`). Implemented as `variant="underline"` on `TabsList` / `TabsTrigger` (`shared/ui/tabs`).
+
+```css
+/* TabsList */
+background: transparent;
+border-radius: 0;
+padding: 0;
+border-bottom: 1px solid var(--bg-elevated);
+
+/* TabsTrigger — base */
+background: transparent;
+border-radius: 0;
+border-bottom: 2px solid transparent;
+padding: 4px 12px 8px;
+color: var(--text-secondary);
+font-size: 14px;
+
+/* TabsTrigger — active */
+border-bottom-color: var(--brand);
+color: var(--text-primary);
+font-weight: 600;
+```
+
+- No background, no box shadow, no rounded corners — flat underline only.
+- Active indicator: `var(--brand)` 2px bottom border (auto light/dark via token).
+- Avatar used in activity item rows: `var(--brand-bg)` fill, `var(--brand)` text, 28px circle.
+
 ### Status Badge
 
 Full pill style — background + border + text color, all semantic. Not dot-only.

--- a/frontend/src/features/voc/review/__tests__/VocCommentList.test.tsx
+++ b/frontend/src/features/voc/review/__tests__/VocCommentList.test.tsx
@@ -16,7 +16,7 @@ const mkComment = (over: Partial<Comment> = {}): Comment => ({
 });
 
 describe('VocCommentList', () => {
-  it('빈 상태 — "댓글 0개" 헤더 + 푸터 textarea 노출', () => {
+  it('빈 상태 — 빈 메시지 + 푸터 textarea 노출', () => {
     render(
       <VocComment
         comments={[]}
@@ -28,11 +28,11 @@ describe('VocCommentList', () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByRole('heading', { name: /댓글 0개/ })).toBeInTheDocument();
+    expect(screen.getByText('아직 작성된 댓글이 없습니다.')).toBeInTheDocument();
     expect(screen.getByLabelText('new comment')).toBeInTheDocument();
   });
 
-  it('댓글 목록 렌더링 + 카운트', () => {
+  it('댓글 목록 렌더링', () => {
     render(
       <VocComment
         comments={[mkComment(), mkComment({ id: 'c-2', body: '확인했습니다' })]}
@@ -44,7 +44,6 @@ describe('VocCommentList', () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByRole('heading', { name: /댓글 2개/ })).toBeInTheDocument();
     expect(screen.getByText('리뷰 부탁드립니다')).toBeInTheDocument();
     expect(screen.getByText('확인했습니다')).toBeInTheDocument();
   });

--- a/frontend/src/features/voc/review/ui/VocActionSection.tsx
+++ b/frontend/src/features/voc/review/ui/VocActionSection.tsx
@@ -41,11 +41,21 @@ export function VocActionSection({
   return (
     <CollapsibleSection title="활동" testId="drawer-actions">
       <Tabs defaultValue="comment" data-pcomp="review-sections">
-        <TabsList className="w-full justify-start">
-          <TabsTrigger value="comment">Comment</TabsTrigger>
-          <TabsTrigger value="history">History</TabsTrigger>
-          <TabsTrigger value="subtask">Subtask</TabsTrigger>
-          {canSeeInternal && <TabsTrigger value="internal">InternalNote</TabsTrigger>}
+        <TabsList variant="underline">
+          <TabsTrigger variant="underline" value="comment">
+            Comment
+          </TabsTrigger>
+          <TabsTrigger variant="underline" value="history">
+            History
+          </TabsTrigger>
+          <TabsTrigger variant="underline" value="subtask">
+            Subtask
+          </TabsTrigger>
+          {canSeeInternal && (
+            <TabsTrigger variant="underline" value="internal">
+              InternalNote
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="comment">

--- a/frontend/src/features/voc/review/ui/VocComment.tsx
+++ b/frontend/src/features/voc/review/ui/VocComment.tsx
@@ -21,6 +21,23 @@ interface Props {
   onDelete: (id: string) => void;
 }
 
+function ActivityAvatar({ userId }: { userId: string }) {
+  const initial = userId[0]?.toUpperCase() ?? '?';
+  return (
+    <span
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+      style={{ background: 'var(--brand-bg)', color: 'var(--brand)' }}
+      aria-hidden
+    >
+      {initial}
+    </span>
+  );
+}
+
+function formatTime(iso: string) {
+  return iso.slice(0, 16).replace('T', ' ');
+}
+
 export function VocComment({
   comments,
   currentUserId,
@@ -34,123 +51,123 @@ export function VocComment({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState('');
 
+  const submitDraft = () => {
+    const next = draft.trim();
+    if (next) {
+      onAdd(next);
+      setDraft('');
+    }
+  };
+
   return (
     <section
       data-testid="drawer-comments"
-      className="flex flex-col gap-2"
+      className="flex flex-col gap-4 py-1"
       aria-labelledby="voc-comments-heading"
     >
-      <h3
-        id="voc-comments-heading"
-        className="text-xs font-medium"
-        style={{ color: 'var(--text-secondary)' }}
-      >
-        댓글 {comments.length}개
-      </h3>
       {comments.length === 0 ? (
         <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
           아직 작성된 댓글이 없습니다.
         </p>
       ) : (
-        <ul className="flex flex-col gap-2">
+        <ul className="flex flex-col gap-4">
           {comments.map((c) => {
             const isOwn = c.author_id === currentUserId;
             const isEditing = editingId === c.id;
             const edited = c.updated_at !== c.created_at;
+            const shortUser = c.author_id.slice(0, 8);
             return (
-              <li
-                key={c.id}
-                className="rounded border p-2 text-sm"
-                style={{
-                  borderColor: 'var(--border-standard)',
-                  background: 'var(--bg-elevated)',
-                }}
-              >
-                <div
-                  className="flex items-center justify-between text-[11px]"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  <span>
-                    {c.created_at.slice(0, 16).replace('T', ' ')}
-                    {edited && <span className="ml-1">(수정됨)</span>}
-                  </span>
-                  {isOwn && !isEditing && (
-                    <span className="flex gap-1">
-                      <button
-                        type="button"
-                        data-testid={`comment-edit-${c.id}`}
-                        aria-label="수정"
-                        className="text-[11px]"
-                        style={{ color: 'var(--text-secondary)' }}
-                        onClick={() => {
-                          setEditingId(c.id);
-                          setEditBody(c.body);
-                        }}
-                      >
-                        수정
-                      </button>
-                      <button
-                        type="button"
-                        data-testid={`comment-delete-${c.id}`}
-                        aria-label="삭제"
-                        className="text-[11px]"
-                        style={{ color: 'var(--text-secondary)' }}
-                        onClick={() => onDelete(c.id)}
-                      >
-                        삭제
-                      </button>
-                    </span>
+              <li key={c.id} className="flex gap-3">
+                <ActivityAvatar userId={c.author_id} />
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <div className="flex items-center justify-between gap-x-1">
+                    <div className="flex flex-wrap items-center gap-x-1 text-xs">
+                      <span className="font-medium" style={{ color: 'var(--text-primary)' }}>
+                        {shortUser}
+                      </span>
+                      <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+                      <span style={{ color: 'var(--text-tertiary)' }}>
+                        {formatTime(c.created_at)}
+                        {edited && <span className="ml-1">(수정됨)</span>}
+                      </span>
+                    </div>
+                    {isOwn && !isEditing && (
+                      <span className="flex gap-2">
+                        <button
+                          type="button"
+                          data-testid={`comment-edit-${c.id}`}
+                          aria-label="수정"
+                          className="text-[11px]"
+                          style={{ color: 'var(--text-tertiary)' }}
+                          onClick={() => {
+                            setEditingId(c.id);
+                            setEditBody(c.body);
+                          }}
+                        >
+                          수정
+                        </button>
+                        <button
+                          type="button"
+                          data-testid={`comment-delete-${c.id}`}
+                          aria-label="삭제"
+                          className="text-[11px]"
+                          style={{ color: 'var(--text-tertiary)' }}
+                          onClick={() => onDelete(c.id)}
+                        >
+                          삭제
+                        </button>
+                      </span>
+                    )}
+                  </div>
+                  {isEditing ? (
+                    <form
+                      className="mt-1 flex flex-col gap-2"
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        const next = editBody.trim();
+                        if (next) {
+                          onEdit(c.id, next);
+                          setEditingId(null);
+                        }
+                      }}
+                    >
+                      <Textarea
+                        value={editBody}
+                        onChange={(e) => setEditBody(e.target.value)}
+                        aria-label="댓글 수정"
+                      />
+                      <div className="flex gap-2">
+                        <Button type="submit" size="sm" disabled={pending || !editBody.trim()}>
+                          저장
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setEditingId(null)}
+                        >
+                          취소
+                        </Button>
+                      </div>
+                    </form>
+                  ) : (
+                    <p className="text-sm" style={{ color: 'var(--text-primary)' }}>
+                      {c.body}
+                    </p>
                   )}
                 </div>
-                {isEditing ? (
-                  <form
-                    className="mt-1 flex flex-col gap-2"
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      const next = editBody.trim();
-                      if (next) {
-                        onEdit(c.id, next);
-                        setEditingId(null);
-                      }
-                    }}
-                  >
-                    <Textarea
-                      value={editBody}
-                      onChange={(e) => setEditBody(e.target.value)}
-                      aria-label="댓글 수정"
-                    />
-                    <div className="flex gap-2">
-                      <Button type="submit" size="sm" disabled={pending || !editBody.trim()}>
-                        저장
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setEditingId(null)}
-                      >
-                        취소
-                      </Button>
-                    </div>
-                  </form>
-                ) : (
-                  <div style={{ color: 'var(--text-primary)' }}>{c.body}</div>
-                )}
               </li>
             );
           })}
         </ul>
       )}
+
       {canWrite && (
         <form
-          className="mt-1 flex flex-col gap-2"
+          className="flex flex-col gap-2"
           onSubmit={(e) => {
             e.preventDefault();
-            const next = draft.trim();
-            if (next) {
-              onAdd(next);
-              setDraft('');
-            }
+            submitDraft();
           }}
         >
           <Textarea
@@ -159,11 +176,7 @@ export function VocComment({
             onKeyDown={(e) => {
               if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
                 e.preventDefault();
-                const next = draft.trim();
-                if (next) {
-                  onAdd(next);
-                  setDraft('');
-                }
+                submitDraft();
               }
             }}
             placeholder="댓글을 입력하세요 (Ctrl+Enter로 등록)"

--- a/frontend/src/features/voc/review/ui/VocHistory.tsx
+++ b/frontend/src/features/voc/review/ui/VocHistory.tsx
@@ -7,6 +7,23 @@ interface Props {
   loading: boolean;
 }
 
+function ActivityAvatar({ userId }: { userId: string }) {
+  const initial = userId[0]?.toUpperCase() ?? '?';
+  return (
+    <span
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+      style={{ background: 'var(--brand-bg)', color: 'var(--brand)' }}
+      aria-hidden
+    >
+      {initial}
+    </span>
+  );
+}
+
+function formatTime(iso: string) {
+  return iso.slice(0, 16).replace('T', ' ');
+}
+
 export function VocHistory({ entries, loading }: Props) {
   if (loading) return <LoadingState />;
 
@@ -19,22 +36,32 @@ export function VocHistory({ entries, loading }: Props) {
   }
 
   return (
-    <ol className="flex flex-col gap-2">
-      {entries.map((h) => (
-        <li
-          key={h.id}
-          className="rounded border p-2 text-xs"
-          style={{ borderColor: 'var(--border-standard)' }}
-        >
-          <div style={{ color: 'var(--text-secondary)' }}>
-            {h.changed_at.slice(0, 16).replace('T', ' ')}
-          </div>
-          <div style={{ color: 'var(--text-primary)' }}>
-            {(VOC_FIELD_LABELS as Record<string, string>)[h.field] ?? h.field}: {h.old_value ?? '∅'}{' '}
-            → {h.new_value ?? '∅'}
-          </div>
-        </li>
-      ))}
+    <ol className="flex flex-col gap-4 py-1">
+      {entries.map((h) => {
+        const fieldLabel = (VOC_FIELD_LABELS as Record<string, string>)[h.field] ?? h.field;
+        const shortUser = h.changed_by.slice(0, 8);
+        return (
+          <li key={h.id} className="flex gap-3">
+            <ActivityAvatar userId={h.changed_by} />
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <div className="flex flex-wrap items-center gap-x-1 text-xs">
+                <span className="font-medium" style={{ color: 'var(--text-primary)' }}>
+                  {shortUser}
+                </span>
+                <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+                <span style={{ color: 'var(--text-secondary)' }}>{fieldLabel} 변경</span>
+                <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+                <span style={{ color: 'var(--text-tertiary)' }}>{formatTime(h.changed_at)}</span>
+              </div>
+              <div className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                <span style={{ color: 'var(--text-tertiary)' }}>{h.old_value ?? '∅'}</span>
+                {' → '}
+                <span style={{ color: 'var(--text-primary)' }}>{h.new_value ?? '∅'}</span>
+              </div>
+            </div>
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/frontend/src/shared/ui/tabs/index.tsx
+++ b/frontend/src/shared/ui/tabs/index.tsx
@@ -1,19 +1,47 @@
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@shared/lib/cn';
 
 const Tabs = TabsPrimitive.Root;
 
+const tabsListVariants = cva('inline-flex items-center', {
+  variants: {
+    variant: {
+      default:
+        'h-10 justify-center rounded-md bg-[color:var(--bg-elevated)] p-1 text-[color:var(--text-secondary)]',
+      underline:
+        'w-full justify-start gap-1 rounded-none border-b border-[color:var(--bg-elevated)] bg-transparent p-0',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+const tabsTriggerVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-[color:var(--bg-app)] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default:
+          'rounded-sm px-3 py-1.5 data-[state=active]:bg-[color:var(--bg-surface)] data-[state=active]:text-[color:var(--text-primary)] data-[state=active]:shadow-sm',
+        underline:
+          'rounded-none border-b-2 border-transparent bg-transparent px-3 pb-2 pt-1 text-[color:var(--text-secondary)] shadow-none data-[state=active]:border-[color:var(--brand)] data-[state=active]:bg-transparent data-[state=active]:font-semibold data-[state=active]:text-[color:var(--text-primary)] data-[state=active]:shadow-none',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+);
+
+type ListVariant = VariantProps<typeof tabsListVariants>['variant'];
+type TriggerVariant = VariantProps<typeof tabsTriggerVariants>['variant'];
+
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & { variant?: ListVariant }
+>(({ className, variant, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-[color:var(--bg-elevated)] p-1 text-[color:var(--text-secondary)]',
-      className,
-    )}
+    className={cn(tabsListVariants({ variant }), className)}
     {...props}
   />
 ));
@@ -21,14 +49,11 @@ TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & { variant?: TriggerVariant }
+>(({ className, variant, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-[color:var(--bg-app)] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-[color:var(--bg-surface)] data-[state=active]:text-[color:var(--text-primary)] data-[state=active]:shadow-sm',
-      className,
-    )}
+    className={cn(tabsTriggerVariants({ variant }), className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary

- `TabsList`/`TabsTrigger`에 `variant="underline"` cva prop 추가 — 하드코딩된 클래스 제거
- VocHistory: 박스·테두리 제거, 아바타 + 이름/섹션/시간/변경내용 레이아웃으로 재설계
- VocComment: 동일 아바타 레이아웃 통일, 댓글 카운트 헤딩 제거
- docs: `feature-voc.md §8.13` Comment CRUD API 표 추가, `uidesign.md` Underline Tab spec, `wave-1-6-voc-parity.md` C-14 BE 미연결 현황 기록

## Test plan

- [ ] `VocCommentList` 테스트 9건 통과 확인
- [ ] typecheck clean
- [ ] Comment/History 탭 언더라인 스타일 시각 확인
- [ ] 기존 default variant tabs 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)