### PR TITLE
feat(mock): wire comment/subtask/history mock data to activity panel

### DIFF
--- a/frontend/src/entities/voc/api/vocApi.ts
+++ b/frontend/src/entities/voc/api/vocApi.ts
@@ -1,4 +1,5 @@
 import { apiGet, apiPost, apiPatch } from '@shared/api/client';
+import { z } from 'zod';
 import {
   VocListResponse,
   VocDetail,
@@ -10,7 +11,14 @@ import {
   InternalNoteCreate,
   VocHistoryListResponse,
   type VocHistoryEntry,
+  CommentListResponse,
+  type Comment,
+  VocStatus,
 } from '@contracts/voc';
+
+const SubTaskListResponse = z.object({
+  rows: z.array(z.object({ id: z.string(), title: z.string(), status: VocStatus })),
+});
 
 function toQs(query: Partial<VocListQuery>): string {
   const params = new URLSearchParams();
@@ -51,5 +59,11 @@ export const vocApi = {
   },
   history(id: string): Promise<VocHistoryEntry[]> {
     return apiGet(`/api/vocs/${id}/history`, VocHistoryListResponse).then((r) => r.rows);
+  },
+  comments(id: string): Promise<Comment[]> {
+    return apiGet(`/api/vocs/${id}/comments`, CommentListResponse).then((r) => r.rows);
+  },
+  subtasks(id: string): Promise<z.infer<typeof SubTaskListResponse>['rows']> {
+    return apiGet(`/api/vocs/${id}/subtasks`, SubTaskListResponse).then((r) => r.rows);
   },
 };

--- a/frontend/src/entities/voc/api/vocQueryKeys.ts
+++ b/frontend/src/entities/voc/api/vocQueryKeys.ts
@@ -8,4 +8,6 @@ export const vocQueryKeys = {
   detail: (role: Role, id: string) => ['voc', role, 'detail', id] as const,
   notes: (role: Role, id: string) => ['voc', role, 'notes', id] as const,
   history: (role: Role, id: string) => ['voc', role, 'history', id] as const,
+  comments: (role: Role, id: string) => ['voc', role, 'comments', id] as const,
+  subtasks: (role: Role, id: string) => ['voc', role, 'subtasks', id] as const,
 } as const;

--- a/frontend/src/features/voc/review/model/useDrawerQueries.ts
+++ b/frontend/src/features/voc/review/model/useDrawerQueries.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { vocApi, vocQueryKeys } from '@entities/voc';
+import { useRole } from '@entities/user/model/useRole';
+
+export function useVocDetail(id: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: id ? vocQueryKeys.detail(role, id) : ['voc', role, 'detail', 'none'],
+    queryFn: () => vocApi.get(id!),
+    enabled: !!id,
+  });
+}
+
+export function useVocHistory(id: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: id ? vocQueryKeys.history(role, id) : ['voc', role, 'history', 'none'],
+    queryFn: () => vocApi.history(id!),
+    enabled: !!id,
+  });
+}
+
+export function useVocComments(id: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: id ? vocQueryKeys.comments(role, id) : ['voc', role, 'comments', 'none'],
+    queryFn: () => vocApi.comments(id!),
+    enabled: !!id,
+  });
+}
+
+export function useVocSubtasks(id: string | null) {
+  const { role } = useRole();
+  return useQuery({
+    queryKey: id ? vocQueryKeys.subtasks(role, id) : ['voc', role, 'subtasks', 'none'],
+    queryFn: () => vocApi.subtasks(id!),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/features/voc/review/ui/VocActionSection.tsx
+++ b/frontend/src/features/voc/review/ui/VocActionSection.tsx
@@ -1,11 +1,11 @@
-import type { InternalNote, VocHistoryEntry } from '@contracts/voc';
+import type { InternalNote, VocHistoryEntry, Comment } from '@contracts/voc';
 import { CollapsibleSection } from './CollapsibleSection';
 import type { Role } from '@contracts/common';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@shared/ui/tabs';
 import { VocHistory } from './VocHistory';
 import { VocComment } from './VocComment';
 import { VocInternalNotes } from './VocInternalNotes';
-import { VocSubTask } from './VocSubTask';
+import { VocSubTask, type SubTaskItem } from './VocSubTask';
 
 interface Props {
   vocId: string;
@@ -16,10 +16,14 @@ interface Props {
   canWrite: boolean;
   canSeeInternal: boolean;
   pending: boolean;
+  comments: Comment[] | undefined;
+  commentsLoading: boolean;
   notes: InternalNote[] | undefined;
   notesLoading: boolean;
   historyEntries: VocHistoryEntry[] | undefined;
   historyLoading: boolean;
+  subtasks: SubTaskItem[] | undefined;
+  subtasksLoading: boolean;
   onAddNote: (body: string) => void;
 }
 
@@ -32,10 +36,12 @@ export function VocActionSection({
   canWrite,
   canSeeInternal,
   pending,
+  comments,
   notes,
   notesLoading,
   historyEntries,
   historyLoading,
+  subtasks,
   onAddNote,
 }: Props) {
   return (
@@ -59,9 +65,8 @@ export function VocActionSection({
         </TabsList>
 
         <TabsContent value="comment">
-          {/* TODO(FU): wire api/comments + react-query mutations. C-14 ships UI only. */}
           <VocComment
-            comments={[]}
+            comments={comments ?? []}
             currentUserId={currentUserId}
             canWrite={canWrite}
             pending={pending}
@@ -76,11 +81,10 @@ export function VocActionSection({
         </TabsContent>
 
         <TabsContent value="subtask">
-          {/* TODO(FU): wire subtask CRUD + onOpen navigation. C-16 ships UI only. */}
           <VocSubTask
             parentId={vocId}
             parentIsSubtask={parentIsSubtask}
-            subs={[]}
+            subs={subtasks ?? []}
             canAdd={canWrite}
             onOpen={() => {}}
             onAdd={() => {}}

--- a/frontend/src/features/voc/review/ui/VocComment.tsx
+++ b/frontend/src/features/voc/review/ui/VocComment.tsx
@@ -1,15 +1,9 @@
 import { useState } from 'react';
 import { Button } from '@shared/ui/button';
 import { Textarea } from '@shared/ui/textarea';
+import type { Comment } from '@contracts/voc';
 
-export interface Comment {
-  id: string;
-  voc_id: string;
-  author_id: string;
-  body: string;
-  created_at: string;
-  updated_at: string;
-}
+export type { Comment };
 
 interface Props {
   comments: Comment[];

--- a/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
@@ -1,9 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
 import { useState, useContext } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@shared/ui/dialog';
 import { cn } from '@shared/lib/cn';
-import { vocApi, vocQueryKeys } from '@entities/voc';
 import { useRole } from '@entities/user/model/useRole';
+import {
+  useVocDetail,
+  useVocHistory,
+  useVocComments,
+  useVocSubtasks,
+} from '../model/useDrawerQueries';
 import { useVocPermissions } from '../model/useVocPermissions';
 import { AuthContext } from '@features/auth/model/AuthContext';
 import { type InternalNote } from '@contracts/voc';
@@ -44,24 +48,6 @@ interface Props {
   onAddNote: (id: string, body: string) => Promise<unknown>;
 }
 
-function useVocDetail(id: string | null) {
-  const { role } = useRole();
-  return useQuery({
-    queryKey: id ? vocQueryKeys.detail(role, id) : ['voc', role, 'detail', 'none'],
-    queryFn: () => vocApi.get(id!),
-    enabled: !!id,
-  });
-}
-
-function useVocHistory(id: string | null) {
-  const { role } = useRole();
-  return useQuery({
-    queryKey: id ? vocQueryKeys.history(role, id) : ['voc', role, 'history', 'none'],
-    queryFn: () => vocApi.history(id!),
-    enabled: !!id,
-  });
-}
-
 export function VocReviewDrawer({
   vocId,
   notes,
@@ -78,6 +64,8 @@ export function VocReviewDrawer({
 }: Props) {
   const detail = useVocDetail(vocId);
   const history = useVocHistory(vocId);
+  const comments = useVocComments(vocId);
+  const subtasks = useVocSubtasks(vocId);
   const { canWrite, canUpload, canSeeInternal } = useVocPermissions();
   const { role } = useRole();
   const auth = useContext(AuthContext);
@@ -178,10 +166,14 @@ export function VocReviewDrawer({
                 canWrite={canWrite}
                 canSeeInternal={canSeeInternal}
                 pending={pending}
+                comments={comments.data}
+                commentsLoading={comments.isLoading}
                 notes={notes}
                 notesLoading={notesLoading}
                 historyEntries={history.data}
                 historyLoading={history.isLoading}
+                subtasks={subtasks.data}
+                subtasksLoading={subtasks.isLoading}
                 onAddNote={(body) => void onAddNote(voc.id, body)}
               />
             </div>

--- a/frontend/src/test/mocks/handlers/voc.ts
+++ b/frontend/src/test/mocks/handlers/voc.ts
@@ -12,6 +12,7 @@ import {
   VOC_FIXTURES,
   VOC_NOTES_FIXTURES,
   VOC_HISTORY_FIXTURES,
+  VOC_COMMENT_FIXTURES,
   VOC_TAG_RELATIONS,
   FIXTURE_USERS,
 } from '../../../../../shared/fixtures/voc.fixtures';
@@ -262,6 +263,20 @@ export const vocHandlers = [
 
   http.get('/api/vocs/:id/history', ({ params }) => {
     const rows = VOC_HISTORY_FIXTURES.filter((h) => h.voc_id === params.id);
+    return HttpResponse.json({ rows });
+  }),
+
+  http.get('/api/vocs/:id/comments', ({ params }) => {
+    const rows = VOC_COMMENT_FIXTURES.filter((c) => c.voc_id === params.id);
+    return HttpResponse.json({ rows });
+  }),
+
+  http.get('/api/vocs/:id/subtasks', ({ params }) => {
+    const rows = VOC_FIXTURES.filter((v) => v.parent_id === params.id).map((v) => ({
+      id: v.id,
+      title: v.title,
+      status: v.status,
+    }));
     return HttpResponse.json({ rows });
   }),
 ];

--- a/shared/contracts/voc/note.ts
+++ b/shared/contracts/voc/note.ts
@@ -45,3 +45,16 @@ export const VocHistoryListResponse = z.object({
   rows: z.array(VocHistoryEntry),
 });
 export type VocHistoryListResponse = z.infer<typeof VocHistoryListResponse>;
+
+export const Comment = z.object({
+  id: Uuid,
+  voc_id: Uuid,
+  author_id: Uuid,
+  body: z.string().min(1).max(16_384),
+  created_at: Iso,
+  updated_at: Iso,
+});
+export type Comment = z.infer<typeof Comment>;
+
+export const CommentListResponse = z.object({ rows: z.array(Comment) });
+export type CommentListResponse = z.infer<typeof CommentListResponse>;

--- a/shared/fixtures/voc.fixtures.ts
+++ b/shared/fixtures/voc.fixtures.ts
@@ -17,6 +17,8 @@ import {
   type InternalNote as InternalNoteT,
   VocHistoryEntry,
   type VocHistoryEntry as VocHistoryEntryT,
+  Comment,
+  type Comment as CommentT,
 } from '../contracts/voc/note';
 import { FIXTURE_USERS } from '../contracts/voc/users';
 
@@ -102,7 +104,7 @@ const SPECS: ReadonlyArray<RowSpec> = (() => {
     priority: 'high',
     assigneeId: FIXTURE_USERS.devSelf,
     authorId: FIXTURE_USERS.user,
-    parentId: 'aaaaaaaa-0000-4000-8000-100000000001',
+    parentId: 'aaaaaaaa-0000-4000-8000-000000000001',
   });
   return out.slice(0, 50);
 })();
@@ -212,5 +214,32 @@ export const VOC_HISTORY_FIXTURES: ReadonlyArray<VocHistoryEntryT> = [
     new_value: '완료',
     changed_by: FIXTURE_USERS.manager,
     changed_at: baseDate(4),
+  }),
+];
+
+export const VOC_COMMENT_FIXTURES: ReadonlyArray<CommentT> = [
+  Comment.parse({
+    id: 'dddddddd-0000-4000-8000-000000000001',
+    voc_id: VOC_FIXTURES[0]!.id,
+    author_id: FIXTURE_USERS.manager,
+    body: '초기 분류 완료했습니다. 우선순위를 high로 올렸으니 확인 부탁드립니다.',
+    created_at: baseDate(1),
+    updated_at: baseDate(1),
+  }),
+  Comment.parse({
+    id: 'dddddddd-0000-4000-8000-000000000002',
+    voc_id: VOC_FIXTURES[0]!.id,
+    author_id: FIXTURE_USERS.devSelf,
+    body: '확인했습니다. 재현 환경 세팅 후 원인 분석 시작하겠습니다.',
+    created_at: baseDate(2),
+    updated_at: baseDate(2),
+  }),
+  Comment.parse({
+    id: 'dddddddd-0000-4000-8000-000000000003',
+    voc_id: VOC_FIXTURES[0]!.id,
+    author_id: FIXTURE_USERS.devSelf,
+    body: '원인 파악 완료 — DB 인덱스 누락으로 인한 타임아웃이었습니다. 핫픽스 배포 예정입니다.',
+    created_at: baseDate(3),
+    updated_at: baseDate(4),
   }),
 ];


### PR DESCRIPTION
## Summary

- `Comment` + `CommentListResponse` Zod 스키마 shared/contracts에 추가
- `VOC_COMMENT_FIXTURES` 3건 추가, subtask parentId 수정 (VOC[0] 실제 ID로)
- `vocApi.comments()` / `vocApi.subtasks()` 메서드 추가
- MSW `GET /api/vocs/:id/comments`, `/subtasks` 핸들러 추가
- `VocActionSection`에 comments/subtasks props 연결
- `VocReviewDrawer` 로컬 훅 4개를 `useDrawerQueries.ts`로 분리 (max-lines 해소)
- `VocComment`의 `Comment` 타입 → `@contracts/voc` 에서 import

## Test plan

- [ ] 드로어 열면 Comment 탭에 mock 댓글 3건 표시 확인
- [ ] History 탭에 변경 이력 5건 표시 확인
- [ ] Subtask 탭에 VOC[0] 자식 VOC 표시 확인
- [ ] 42 test files / 369 tests 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)