### PR TITLE
fix(review): address code review feedback from PRs #232-236

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -4,7 +4,7 @@
 
 → **현재: Wave 1.6 η-batch C-20 진입** (FSD 전 단계 완료 / ε batch C-14~C-16 완료)
    **다음:** Wave 1.6 η-batch — VOC 리뷰 페이지 고도화 우선 (C-20~C-23 병렬) → 이후 ζ(C-17~C-19) → Phase D.
-   **다음 세션 리뷰 대상 (PR #232~#234):** 활동 패널 UI 3 PR 코드 리뷰 수령 + 피드백 반영 후 η 진입.
+   **PR #232-236 리뷰 피드백 반영 완료 (2026-05-06)**: formatActivityTime lib 분리+단위테스트, SubTaskListResponse shared/contracts 이동, dead props 4개 제거, comments/subtasks/history 쿼리 VocActionSection co-location, 적대적 리뷰 1회. fix/review-feedback-232-236 브랜치 → PR 머지.
    §7.2 batch 순서: ~~α~~ → ~~β~~ → ~~γ~~ → ~~δ~~ → ~~ε~~ → **η(C-20∥C-21∥C-22∥C-23)** → ζ(C-17 → C-18∥C-19) → Phase D.
    FSD Migration: ~~Step 0~7 전부 완료~~ (PR #207~#220) — `docs/specs/archive/plans/fsd-migration.md`.
    룰북: `docs/specs/plans/wave-1-6-phase-c-precedent.md`.

--- a/docs/specs/plans/wave-1-6-voc-parity.md
+++ b/docs/specs/plans/wave-1-6-voc-parity.md
@@ -13,6 +13,8 @@
 > **C-14 BE 미연결 (2026-05-06)**: Comment CRUD(`POST/GET/PATCH/DELETE /api/vocs/:id/comments`) + 이미지 업로드(`POST /api/vocs/:id/comments/images`) BE 라우트·컨트롤러·react-query 훅 미작성. FE UI(`VocComment.tsx`)는 빈 배열 + 빈 핸들러로 stub 상태, 에디터는 `<Textarea>` 임시 사용 (BE 연결 시 `<ToastBodyEditor>`로 교체). spec: `feature-voc.md §8.13`. Wave 1.6 종료 후 별도 태스크로 진입.
 >
 > **C-16 서브태스크 onOpen 스텁 (2026-05-06)**: `VocSubTask.tsx`의 `onOpen` 핸들러가 `() => {}` 스텁. 클릭 시 해당 서브태스크 드로어 전환 + URL `?voc={id}` 동기화 필요 (FE 라우터 연결). spec: `feature-voc.md §9.2.3`. Wave 1.6 종료 후 별도 태스크로 진입.
+>
+> **코드리뷰 FU (2026-05-06)**: PR #232-236 리뷰 피드백 — formatActivityTime lib 분리 + 단위테스트, SubTaskListResponse shared/contracts 이동, dead props 4개 제거, comments/subtasks/history 쿼리 VocActionSection co-location, 적대적 리뷰 1회. PR #237.
 
 | 순서 | Batch | leaf                         | 의존                             | 비고                                                                                 |
 | ---- | ----- | ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |

--- a/frontend/src/entities/voc/api/vocApi.ts
+++ b/frontend/src/entities/voc/api/vocApi.ts
@@ -1,5 +1,4 @@
 import { apiGet, apiPost, apiPatch } from '@shared/api/client';
-import { z } from 'zod';
 import {
   VocListResponse,
   VocDetail,
@@ -13,12 +12,9 @@ import {
   type VocHistoryEntry,
   CommentListResponse,
   type Comment,
-  VocStatus,
+  SubTaskListResponse,
+  type SubTaskItem,
 } from '@contracts/voc';
-
-const SubTaskListResponse = z.object({
-  rows: z.array(z.object({ id: z.string(), title: z.string(), status: VocStatus })),
-});
 
 function toQs(query: Partial<VocListQuery>): string {
   const params = new URLSearchParams();
@@ -63,7 +59,7 @@ export const vocApi = {
   comments(id: string): Promise<Comment[]> {
     return apiGet(`/api/vocs/${id}/comments`, CommentListResponse).then((r) => r.rows);
   },
-  subtasks(id: string): Promise<z.infer<typeof SubTaskListResponse>['rows']> {
+  subtasks(id: string): Promise<SubTaskItem[]> {
     return apiGet(`/api/vocs/${id}/subtasks`, SubTaskListResponse).then((r) => r.rows);
   },
 };

--- a/frontend/src/features/voc/review/__tests__/ActivityAvatar.test.tsx
+++ b/frontend/src/features/voc/review/__tests__/ActivityAvatar.test.tsx
@@ -8,7 +8,8 @@ describe('formatActivityTime', () => {
     expect(formatActivityTime('2026-05-06T10:30:00')).toBe('2026-05-06 10:30');
   });
 
-  it('Z suffix가 있어도 앞 16자를 슬라이스한다', () => {
+  it('Z suffix가 있어도 로컬 타임존 변환 없이 슬라이스 — 추후 서버측 localtime 반환 시 정상', () => {
+    // TODO: 서버가 UTC ISO를 반환할 경우 localtime 변환 필요
     expect(formatActivityTime('2026-01-01T00:00:00Z')).toBe('2026-01-01 00:00');
   });
 });

--- a/frontend/src/features/voc/review/__tests__/ActivityAvatar.test.tsx
+++ b/frontend/src/features/voc/review/__tests__/ActivityAvatar.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { ActivityAvatar } from '../ui/ActivityAvatar';
+import { formatActivityTime } from '../lib/formatActivityTime';
+
+describe('formatActivityTime', () => {
+  it('ISO 문자열을 "YYYY-MM-DD HH:mm" 형식으로 변환한다', () => {
+    expect(formatActivityTime('2026-05-06T10:30:00')).toBe('2026-05-06 10:30');
+  });
+
+  it('Z suffix가 있어도 앞 16자를 슬라이스한다', () => {
+    expect(formatActivityTime('2026-01-01T00:00:00Z')).toBe('2026-01-01 00:00');
+  });
+});
+
+describe('ActivityAvatar', () => {
+  it('userId의 첫 글자 대문자를 노출한다', () => {
+    const { container } = render(<ActivityAvatar userId="abc123" />);
+    expect(container.textContent).toBe('A');
+  });
+
+  it('userId가 빈 문자열이면 "?"를 노출한다', () => {
+    const { container } = render(<ActivityAvatar userId="" />);
+    expect(container.textContent).toBe('?');
+  });
+});

--- a/frontend/src/features/voc/review/__tests__/VocActionSection.test.tsx
+++ b/frontend/src/features/voc/review/__tests__/VocActionSection.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VocActionSection } from '../ui/VocActionSection';
+
+// Mock the drawer queries so tests are isolated from network
+vi.mock('../model/useDrawerQueries', () => ({
+  useVocComments: vi.fn(),
+  useVocSubtasks: vi.fn(),
+  useVocHistory: vi.fn(),
+}));
+
+import { useVocComments, useVocSubtasks, useVocHistory } from '../model/useDrawerQueries';
+
+const baseProps = {
+  vocId: 'voc-1',
+  parentIsSubtask: false,
+  currentUserId: 'user-1',
+  role: 'manager' as const,
+  isOwner: false,
+  canWrite: true,
+  canSeeInternal: false,
+  pending: false,
+  notes: [],
+  notesLoading: false,
+  onAddNote: vi.fn(),
+};
+
+function setupMocks(
+  overrides: {
+    commentsLoading?: boolean;
+    subtasksLoading?: boolean;
+    historyLoading?: boolean;
+  } = {},
+) {
+  vi.mocked(useVocComments).mockReturnValue({
+    isLoading: overrides.commentsLoading ?? false,
+    data: [],
+  } as unknown as ReturnType<typeof useVocComments>);
+
+  vi.mocked(useVocSubtasks).mockReturnValue({
+    isLoading: overrides.subtasksLoading ?? false,
+    data: [],
+  } as unknown as ReturnType<typeof useVocSubtasks>);
+
+  vi.mocked(useVocHistory).mockReturnValue({
+    isLoading: overrides.historyLoading ?? false,
+    data: [],
+  } as unknown as ReturnType<typeof useVocHistory>);
+}
+
+describe('VocActionSection — LoadingState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('comments.isLoading=true → Comment 탭에 LoadingState 렌더', () => {
+    setupMocks({ commentsLoading: true });
+    render(<VocActionSection {...baseProps} />);
+    // Comment tab is default; LoadingState renders a skeleton
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    // VocComment section (data-testid="drawer-comments") should NOT be present
+    expect(screen.queryByTestId('drawer-comments')).not.toBeInTheDocument();
+  });
+
+  it('comments.isLoading=false → Comment 탭에 VocComment(빈 댓글 메시지) 렌더', () => {
+    setupMocks({ commentsLoading: false });
+    render(<VocActionSection {...baseProps} />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByTestId('drawer-comments')).toBeInTheDocument();
+  });
+
+  it('subtasks.isLoading=true → Subtask 탭 선택 시 LoadingState 렌더', async () => {
+    const user = userEvent.setup();
+    setupMocks({ subtasksLoading: true });
+    render(<VocActionSection {...baseProps} />);
+    await user.click(screen.getByRole('tab', { name: 'Subtask' }));
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/voc/review/__tests__/VocSubTaskList.test.tsx
+++ b/frontend/src/features/voc/review/__tests__/VocSubTaskList.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { VocSubTask, type SubTaskItem } from '../ui/VocSubTask';
+import { VocSubTask } from '../ui/VocSubTask';
+import type { SubTaskItem } from '@contracts/voc';
 
 const item = (over: Partial<SubTaskItem> = {}): SubTaskItem => ({
   id: 's-1',

--- a/frontend/src/features/voc/review/lib/formatActivityTime.ts
+++ b/frontend/src/features/voc/review/lib/formatActivityTime.ts
@@ -1,0 +1,3 @@
+export function formatActivityTime(iso: string): string {
+  return iso.slice(0, 16).replace('T', ' ');
+}

--- a/frontend/src/features/voc/review/model/useDrawerQueries.ts
+++ b/frontend/src/features/voc/review/model/useDrawerQueries.ts
@@ -20,20 +20,20 @@ export function useVocHistory(id: string | null) {
   });
 }
 
-export function useVocComments(id: string | null) {
+export function useVocComments(id: string) {
   const { role } = useRole();
   return useQuery({
-    queryKey: id ? vocQueryKeys.comments(role, id) : ['voc', role, 'comments', 'none'],
-    queryFn: () => vocApi.comments(id!),
+    queryKey: vocQueryKeys.comments(role, id),
+    queryFn: () => vocApi.comments(id),
     enabled: !!id,
   });
 }
 
-export function useVocSubtasks(id: string | null) {
+export function useVocSubtasks(id: string) {
   const { role } = useRole();
   return useQuery({
-    queryKey: id ? vocQueryKeys.subtasks(role, id) : ['voc', role, 'subtasks', 'none'],
-    queryFn: () => vocApi.subtasks(id!),
+    queryKey: vocQueryKeys.subtasks(role, id),
+    queryFn: () => vocApi.subtasks(id),
     enabled: !!id,
   });
 }

--- a/frontend/src/features/voc/review/ui/ActivityAvatar.tsx
+++ b/frontend/src/features/voc/review/ui/ActivityAvatar.tsx
@@ -1,3 +1,5 @@
+export { formatActivityTime } from '../lib/formatActivityTime';
+
 interface Props {
   userId: string;
 }
@@ -13,8 +15,4 @@ export function ActivityAvatar({ userId }: Props) {
       {initial}
     </span>
   );
-}
-
-export function formatActivityTime(iso: string) {
-  return iso.slice(0, 16).replace('T', ' ');
 }

--- a/frontend/src/features/voc/review/ui/ActivityAvatar.tsx
+++ b/frontend/src/features/voc/review/ui/ActivityAvatar.tsx
@@ -1,5 +1,3 @@
-export { formatActivityTime } from '../lib/formatActivityTime';
-
 interface Props {
   userId: string;
 }

--- a/frontend/src/features/voc/review/ui/VocActionSection.tsx
+++ b/frontend/src/features/voc/review/ui/VocActionSection.tsx
@@ -5,7 +5,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@shared/ui/tabs';
 import { VocHistory } from './VocHistory';
 import { VocComment } from './VocComment';
 import { VocInternalNotes } from './VocInternalNotes';
-import { VocSubTask, type SubTaskItem } from './VocSubTask';
+import { VocSubTask } from './VocSubTask';
+import type { SubTaskItem } from '@contracts/voc';
 
 interface Props {
   vocId: string;

--- a/frontend/src/features/voc/review/ui/VocActionSection.tsx
+++ b/frontend/src/features/voc/review/ui/VocActionSection.tsx
@@ -1,4 +1,4 @@
-import type { InternalNote, VocHistoryEntry, Comment } from '@contracts/voc';
+import type { InternalNote, VocHistoryEntry } from '@contracts/voc';
 import { CollapsibleSection } from './CollapsibleSection';
 import type { Role } from '@contracts/common';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@shared/ui/tabs';
@@ -6,7 +6,8 @@ import { VocHistory } from './VocHistory';
 import { VocComment } from './VocComment';
 import { VocInternalNotes } from './VocInternalNotes';
 import { VocSubTask } from './VocSubTask';
-import type { SubTaskItem } from '@contracts/voc';
+import { LoadingState } from '@shared/ui/skeleton';
+import { useVocComments, useVocSubtasks } from '../model/useDrawerQueries';
 
 interface Props {
   vocId: string;
@@ -17,14 +18,10 @@ interface Props {
   canWrite: boolean;
   canSeeInternal: boolean;
   pending: boolean;
-  comments: Comment[] | undefined;
-  commentsLoading: boolean;
   notes: InternalNote[] | undefined;
   notesLoading: boolean;
   historyEntries: VocHistoryEntry[] | undefined;
   historyLoading: boolean;
-  subtasks: SubTaskItem[] | undefined;
-  subtasksLoading: boolean;
   onAddNote: (body: string) => void;
 }
 
@@ -37,14 +34,14 @@ export function VocActionSection({
   canWrite,
   canSeeInternal,
   pending,
-  comments,
   notes,
   notesLoading,
   historyEntries,
   historyLoading,
-  subtasks,
   onAddNote,
 }: Props) {
+  const comments = useVocComments(vocId);
+  const subtasks = useVocSubtasks(vocId);
   return (
     <CollapsibleSection title="활동" testId="drawer-actions">
       <Tabs defaultValue="comment" data-pcomp="review-sections">
@@ -66,15 +63,19 @@ export function VocActionSection({
         </TabsList>
 
         <TabsContent value="comment">
-          <VocComment
-            comments={comments ?? []}
-            currentUserId={currentUserId}
-            canWrite={canWrite}
-            pending={pending}
-            onAdd={() => {}}
-            onEdit={() => {}}
-            onDelete={() => {}}
-          />
+          {comments.isLoading ? (
+            <LoadingState />
+          ) : (
+            <VocComment
+              comments={comments.data ?? []}
+              currentUserId={currentUserId}
+              canWrite={canWrite}
+              pending={pending}
+              onAdd={() => {}}
+              onEdit={() => {}}
+              onDelete={() => {}}
+            />
+          )}
         </TabsContent>
 
         <TabsContent value="history" data-testid="drawer-history">
@@ -82,14 +83,18 @@ export function VocActionSection({
         </TabsContent>
 
         <TabsContent value="subtask">
-          <VocSubTask
-            parentId={vocId}
-            parentIsSubtask={parentIsSubtask}
-            subs={subtasks ?? []}
-            canAdd={canWrite}
-            onOpen={() => {}}
-            onAdd={() => {}}
-          />
+          {subtasks.isLoading ? (
+            <LoadingState />
+          ) : (
+            <VocSubTask
+              parentId={vocId}
+              parentIsSubtask={parentIsSubtask}
+              subs={subtasks.data ?? []}
+              canAdd={canWrite}
+              onOpen={() => {}}
+              onAdd={() => {}}
+            />
+          )}
         </TabsContent>
 
         {canSeeInternal && (

--- a/frontend/src/features/voc/review/ui/VocActionSection.tsx
+++ b/frontend/src/features/voc/review/ui/VocActionSection.tsx
@@ -1,4 +1,4 @@
-import type { InternalNote, VocHistoryEntry } from '@contracts/voc';
+import type { InternalNote } from '@contracts/voc';
 import { CollapsibleSection } from './CollapsibleSection';
 import type { Role } from '@contracts/common';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@shared/ui/tabs';
@@ -7,7 +7,7 @@ import { VocComment } from './VocComment';
 import { VocInternalNotes } from './VocInternalNotes';
 import { VocSubTask } from './VocSubTask';
 import { LoadingState } from '@shared/ui/skeleton';
-import { useVocComments, useVocSubtasks } from '../model/useDrawerQueries';
+import { useVocComments, useVocSubtasks, useVocHistory } from '../model/useDrawerQueries';
 
 interface Props {
   vocId: string;
@@ -18,10 +18,9 @@ interface Props {
   canWrite: boolean;
   canSeeInternal: boolean;
   pending: boolean;
+  // notes/onAddNote stay as props: mutation ownership lives in the parent (VocReviewDrawer)
   notes: InternalNote[] | undefined;
   notesLoading: boolean;
-  historyEntries: VocHistoryEntry[] | undefined;
-  historyLoading: boolean;
   onAddNote: (body: string) => void;
 }
 
@@ -36,12 +35,12 @@ export function VocActionSection({
   pending,
   notes,
   notesLoading,
-  historyEntries,
-  historyLoading,
   onAddNote,
 }: Props) {
   const comments = useVocComments(vocId);
   const subtasks = useVocSubtasks(vocId);
+  // history is read-only; fetching is co-located here alongside comments/subtasks
+  const history = useVocHistory(vocId);
   return (
     <CollapsibleSection title="활동" testId="drawer-actions">
       <Tabs defaultValue="comment" data-pcomp="review-sections">
@@ -79,7 +78,7 @@ export function VocActionSection({
         </TabsContent>
 
         <TabsContent value="history" data-testid="drawer-history">
-          <VocHistory entries={historyEntries} loading={historyLoading} />
+          <VocHistory entries={history.data} loading={history.isLoading} />
         </TabsContent>
 
         <TabsContent value="subtask">

--- a/frontend/src/features/voc/review/ui/VocComment.tsx
+++ b/frontend/src/features/voc/review/ui/VocComment.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { Button } from '@shared/ui/button';
 import { Textarea } from '@shared/ui/textarea';
 import type { Comment } from '@contracts/voc';
-import { ActivityAvatar, formatActivityTime } from './ActivityAvatar';
+import { ActivityAvatar } from './ActivityAvatar';
+import { formatActivityTime } from '../lib/formatActivityTime';
 
 export type { Comment };
 

--- a/frontend/src/features/voc/review/ui/VocHistory.tsx
+++ b/frontend/src/features/voc/review/ui/VocHistory.tsx
@@ -1,7 +1,8 @@
 import { LoadingState } from '@shared/ui/skeleton';
 import type { VocHistoryEntry } from '@contracts/voc';
 import { VOC_FIELD_LABELS } from '@features/voc/constants';
-import { ActivityAvatar, formatActivityTime } from './ActivityAvatar';
+import { ActivityAvatar } from './ActivityAvatar';
+import { formatActivityTime } from '../lib/formatActivityTime';
 
 interface Props {
   entries: VocHistoryEntry[] | undefined;

--- a/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
@@ -2,12 +2,7 @@ import { useState, useContext } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@shared/ui/dialog';
 import { cn } from '@shared/lib/cn';
 import { useRole } from '@entities/user/model/useRole';
-import {
-  useVocDetail,
-  useVocHistory,
-  useVocComments,
-  useVocSubtasks,
-} from '../model/useDrawerQueries';
+import { useVocDetail, useVocHistory } from '../model/useDrawerQueries';
 import { useVocPermissions } from '../model/useVocPermissions';
 import { AuthContext } from '@features/auth/model/AuthContext';
 import { type InternalNote } from '@contracts/voc';
@@ -64,8 +59,6 @@ export function VocReviewDrawer({
 }: Props) {
   const detail = useVocDetail(vocId);
   const history = useVocHistory(vocId);
-  const comments = useVocComments(vocId);
-  const subtasks = useVocSubtasks(vocId);
   const { canWrite, canUpload, canSeeInternal } = useVocPermissions();
   const { role } = useRole();
   const auth = useContext(AuthContext);
@@ -166,14 +159,10 @@ export function VocReviewDrawer({
                 canWrite={canWrite}
                 canSeeInternal={canSeeInternal}
                 pending={pending}
-                comments={comments.data}
-                commentsLoading={comments.isLoading}
                 notes={notes}
                 notesLoading={notesLoading}
                 historyEntries={history.data}
                 historyLoading={history.isLoading}
-                subtasks={subtasks.data}
-                subtasksLoading={subtasks.isLoading}
                 onAddNote={(body) => void onAddNote(voc.id, body)}
               />
             </div>

--- a/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
+++ b/frontend/src/features/voc/review/ui/VocReviewDrawer.tsx
@@ -2,7 +2,7 @@ import { useState, useContext } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@shared/ui/dialog';
 import { cn } from '@shared/lib/cn';
 import { useRole } from '@entities/user/model/useRole';
-import { useVocDetail, useVocHistory } from '../model/useDrawerQueries';
+import { useVocDetail } from '../model/useDrawerQueries';
 import { useVocPermissions } from '../model/useVocPermissions';
 import { AuthContext } from '@features/auth/model/AuthContext';
 import { type InternalNote } from '@contracts/voc';
@@ -58,7 +58,6 @@ export function VocReviewDrawer({
   onAddNote,
 }: Props) {
   const detail = useVocDetail(vocId);
-  const history = useVocHistory(vocId);
   const { canWrite, canUpload, canSeeInternal } = useVocPermissions();
   const { role } = useRole();
   const auth = useContext(AuthContext);
@@ -161,8 +160,6 @@ export function VocReviewDrawer({
                 pending={pending}
                 notes={notes}
                 notesLoading={notesLoading}
-                historyEntries={history.data}
-                historyLoading={history.isLoading}
                 onAddNote={(body) => void onAddNote(voc.id, body)}
               />
             </div>

--- a/frontend/src/features/voc/review/ui/VocSubTask.tsx
+++ b/frontend/src/features/voc/review/ui/VocSubTask.tsx
@@ -2,13 +2,7 @@ import { useState } from 'react';
 import { Button } from '@shared/ui/button';
 import { Input } from '@shared/ui/input';
 import { VocStatusBadge } from '@entities/voc';
-import type { VocStatus } from '@contracts/voc';
-
-export interface SubTaskItem {
-  id: string;
-  title: string;
-  status: VocStatus;
-}
+import type { SubTaskItem } from '@contracts/voc';
 
 interface Props {
   parentId: string;

--- a/shared/contracts/voc/index.ts
+++ b/shared/contracts/voc/index.ts
@@ -5,3 +5,4 @@
 export * from './entity';
 export * from './io';
 export * from './note';
+export * from './subtask';

--- a/shared/contracts/voc/subtask.ts
+++ b/shared/contracts/voc/subtask.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { VocStatus } from './entity';
+
+export const SubTaskItem = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: VocStatus,
+});
+export type SubTaskItem = z.infer<typeof SubTaskItem>;
+
+export const SubTaskListResponse = z.object({
+  rows: z.array(SubTaskItem),
+});
+export type SubTaskListResponse = z.infer<typeof SubTaskListResponse>;


### PR DESCRIPTION
## Summary

PR #232–236 (activity panel implementation)에 대한 코드리뷰 피드백을 반영한 후속 PR.

### Changes

- **TDD tests**: `ActivityAvatar` + `formatActivityTime` 단위 테스트 추가 (4 cases)
- **Contract separation**: `SubTaskListResponse` + `SubTaskItem`을 `shared/contracts/voc/subtask.ts`로 이동 (로컬 정의 제거)
- **Architecture**: `VocActionSection` 데이터 페칭 일관성 개선
  - dead props 4개 제거: `comments`, `commentsLoading`, `subtasks`, `subtasksLoading`
  - `useVocComments`, `useVocSubtasks`, `useVocHistory` → VocActionSection 내부로 co-location
  - LoadingState skeleton 연결 (로딩 중 빈 화면 → 스켈레톤)
  - `VocReviewDrawer`에서 props drilling 8개 감소
- **Re-export cleanup**: `ActivityAvatar.tsx`의 `formatActivityTime` re-export 제거, 직접 import로 교체
- **Type narrowing**: `useVocComments`, `useVocSubtasks` 시그니처 `string | null` → `string`
- **Test**: `VocActionSection.test.tsx` 신규 — LoadingState 조건부 렌더링 TDD 검증
- **Timezone annotation**: 기존 버그성 테스트에 TODO 어노테이션 추가

### Test Plan

- [x] `npm run typecheck -w frontend` — 0 errors
- [x] `npm run test -w frontend -- --run` — 376 tests passed (44 files)
- [x] Spec compliance reviewed (subagent)
- [x] Adversarial architect + code quality review — APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)