### PR TITLE
chore(mcp): add context-mode as project-scoped MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "context-mode": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "context-mode"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`context-mode` MCP 서버를 project-scope 로 등록 (`.mcp.json`).

- MCP-only 설치 (hooks / slash commands 없음)
- 11개 `ctx_*` 도구 제공 (sandbox execute, FTS5 index/search, stats/doctor 등)
- 이 레포 안에서만 동작

## Test plan

- [ ] Claude Code 재시작 후 `/mcp` 에서 `context-mode: ✓ Connected` 확인