### PR TITLE
docs(wave-3): plan + ADR 0004/0005 + 5 open questions

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -12,6 +12,13 @@
    3. Phase 2 spec 보강 ADR 1건 (BE `total` 의미 / zod self-recursive 회피 / status grouping × expand 배타) → 구현
    4. Phase 2 머지 후 `feat/dashboard-shell` 진입 (Wave 2)
 
+→ **Wave 3 plan draft (병렬 트랙, branch `docs/wave-3-plan`, 2026-05-09)**
+   - `docs/specs/plans/wave-3-admin.md` — Admin 4 화면 (Tag Master / Trash / External Masters / Users) plan
+   - `docs/adr/0004-admin-permission-model.md` (Proposed) + `docs/adr/0005-trash-restore-policy.md` (Proposed)
+   - OQ 5 건 (`docs/specs/plans/open-questions.md`) — 사용자 결정 후 spec 동기화 PR 선행
+   - Hard-block: Wave 2 머지 + 마이그 012 머지 + OQ 5건 답변 모두 충족 후 Phase A 진입
+   - PR 은 사용자가 open. 본 worktree 는 commit only.
+
 → **PR 본문 = `docs/voc-completion-single-pr` 12 commit + driver D-1~D-5 재PASS + 머지 요청 1줄**
    - Phase B (BE master + create 강제룰) — `ad1ef50`
    - Phase C minimal + major — `c56af67` + `b85240a`

--- a/docs/adr/0004-admin-permission-model.md
+++ b/docs/adr/0004-admin-permission-model.md
@@ -1,0 +1,70 @@
+# 0004 — Admin 페이지 4 화면 권한 모델
+
+## Status
+
+Proposed (Wave 3 진입 전 사용자 결정 필요 — `docs/specs/plans/wave-3-admin.md §7 OQ-1 / OQ-2`)
+
+## Context
+
+Wave 3 은 관리자 페이지 4 화면(Tag Master / Trash / External Masters / Users) 의 vertical slice 를 다룬다. 현 spec 은 화면별 권한이 단편적으로 분산되어 있고, 일부 spec 사이에 불일치가 있다.
+
+- **§2.3 (요구사항 4 종 룰)**: "시스템/메뉴/유형/태그규칙/사용자 role 관리: Admin 전용." Soft Delete 도 Admin 전용.
+- **§15.3 (Tag Master)**: "Admin (병합/외부 잠금/규칙 일시중지). Manager 읽기 전용."
+- **`feature-voc.md §9.4.6` (Tag Master 본문)**: "Admin/Manager (시스템/메뉴/유형 관리와 동일 정책)." — §15.3 과 충돌.
+- **§15.4 (Trash)**: "Admin (복원/즉시 영구삭제). Manager 읽기 전용." (`feature-voc.md §9.4.7` 일치)
+- **§16.3 (External Masters Refresh)**: "Refresh 권한 = Manager 이상." 화면 진입 권한은 미명시.
+- **§15.2 (Users)**: "Admin 이 사용자 관리 화면에서 role 변경 / `is_active` 토글." (§2.3 일관)
+
+`uidesign.md §14.3 (Role Pill)` + `§10.5.1` 가 사이드바 admin 그룹의 role guard precedent 를 정의. role 4 종은 `admin / manager / dev / user` (D18, 2026-04-26).
+
+본 ADR 은 4 화면별 mutate / read 권한을 잠그고, Wave 3 의 모든 BE 라우트 가드 / FE sidebar 가드의 정본을 제공한다.
+
+## Decision
+
+**제안 (사용자 최종 결정 시점에 잠근다):**
+
+| 화면 | Mutate 권한 | Read 권한 | Sidebar 항목 노출 |
+| --- | --- | --- | --- |
+| **Tag Master** | **Admin only** (OQ-1 Option A) — 추가/편집/삭제/병합 | Admin / Manager | Admin / Manager |
+| **Trash** | Admin only — 복원 (영구삭제는 disabled) | Admin only (Manager 미노출) | Admin only |
+| **External Masters** | Manager 이상 — refresh 트리거 | Manager 이상 (OQ-2 Option A) | Manager 이상 |
+| **Users** | Admin only — role 변경 / is_active 토글 | Admin only | Admin only |
+
+추가 룰:
+1. **이중 방어 의무** — FE sidebar 그룹은 `role ∈ {admin, manager}` 에서만 렌더 (component tree level 가드, not `display: none`). BE 는 모든 admin 라우트에 `requireRole(['admin'])` 또는 `requireRole(['admin','manager'])` 미들웨어 적용. 단일 방어 금지.
+2. **404 vs 403** — Trash 는 Manager 도 진입 자체 차단(404, "존재 자체 은닉" — `requirements.md §6.1` `voc_internal_notes` precedent). Tag Master / Users / External Masters 는 403 (사용자 인지 가능).
+3. **Last-admin guard** — Users Phase E 에서 마지막 admin → user 강등 시 BE `CONFLICT 409` 응답 (`requirements.md §6.1`). FE 는 토스트 + 행동 차단.
+4. **Audit 의무** — 모든 mutate 는 audit row 기록. Tag Master = `voc_history` 또는 신규 `tag_history` (OQ 별도), Trash 복원 = `voc_history` + `voc_restore_log` (마이그 015), Users = `user_role_log` (OQ-3 별도 결정).
+
+## Considered Options
+
+**Option A (채택 제안)**: 화면별 권한 차등 — Tag Master / Trash / Users = Admin only mutate, External Masters = Manager+ mutate.
+
+- 장점: §2.3 룰 ("Admin 전용 mutate") 정합 + irreversible 액션 (merge, 영구삭제 placeholder, role 변경) 권한 좁힘으로 reversibility gate 정합 + Manager 는 일상 트리아지 (voc_tags 부착/해제, 외부 마스터 refresh) 권한 그대로 유지.
+- 단점: §9.4.6 본문 + §15.3 사이의 spec 불일치를 §15.3 쪽으로 동기화하는 추가 PR 필요. Manager 가 일상 태그 정리 시 Admin 호출 의존.
+
+**Option B**: §9.4.6 채택 — Tag Master 도 Admin/Manager 양쪽 mutate.
+
+- 장점: Manager 가 트리아지 일상 운영자라 자연스러움. §9.4.6 본문 그대로 사용.
+- 단점: Tag merge 가 데이터 손실급 (source 행 제거 = irreversible) 인데 Manager 까지 권한 부여하는 건 reversibility gate 위반. 실수 발생 시 복구 불가.
+
+**Option C**: 모든 화면 Admin only.
+
+- 장점: 단일 정책으로 단순.
+- 단점: External Masters refresh 가 §16.3 명시적 "Manager 이상" 룰을 위반. Manager 의 트리아지 운영 차단.
+
+## Consequences
+
+- **Manager 의 일상 운영**: voc 도메인 (assignee, status 전환, 태그 부착/해제, 외부 마스터 refresh) 은 그대로. 마스터 데이터 mutate (Tag CRUD, role 변경, soft delete 복원) 만 Admin 의존.
+- **`feature-voc.md §9.4.6` 동기화 필요**: "Admin/Manager" → "Admin (mutate) / Manager (read)" 로 갱신하는 spec PR 가 본 ADR Accepted 직후 선행.
+- **BE 가드 단일 helper**: `requireRole(['admin'])` / `requireRole(['admin','manager'])` 미들웨어 2 종 도입. `assertCanManageVoc` (D21, voc 도메인 전용) 와는 별 함수.
+- **사이드바 그룹 가드**: `uidesign.md §10.5.1` precedent 에 admin 4 화면 sidebar 매트릭스 추가 (User/Dev = 그룹 미노출, Manager = External Masters + Tag Master read 만, Admin = 4 종 전부).
+- **회귀 테스트 의무**: 4 화면 × 4 role = 16 권한 매트릭스 + last-admin guard + Trash 404 vs 403 분리 = BE Jest+Supertest 회귀 18 건 이상.
+- **Follow-up**: OIDC 실연동 시 role mapping 정책 + Result Review (§15.1) 화면 진입 시 동일 매트릭스 확장 — 본 ADR 이 baseline.
+
+## Follow-ups
+
+- [ ] OQ-1 사용자 결정 → ADR Status Accepted 전환 + `requirements.md §15.3` ↔ `feature-voc.md §9.4.6` 동기화 PR
+- [ ] OQ-2 사용자 결정 → External Masters 화면 read 권한 spec 명시 (`external-masters.md` 갱신)
+- [ ] `uidesign.md §10.5` 에 admin 4 화면 sidebar role 매트릭스 추가
+- [ ] BE 가드 helper 단일화 (`requireRole`) — Wave 3 Phase A 에 동봉

--- a/docs/adr/0005-trash-restore-policy.md
+++ b/docs/adr/0005-trash-restore-policy.md
@@ -1,0 +1,104 @@
+# 0005 — Trash 복원 정책 (보존 / 복원자 / cascade / audit)
+
+## Status
+
+Proposed (Wave 3 진입 전 사용자 결정 필요 — `docs/specs/plans/wave-3-admin.md §7 OQ-3 / OQ-4`)
+
+## Context
+
+Wave 3 Phase C 의 Trash 화면은 §8.9 Soft Delete 로 `deleted_at IS NOT NULL` 인 VOC 를 UI 로 조회·복원·영구삭제 진입점을 제공한다. 정본은 `feature-voc.md §9.4.7` + `requirements.md §15.4`.
+
+기존 spec 의 단편:
+- **§D7 (요구사항 §17)**: "데이터 보존 = 무기한" — VOC soft delete 및 voc_history 모두.
+- **§9.4.7 영구삭제**: "MVP 는 영구삭제 비활성화 (disabled + tooltip "MVP는 영구삭제 미지원"). NextGen 활성화 자리만 확보."
+- **§9.4.7 복원**: "`PATCH /api/vocs/:id/restore` → `vocs.deleted_at=NULL` + `voc_history` `restore` 이벤트 + `tag_rules` 멱등 재실행."
+- **§D13 (`vocs.parent_id` ON DELETE SET NULL)**: 부모 hard delete 시 sub-task 보존 (D7 무기한 보존과 일관).
+- **§15.4 운영 갭 해소**: `vocs.deleted_by` / `voc_restore_log` 컬럼/테이블 추가 (마이그 015 — `next-session-tasks.md` 표기와 spec 표기 충돌 OQ-4).
+- **§9.4.7 회귀 테스트 3 건**: (1) Manager `/trash` 호출 시 403, (2) 복원 후 일반 목록 노출, (3) 복원 시 `tag_rules` 재실행으로 `voc_tags.source='rule'` 재부착.
+
+미결 항목: 보존 기간(`§15.4` "30일 보존 후 자동 영구 삭제" ↔ §D7 "무기한"), cascade 룰(부모 hard delete 시 복원), audit 컬럼 정합, Manager 의 진입 권한 (404 vs 403).
+
+본 ADR 은 위 단편을 통합하여 Trash 화면 복원 정책을 정본으로 잠근다.
+
+## Decision
+
+**제안 (사용자 최종 결정 시점에 잠근다):**
+
+### 1. 보존 기간
+
+**무기한** (D7 정합). `§15.4` 의 "30일 보존 후 자동 영구 삭제" 표현은 NextGen 활성화 시 운영 옵션으로 재논의. MVP 는 자동 영구삭제 cron 없음. → **`§15.4` 표현 동기화 PR 선행 필요** (OQ-4 동봉).
+
+### 2. 복원 권한
+
+**Admin only.** Manager 는 `/admin/trash` 라우트 진입 자체 차단 (404, ADR 0004 §"404 vs 403" 정합 — 존재 은닉). 사이드바 admin 그룹에서도 Manager 는 "휴지통" 항목 미노출.
+
+### 3. 영구삭제
+
+**MVP 비활성화** (§9.4.7 그대로). 버튼은 disabled + tooltip. 자리만 확보. NextGen 활성화 시:
+- 권한: Admin only (영구삭제는 reversibility gate 상 가장 위험한 액션)
+- 절차: 2-step 확인 (확인 다이얼로그 + "이 VOC 의 issue_code 입력" 매치)
+- audit: `voc_restore_log` 에 `action='hard_delete'` 행 추가 (PIPA 7 년 보존)
+
+### 4. Cascade 룰
+
+| 케이스 | 정책 |
+| --- | --- |
+| Soft-deleted VOC 의 sub-task 도 함께 soft-deleted | 부모 복원 시 sub-task **자동 복원 안 함**. Sub-task 는 개별 행으로 휴지통 노출 + 개별 복원. (이유: sub-task 일부만 복원하고 싶은 운영 케이스 존재 + cascade 자동 복원은 트랜잭션 비용) |
+| 부모 hard delete (D13 ON DELETE SET NULL) 후 sub-task 복원 | sub-task 의 `parent_id=NULL` 그대로 root VOC 로 복원 (§9.4.7 명시) |
+| 병합으로 사라진 태그가 부착되어 있던 VOC 복원 | 복원 시 `tag_rules` 멱등 재실행 → 새 태그 자동 부착. 이전 태그 부착 row 는 재현 불가 (병합 = irreversible). 운영 가이드에 명시. |
+| Soft-deleted VOC 의 첨부파일 | §8.9 정책 그대로 (`?includeDeleted=true` 로 Admin 다운로드 가능). 복원 시 첨부 row 그대로 보존. |
+
+### 5. Audit
+
+`voc_restore_log` 테이블 (마이그 015) 컬럼:
+
+| 컬럼 | 타입 | 비고 |
+| --- | --- | --- |
+| `id` | uuid | PK |
+| `voc_id` | uuid FK → vocs.id | RESTRICT (vocs hard delete 시 audit 보호) |
+| `action` | text CHECK (`restore` / `hard_delete`) | NextGen 영구삭제 시 hard_delete 사용 |
+| `actor_id` | uuid FK → users.id | 복원자 / 영구삭제자 |
+| `before_deleted_at` | timestamptz | 복원 전 deleted_at 값 |
+| `before_deleted_by` | uuid FK → users.id | 원 삭제자 (vocs.deleted_by 와 join) |
+| `created_at` | timestamptz default now() | |
+
+`vocs.deleted_by` 컬럼 추가 (마이그 015) — `vocs.deleted_at` 세팅 시 함께 기록. 기존 §15.1.1 PIPA 7 년 보존 룰 정합.
+
+### 6. 회귀 테스트 (`feature-voc.md §9.4.7` 3 건 + 본 ADR 추가 4 건 = 7 건)
+
+- 기존 3 건 유지.
+- 추가 (4): (a) Manager 가 `/admin/trash` 진입 시 404 (sidebar 미노출 + route 차단), (b) Sub-task 만 soft-deleted 인 케이스 휴지통 노출, (c) 부모 hard delete 후 sub-task 복원 시 `parent_id=NULL` 그대로, (d) 복원 시 `voc_restore_log` row 1 건 추가 + `vocs.deleted_at=NULL` + `vocs.deleted_by=NULL`.
+
+## Considered Options
+
+**Option A (채택 제안)**: 무기한 보존 + Admin only 복원 + 영구삭제 disabled + sub-task 개별 복원 + `voc_restore_log` 별 테이블.
+
+- 장점: D7 / §9.4.7 / §15.4 정합 + reversibility gate 정합 (irreversible 액션은 권한 좁힘 + 자동화 제거).
+- 단점: §15.4 의 "30일 보존" 표현 동기화 PR 필요.
+
+**Option B**: 30 일 보존 + 자동 cron 영구삭제.
+
+- 장점: §15.4 표현 그대로.
+- 단점: D7 무기한 정책 위반. cron job spec 미작성 (§15.1.1 retention 만료 마스킹 cron 만 명시). MVP 범위 초과.
+
+**Option C**: cascade 자동 복원 (부모 복원 시 sub-task 도 함께).
+
+- 장점: 운영자 클릭 1 회로 끝.
+- 단점: 일부만 복원하고 싶은 운영 케이스 차단. cascade 트랜잭션 비용 + tag_rules 재실행 N 회. 사용자 의도 추정 위험.
+
+## Consequences
+
+- **마이그 015 spec 잠금**: `vocs.deleted_by uuid FK → users.id NULL` + `voc_restore_log` 테이블 신설. rollback SQL 동봉.
+- **§15.4 동기화 PR**: "30일 보존 후 자동 영구 삭제" → "MVP 무기한 보존, NextGen 자동 cron 재논의" 표현 변경. Wave 3 Phase A 와 함께.
+- **Sidebar admin 그룹 매트릭스**: Manager 는 "휴지통" 미노출 (ADR 0004 와 일관). 4 화면 중 Trash 만 Manager 미노출.
+- **Audit 단일 정본**: `voc_restore_log` 가 복원/영구삭제 단일 audit. `voc_history` 의 `restore` 이벤트 row 는 그대로 유지 (사람 친화 view), `voc_restore_log` 는 머신 친화 (`actor_id` 인덱스 / `action` 인덱스).
+- **회귀 테스트 7 건**: Wave 3 Phase C BE Jest 통합 테스트 의무.
+- **NextGen 영구삭제 활성화 경로**: 본 ADR §3 의 절차를 그대로 활성화 → ADR 갱신 + spec sync. 컬럼 / 테이블은 본 Wave 에서 자리 확보 완료.
+
+## Follow-ups
+
+- [ ] OQ-3 사용자 결정 (`user_role_log` vs `voc_history` 확장) — Users 화면 audit 와 본 ADR `voc_restore_log` 의 정합 검토
+- [ ] OQ-4 사용자 결정 → 마이그 번호 (`015` vs `next-session-tasks.md` 8-PR3) 정합 + `next-session-tasks.md §권한·스키마 인프라 PR 후보` 동기화
+- [ ] `requirements.md §15.4` "30일 보존" 표현 → "MVP 무기한, NextGen 재논의" 동기화 PR
+- [ ] `feature-voc.md §9.4.7` 회귀 테스트 3 건 → 7 건 (sub-task / cascade / audit) 보강
+- [ ] NextGen 영구삭제 활성화 시 별 ADR 또는 본 ADR Status `Accepted → Superseded by 000X`

--- a/docs/specs/plans/followup-bucket.md
+++ b/docs/specs/plans/followup-bucket.md
@@ -18,6 +18,8 @@
 | ---------- | --------------- | ----- | ------ | ----- |
 | _none yet_ |                 |       |        |       |
 
+> Wave 3 (Admin 4 화면) 의 OQ 5 건은 닫힌 wave 가 아니므로 본 bucket 진입 X — `plans/open-questions.md` 에서 추적 (R6 정합).
+
 ## 머지 완료 (✅)
 
 | ID         | Trigger (spawn) | Title | Resolution |

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -15,6 +15,7 @@
 | **/voc 완성** | [`voc-completion-driver.md`](./voc-completion-driver.md)                                                  | 🟢 `docs/voc-completion-single-pr` 9 commit, FE 469 / BE 111 PASS, code-review B-1·H-1·H-2 처리 — **PR open 대기** |
 | **1.6**       | [`wave-1-6-voc-parity.md`](./wave-1-6-voc-parity.md) (history)                                            | ✅ 잔여 η/ζ/D 모두 `/voc 완성` 단일 PR 로 흡수.                                                                    |
 | **1.7**       | [`wave-1-7-voc-create-modal.md`](./wave-1-7-voc-create-modal.md) (history)                                | ✅ Phase A 머지(PR #185) + B/C/D `/voc 완성` 단일 PR 로 흡수.                                                      |
+| **3 (draft)** | [`wave-3-admin.md`](./wave-3-admin.md) + ADR [`0004`](../../adr/0004-admin-permission-model.md) / [`0005`](../../adr/0005-trash-restore-policy.md) | 🟡 plan draft (사용자 승인 + OQ 5건 결정 대기 — `open-questions.md`). Wave 2 머지 + 마이그 012 머지 후 Phase A 진입. |
 
 ### Hard-blocks
 

--- a/docs/specs/plans/open-questions.md
+++ b/docs/specs/plans/open-questions.md
@@ -1,0 +1,24 @@
+# Open Questions
+
+> Wave / Phase 진입 전 사용자 결정이 필요한 항목의 단일 누적 위치. 각 항목 결정 후 정본 spec 동기화 PR 선행.
+> 본 파일은 plan-doc 트리(`docs/specs/plans/`) 내 위치 — `.omc/plans/open-questions.md` 가 아닌 정본 docs hygiene 룰 §3 SoT 정합.
+
+---
+
+## Wave 3 (Admin 4 화면) — 2026-05-09
+
+플랜 정본: [`wave-3-admin.md`](./wave-3-admin.md). 관련 ADR: `docs/adr/0004-admin-permission-model.md` (Proposed), `docs/adr/0005-trash-restore-policy.md` (Proposed).
+
+- [ ] **OQ-1: Tag Master mutate 권한 (Admin only vs Admin/Manager)** — `requirements.md:540` (Admin only) ↔ `feature-voc.md:657` (Admin/Manager) spec 충돌. 권장: Option A (Admin only mutate). 결정 후 한쪽 spec 동기화 PR 필수. — ADR 0004 Accepted 진입 차단.
+- [ ] **OQ-2: External Masters 화면 read 권한 (Manager+ only vs Dev 보기 허용)** — `external-masters.md` 미명시. 권장: Option A (Manager+ 만). 결정 후 `external-masters.md` 한 줄 추가 — Wave 3 Phase D 진입 차단.
+- [ ] **OQ-3: Users role/is_active 변경 audit log 위치 (`user_role_log` 신규 테이블 vs `voc_history` 확장)** — `requirements.md §15.2` 미명시. 권장: Option A (`user_role_log` 별 테이블). 결정 후 `requirements.md §4` 갱신 + Wave 3 §6.2 task 표 W3-1.5 추가 — ADR 0005 audit 정합 차단.
+- [ ] **OQ-4: 마이그 번호 정합 (013/015 vs `next-session-tasks.md` 8-PR2/8-PR3 = 014/015)** — `next-session-tasks.md:71-73` ↔ `requirements.md:541, 549` 표기 충돌. 권장: spec(013/015) 우선. 결정 후 `next-session-tasks.md §권한·스키마 인프라 PR 후보` 동기화 — Wave 3 Phase A 진입 차단.
+- [ ] **OQ-5: 사이드바 `관리자` 그룹 항목 순서** — spec 미명시 (Tag Master = 그룹 하단 / Trash = 최하단 만). 권장: Result Review → Users → Tag Master → External Masters → Trash. 결정 후 `feature-voc.md §9.4` 또는 `uidesign.md §10.5` 박스 추가 — Wave 3 Phase B 진입 차단.
+
+---
+
+## 운영 룰
+
+- 신규 OQ 발견 시 → 활성 wave 헤더 아래 항목 추가, 결정 후 체크박스 ✅ + 정본 spec 동기화 PR # 기록.
+- Wave 종료 시 → 본 파일에서 해당 wave 헤더 + 항목 제거 (동기화 PR 머지로 spec 이 정본화되었으므로 누적 가치 없음).
+- ADR 결정 의존 항목은 ADR Status `Proposed → Accepted` 와 함께 닫는다.

--- a/docs/specs/plans/wave-3-admin.md
+++ b/docs/specs/plans/wave-3-admin.md
@@ -1,0 +1,243 @@
+# Wave 3 — Admin 4 화면 Plan
+
+> 목적: 관리자 페이지 4 화면 (Tag Master / Trash / External Masters / Users) 의 vertical slice 를 spec 정본에 맞춰 구현·검증한다.
+> 인덱스 규칙: `docs/specs/README.md §7`. Wave 계보: `wave-index.md`. Follow-up bucket: `followup-bucket.md`.
+> 정본 product spec: `requires/requirements.md §15` + `requires/feature-voc.md §9.4.6 / §9.4.7` + `requires/external-masters.md` + `requires/uidesign.md §14.3 (Role Pill) / §10.5 (Sidebar admin group)`.
+
+## 0. 진입 게이트
+
+- **Hard-block**: Wave 2 (Dashboard) 머지 완료 후에만 진입. 현재 `next-session-tasks.md` §"활성 작업"은 Wave 2 hard-block 명시.
+- **사용자 승인**: 본 plan 의 §3 결정·§5 ADR 결정·§6 Phase 게이트가 모두 사용자 승인된 후 Phase A 진입.
+- **ADR 결정 의존**: [`docs/adr/0004-admin-permission-model.md`](../../adr/0004-admin-permission-model.md) + [`docs/adr/0005-trash-restore-policy.md`](../../adr/0005-trash-restore-policy.md) 가 사용자 결정 (Status: Accepted) 으로 전환된 후 Phase B/C 진입 가능.
+
+## 1. 배경
+
+- Wave 0~1.7 은 `/voc` 단일 화면 + 셸 정합화에 집중. 관리자 페이지는 **사이드바 그룹만 자리 확보** 상태.
+- §15.1 Result Review 는 별개 트랙(`feature-voc.md §9.4 관리자 페이지`) 으로 다뤄지며 본 Wave 범위 외. 본 Wave 는 §15.2~§15.4 + 외부 마스터 운영 화면(§16.3) 4 종에 집중.
+- 운영 차단 해소 항목으로 spec 이 예약한 마이그레이션 3 종(`tags.is_external` / `merged_into_id` / `tag_rules.suspended_until` / `vocs.deleted_by` / `voc_restore_log`) 은 본 Wave 진입 전 / 진입 시 별도 PR 로 선행한다.
+
+## 2. 범위
+
+### 2.1 In-scope (4 화면 vertical slice)
+
+| 화면 | 진입 동선 | 권한 (spec 인용) | FE 라우트 | BE 라우트 (신규) | 마이그 |
+| --- | --- | --- | --- | --- | --- |
+| **Tag Master** | 사이드바 `관리자` 그룹 → "태그 마스터" | Admin/Manager (`feature-voc.md §9.4.6`) — **§15.3 과 불일치, OQ-1** | `/admin/tags` | `GET /api/admin/tags` · `POST` · `PATCH /:id` · `DELETE /:id` · `POST /:id/merge` | 013 (`tags.is_external` / `tags.merged_into_id` / `tag_rules.suspended_until`) |
+| **Trash** | 사이드바 `관리자` 그룹 → "휴지통" | Admin only (`§15.4` + `feature-voc.md §9.4.7`) | `/admin/trash` | `GET /api/admin/vocs/trash` · `PATCH /api/vocs/:id/restore` | 015 (`vocs.deleted_by` / `voc_restore_log`) |
+| **External Masters** | 사이드바 `관리자` 그룹 → "외부 마스터" | Manager+ refresh, **읽기 권한 OQ-2** | `/admin/masters` | `POST /api/admin/masters/refresh` (기존 §16.3) + `GET /api/admin/masters/status` (신규) | 없음 (메모리 캐시 + JSON 파일) |
+| **Users** | 사이드바 `관리자` 그룹 → "사용자" | Admin only (§15.2 D14, §2.3) | `/admin/users` | `GET /api/admin/users` · `PATCH /api/admin/users/:id` (role, is_active) | 없음 (012 = 별 트랙으로 선행 — `migration-012-draft.md`) |
+
+### 2.2 Out-of-scope (이 Wave 에서 다루지 않음)
+
+- Result Review (§15.1) — 별 트랙. 본 Wave 진입 시 사이드바 메뉴에서 placeholder 만 노출, 라우트는 next wave.
+- 사용자 초대 버튼 (§15.2 끝) — MVP 비활성화 명시. 자리만 확보.
+- 영구삭제 (§9.4.7 끝) — D7 무기한 보존 정책상 disabled, NextGen 활성화 자리만 확보.
+- 공지/FAQ 관리 (Wave 4) — `?mode=admin` 인라인 진입 (D19). 본 Wave 와 메뉴 그룹은 같으나 화면은 별 Wave.
+- 알림 / 셸 마감 / 시각 회귀 12 화면 (Wave 5) — close gate.
+
+### 2.3 Touch budget (변경 / 비변경)
+
+- **변경**: `frontend/src/features/admin/**` (신규), `frontend/src/pages/admin/**` (신규), `frontend/src/app/router.tsx` (라우트 추가), `backend/src/routes/admin/**` (신규), `backend/src/services/admin/**` (신규), `shared/contracts/admin/**` (신규), `shared/fixtures/admin-*.json` (신규), `backend/migrations/013_*.sql` / `015_*.sql` (신규), `docs/specs/requires/feature-voc.md §9.4.6 / §9.4.7` (필요 시 spec sync), `docs/specs/requires/external-masters.md` (운영 화면 필드 보강).
+- **비변경**: `frontend/src/features/voc/**` 본문, VOC 도메인 라우트, 대시보드 코드, 토큰 정의부 (Phase B addendum 외). uidesign.md §14.3 Role Pill 토큰 그대로 재사용 (이미 §10 에 등록).
+
+## 3. 결정 (잠금 — 사용자 최종 승인 시점에 잠긴다)
+
+| ID | 항목 | 결정 (제안) | 근거 |
+| --- | --- | --- | --- |
+| W3-D1 | 권한 모델 | ADR 0004 — 화면별 차등 (Tag Master = Admin/Manager 양쪽 mutate / Trash = Admin only / Masters Refresh = Manager+ / Users = Admin only) | `requirements.md §2.3` + `§15.x` + `§16.3` + ADR 0004 |
+| W3-D2 | Trash 복구 정책 | ADR 0005 — 30 일 보존 + Admin 복원 + 영구삭제 disabled (NextGen) + `voc_restore_log` audit | `§15.4` + `feature-voc.md §9.4.7` + ADR 0005 |
+| W3-D3 | Phase 분할 | Phase A = 마이그·contract spec / Phase B = Tag Master / Phase C = Trash / Phase D = External Masters / Phase E = Users / Phase F = 종합 검증 | 본 plan §6 |
+| W3-D4 | PR 단위 | 화면당 1 PR (FE+BE+contract+fixture 동봉). 마이그 PR 은 별도 (Phase A). 영구삭제 placeholder 만 자리 확보. | D9 precedent (Wave 1.6) |
+| W3-D5 | TDD 의무 surface | 권한 매트릭스 (BE Jest+Supertest) + 마이그 (rollback) + Tag merge 트랜잭션 + Trash restore 의 `tag_rules` 재실행 | `CLAUDE.md §Engineering rules` "TDD for irreversible surface" |
+| W3-D6 | role guard 진입 | sidebar group 자체를 `role ∈ {admin, manager}` 에서만 렌더 (`uidesign.md §10.5.1` precedent — 본 wave 신설). 라우트 진입 시 BE 403 이중 방어. | `requirements.md §6.1` 표준 에러 + `uidesign.md §14.3` 노트 |
+| W3-D7 | 시각 검증 | 4 화면 visual-diff baseline 신규 추가 (`benchmark/admin/*.png` + `INDEX.md` row). 자손 SKIP 0. | `CLAUDE.md §Top-level directories` benchmark 룰 |
+| W3-D8 | 자동화 정책 | Phase 진행 중 autopilot/ralph 사용 허용. 머지·완료 선언은 사용자 검수 후에만. | Wave 1.6 D10 precedent |
+
+## 4. 원칙
+
+1. **Spec 정본 우선** — `requirements.md §15` + `feature-voc.md §9.4.6/9.4.7` 가 충돌하면 사용자에게 보고 (§7 OQ). 임의 동기화 금지.
+2. **마이그는 별 PR** — Phase A 에서 마이그 013 / 015 spec 확정 + 별 PR 머지 후 Phase B 시작.
+3. **권한 이중 방어** — FE role guard (sidebar group + route boundary) + BE 403 (admin route guard middleware). 단일 방어 금지.
+4. **Audit 우선** — Trash 복원 / Tag merge / User role 변경은 모두 `voc_history` 또는 `voc_restore_log` 또는 신규 `user_role_log` (OQ-3) 에 기록. side-effect 없는 mutate 금지.
+5. **토큰 위반 0** — Role Pill 4 종은 `uidesign.md §14.3` 토큰 그대로. raw hex/OKLCH 도입 금지. 미정의 토큰 발견 시 별 PR 로 spec 갱신 후 진입 (Wave 1.6 Phase B addendum precedent).
+6. **YAGNI** — 사용자 초대, 영구삭제, Result Review 는 placeholder 만 자리 확보. 코드·핸들러 작성 금지.
+
+## 5. 의존성 / 차단 항목
+
+### 5.1 진입 차단 (선행 필수)
+
+- **Wave 2 (Dashboard) 머지** — `next-session-tasks.md` 명시. Phase 8 기조상 dashboard 가 widget contract 도입 → admin 화면이 같은 contract 패턴을 재사용.
+- **마이그 012 (`users.role` enum 4 종)** — 별 트랙. `migration-012-draft.md` 정본. 본 Wave Phase E (Users) 진입 전 머지 필수.
+- **마이그 013 (`tags.is_external` / `tags.merged_into_id` FK / `tag_rules.suspended_until`)** — 본 Wave Phase A 1 PR.
+- **마이그 015 (`vocs.deleted_by` / `voc_restore_log`)** — 본 Wave Phase A 1 PR. (`next-session-tasks.md §권한·스키마 인프라 PR 후보` 는 8-PR3 = 015 로 표기. **8-M1/M2 은 마이그 014 = `notices` 별 트랙** — OQ-4 명세 정합 필요.)
+
+### 5.2 외부 차단 (해소 불가 항목)
+
+- 설비 마스터 MSSQL 스키마 TBD (`external-masters.md §3`) — Phase D 의 External Masters 화면은 stub 데이터로 vertical slice 가능. 실제 운영 swap 은 NextGen.
+- OIDC 인증 (`oidcAuthMiddleware`) 미구현 — 본 Wave 는 `AUTH_MODE=mock` 전제로 role guard 만 검증. OIDC 실연동은 별 트랙.
+
+### 5.3 후속 차단 (본 Wave 가 차단하는 것)
+
+- Wave 4 (공지/FAQ + Notice popup) — 사이드바 그룹 + role guard 패턴 본 Wave 가 정의 → Wave 4 가 재사용. 본 Wave 머지 전 Wave 4 의 sidebar 구조 결정 금지.
+- Wave 5 시각 회귀 12 화면 — 본 Wave 4 화면이 baseline 4 개 추가 → 12 화면 합산 산식 갱신.
+
+## 6. Phase 흐름
+
+```
+Phase A: 마이그 + contract spec (코드 0줄 + SQL 2 PR)
+  ├─ 013_tag_master_ops.sql (tags.is_external / merged_into_id / tag_rules.suspended_until)
+  ├─ 015_trash_audit.sql (vocs.deleted_by / voc_restore_log)
+  ├─ shared/contracts/admin/{tag,trash,master,user}.ts (zod)
+  └─ 사용자 승인 게이트 ──┐
+                          ▼
+Phase B: Tag Master 화면 (1 PR)
+  ├─ TDD: BE 권한 매트릭스 + merge 트랜잭션 회귀 4 건 (§9.4.6)
+  ├─ FE: 표 + 추가/편집/병합 모달
+  ├─ visual-diff baseline 1 건 + INDEX.md row
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase C: Trash 화면 (1 PR)
+  ├─ TDD: 회귀 3 건 (Manager 403 / 복원 후 일반 목록 노출 / 복원 시 tag_rules 재실행)
+  ├─ FE: 표 + 복원 다이얼로그 + 영구삭제 disabled placeholder
+  ├─ visual-diff baseline 1 건
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase D: External Masters 화면 (1 PR)
+  ├─ TDD: refresh 쿨다운 5 분 + atomic swap 실패 시 kept_loaded_at 보존
+  ├─ FE: 마스터 3 종 status 표 + refresh 버튼 + 스냅샷/콜드스타트 배지 (§16.3)
+  ├─ visual-diff baseline 1 건
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase E: Users 화면 (1 PR)
+  ├─ TDD: role 변경 권한 (Admin only) + last-admin 강등 차단 (CONFLICT 409, §6.1) + role 변경 audit
+  ├─ FE: 표 + role pill (§14.3) + role 변경 inline + is_active 토글 + "사용자 초대" 버튼 disabled
+  ├─ visual-diff baseline 1 건
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase F: 종합 검증
+  ├─ 4 화면 visual-diff (자손 포함) SKIP 0
+  ├─ 권한 매트릭스 BE 통합 테스트 그린 (§13.x 권한 시나리오 100%)
+  ├─ FE/BE typecheck + lint + test 모두 그린
+  ├─ 토큰 lint (raw hex/OKLCH 0 hits)
+  ├─ claude-progress.txt + next-session-tasks.md + wave-index.md 갱신
+  └─ 사용자 최종 승인 → Wave 3 완료
+```
+
+### 6.1 Phase 게이트 룰
+
+- 직전 Phase 마지막 PR 머지 + 사용자 검수 통과 시 다음 Phase 진입.
+- Phase 내부에서 발견된 sub-task 는 본 Wave 의 다음 정수 task ID (R2) 로 흡수. 닫힌 wave 가 아니므로 `FU-NNN` bucket 진입 X.
+- Phase B/C/D/E 는 서로 독립이므로 사용자 승인 시 병렬 슬롯 가능. 단 Phase A 머지 전 진입 금지 (마이그·contract 의존).
+
+### 6.2 Task ID 부여 (R1·R2·R3)
+
+| ID | Phase | 작업 (한 줄) | trigger / 비고 |
+| --- | --- | --- | --- |
+| W3-1 | A | 마이그 013 (`tag master ops` 컬럼 3 건) + rollback | spec §15.3 / §9.4.6 |
+| W3-2 | A | 마이그 015 (`trash audit` 컬럼 1 + 테이블 1) + rollback | spec §15.4 / §9.4.7 |
+| W3-3 | A | shared/contracts/admin/{tag,trash,master,user}.ts (zod) + openapi.yaml 갱신 | spec §6.1 |
+| W3-4 | B | Tag Master FE+BE+fixture+E2E (1 PR) | spec §9.4.6 |
+| W3-5 | C | Trash FE+BE+fixture+E2E (1 PR) | spec §9.4.7 |
+| W3-6 | D | External Masters FE+BE+fixture+E2E (1 PR) | spec §16.3 |
+| W3-7 | E | Users FE+BE+fixture+E2E (1 PR) | spec §15.2 |
+| W3-8 | F | 종합 검증 + progress 갱신 (1 PR) | gate close |
+
+> **R5 준수**: 묶음 PR 금지. W3-1 / W3-2 / W3-3 모두 별 PR. W3-4~W3-7 도 화면당 별 PR.
+> **R3 준수**: Phase A/B/C/D/E/F 는 grouping 메타데이터일 뿐 ID 에 부착 금지.
+
+## 7. Open Questions (사용자 결정 대기)
+
+> 본 Wave 진입 전 사용자 답변 필수. 답변 후 정본 spec 동기화 PR 선행 (`CLAUDE.md` "spec 내부 불일치 발견 시 임의 결정 금지").
+
+### OQ-1 — Tag Master 권한: Admin only vs Admin/Manager
+
+- **불일치 위치**:
+  - `requirements.md:540` — "Admin (병합/외부 잠금/규칙 일시중지). Manager 읽기 전용."
+  - `feature-voc.md:657` — "Admin/Manager (시스템/메뉴/유형 관리와 동일 정책)."
+- **Option A (Admin only mutate)**: §15.3 채택. Manager 는 `GET /api/admin/tags` 만 200, `POST/PATCH/DELETE/merge` 는 403. 운영상 Tag 병합·외부 잠금이 데이터 손실급(merge irreversible) 이라 Admin 권한 좁히는 게 안전.
+- **Option B (Admin/Manager 양쪽 mutate)**: §9.4.6 채택. Manager 가 트리아지 운영자라 일상 태그 정리도 Manager 권한이 자연. §2.3 "시스템/메뉴/유형/태그규칙 관리: Admin 전용" 과 "tag CRUD" 의 경계가 불분명.
+- **권장**: **Option A**. Tag 병합·삭제는 reversibility gate 상 irreversible (merge 시 source 행 제거) → 권한 좁힘이 `CLAUDE.md §Reversibility gate` 정합. Manager 일상 정리는 `voc_tags` 부착/해제 (이미 Manager 권한) 로 충분.
+- **결정 후**: ADR 0004 Status `Proposed → Accepted` + `requirements.md §15.3` / `feature-voc.md §9.4.6` 중 한쪽 동기화 PR.
+
+### OQ-2 — External Masters 화면 읽기 권한 (Manager 만? 또는 Admin/Manager 양쪽 + Dev 보기 전용?)
+
+- **spec 미명시**: §16.3 "Refresh 권한 = Manager 이상" 만 있고 화면 진입 자체 권한은 없음.
+- **Option A (Manager+ 만 진입)**: refresh 권한과 일치. User/Dev 는 사이드바 항목 자체 미노출.
+- **Option B (Admin/Manager mutate, Dev 읽기 전용)**: Dev 는 본인 담당 VOC 가 외부 마스터 의존하므로 status 모니터링 욕구 있음. 단 §15 admin 페이지 기조는 "관리자/매니저 영역" 이라 Dev 노출은 spec 결정 필요.
+- **권장**: **Option A**. §15 일관성 + Dev 가 status 필요하면 편집 화면 🔄 아이콘 (§16.3 두 번째 진입점) 이 이미 존재.
+- **결정 후**: `external-masters.md` 에 "관리자 페이지 진입 권한: Manager+" 한 줄 추가.
+
+### OQ-3 — Users role 변경 / is_active 토글 audit log: 신규 `user_role_log` 테이블 vs 기존 `voc_history` 외 별도 솔루션
+
+- **spec 미명시**: §15.2 는 "Admin 이 role 변경" 만 명시. audit row 위치 미정.
+- **Option A (`user_role_log` 신규 테이블)**: 컬럼 `id / user_id / changed_by / before_role / after_role / before_is_active / after_is_active / created_at`. PIPA 7 년 보존 원칙 (§15.1.1 precedent) 적용.
+- **Option B (`voc_history` 확장)**: 기존 audit 트리거에 `target_type='user'` 컬럼 추가. 운영 부담 줄지만 voc 도메인에 user 이벤트 끼이는 의미 충돌.
+- **권장**: **Option A**. user mutation 은 voc 와 직교 도메인 → 별 테이블이 의미 단위 명확. 마이그 016 별 PR 후속 또는 본 Wave Phase A 에 포함 결정 필요.
+- **결정 후**: `requirements.md §4` 에 `user_role_log` 테이블 행 추가 + 본 Wave §6.2 task 표에 W3-1.5 추가.
+
+### OQ-4 — 마이그 번호 정합성
+
+- **불일치 위치**:
+  - `next-session-tasks.md:71-73` — "8-PR2 = migration **014** (`tags.is_external` / `tag_rules.suspended_until`)" + "8-PR3 = migration **015** (`vocs.deleted_by` / `voc_restore_log`)"
+  - `requirements.md:541` — "Phase 8 마이그 **013** 예정" (Tag Master 운영 갭)
+  - `requirements.md:549` — "Phase 8 마이그 **014** 예정" (Trash 운영 갭)
+- 본 plan 은 spec 정본 (§15.3 = 013, §15.4 = 015) 을 따랐으나, `next-session-tasks.md` 는 014/015 로 표기. 마이그 번호는 append-only 라 충돌 시 spec 또는 plan doc 한쪽 동기화 필수.
+- **권장**: spec(`requirements.md`) 우선. `next-session-tasks.md` 의 8-PR2/8-PR3 라벨을 013/015 로 갱신.
+- **결정 후**: `next-session-tasks.md §권한·스키마 인프라 PR 후보` 동기화 PR. (현재 상태 그대로 두면 본 Wave 진입 시 마이그 번호 충돌 — 014 는 `notices.visible_from/to timestamptz` 로 8-M2 가 선점.)
+
+### OQ-5 — 사이드바 `관리자` 그룹 항목 순서
+
+- spec 단편 정보:
+  - `requirements.md §15.3` — "사이드바 `관리자` 그룹 **하단**" (Tag Master)
+  - `requirements.md §15.4` — "사이드바 `관리자` 그룹 **최하단**" (Trash)
+- 4 화면 + Result Review placeholder 5 종 순서 미정.
+- **권장**: **Result Review → Users → Tag Master → External Masters → Trash** (운영 빈도 + Trash = 마지막 = 데이터 폐기성 정합). 단 spec 명시가 없으므로 사용자 결정 필요.
+- **결정 후**: `feature-voc.md §9.4` 또는 `uidesign.md §10.5` 에 sidebar admin 그룹 순서 박스 추가.
+
+> 위 OQ 5 건은 [`docs/specs/plans/open-questions.md`](./open-questions.md) (본 Wave 한정) 에 동기화. (.omc/plans/open-questions.md 가 아닌 docs/specs/plans/ 트리 내 파일 — 정본 위치는 docs hygiene 룰 §3 SoT).
+
+## 8. 위험과 대응
+
+| 위험 | 신호 | 대응 |
+| --- | --- | --- |
+| OQ 미해결 채로 Phase B 진입 | Phase A 머지 시 `requirements.md §15.3` ↔ `feature-voc.md §9.4.6` 동기화 PR 부재 | Phase A 게이트에 OQ-1 / OQ-3 / OQ-4 답변 필수. 한 건이라도 미답이면 Phase B 진입 차단 |
+| 마이그 013 / 015 rollback 누락 | rollback SQL 미작성 또는 검증 없이 머지 | TDD `down.sql` 작성 + 적용 후 컬럼 검증 통합 테스트 그린 후 머지 |
+| Tag merge 트랜잭션 실패 시 부분 적용 | `voc_tags` 재배선 중 `tag_rules.tag_id` 갱신 실패 | 단일 트랜잭션 + savepoint 없는 atomic rollback. 회귀 테스트 4 건 (§9.4.6) |
+| Trash 복원 시 `tag_rules` 재실행이 idempotent 깨짐 | 재실행 후 `voc_tags` 중복 row | `INSERT ... ON CONFLICT DO NOTHING` + 회귀 테스트 (§9.4.7 회귀 3 건) |
+| Last-admin 강등으로 시스템 잠금 | Users Phase E 에서 마지막 admin → user 강등 시 모든 admin 액션 불가 | BE 단일 helper `assertLastAdminGuard` 도입 + CONFLICT 409 응답 (§6.1 정합) + 회귀 테스트 |
+| External Masters refresh 동시 요청 race | Manager 둘이 동시 refresh → atomic swap 깨짐 | DB advisory lock 또는 in-memory mutex (§16.3 atomic swap 정의 보강) |
+| 사이드바 admin 그룹 시각 회귀 미커버 | 4 화면 baseline 만 있고 sidebar 자체 baseline 없음 | Phase F 종합 검증 시 sidebar admin 그룹 시각 케이스 추가 (12 → 13 화면) |
+
+## 9. 작업량 추정
+
+| Phase | 추정 | 비고 |
+| --- | --- | --- |
+| A | 1 세션 | 마이그 2 PR + contract 1 PR. zod 스키마는 spec 가독성에 의존. |
+| B | 1.5 세션 | Tag Master + merge 트랜잭션 + visual-diff |
+| C | 1 세션 | Trash + 복원 회귀 3 건 |
+| D | 1 세션 | External Masters + 스냅샷/콜드스타트 배지 |
+| E | 1.5 세션 | Users + last-admin guard + role pill 4 종 시각 검증 |
+| F | 0.5 세션 | 종합 검증 + progress 갱신 |
+| 합 | 6.5 세션 | OQ 답변 시간 별도. 마이그 012 머지 별 트랙 가정. |
+
+## 10. Definition of Done
+
+- 4 화면 모두 spec (§9.4.6 / §9.4.7 / §16.3 / §15.2) 의 회귀 테스트 항목 그린.
+- 권한 매트릭스 BE 통합 테스트 그린 (§13.x 권한 시나리오 100%, `requirements.md §13`).
+- FE typecheck + lint + test 그린, BE typecheck + test 그린 (per `.claude/CLAUDE.md` test batch).
+- visual-diff 4 화면 baseline 추가 (`benchmark/admin/01-tag-master.png` ~ `04-users.png` + `INDEX.md` row 4 건). 자손 포함 SKIP 0.
+- 토큰 lint 통과 (raw hex/OKLCH 0 hits, `var(--*)` 만 사용).
+- `shared/openapi.yaml` 갱신 + `shared/contracts/admin/**` zod schema 단일 정본.
+- `wave-index.md` Wave 3 row Status `대기 → ✅ PR #N` + `claude-progress.txt` 첫 30 줄 동기화 + `next-session-tasks.md` 활성 작업 표 갱신.
+- ADR 0004 / 0005 Status `Proposed → Accepted` + Decision 본문 사용자 결정 반영.
+- 사용자 최종 승인 → Wave 3 close.
+
+## 11. 참조
+
+- 정본 governance: `CLAUDE.md` (root) + `.claude/CLAUDE.md` + `docs/CLAUDE.md`
+- Doc 정책: `docs/specs/README.md`
+- 정본 product spec: `docs/specs/requires/requirements.md §15`, `feature-voc.md §9.4.6 / §9.4.7`, `external-masters.md`, `uidesign.md §14.3 / §10.5`
+- ID 규칙: `docs/specs/README.md §7` (R1~R7) + `wave-index.md` + `followup-bucket.md`
+- 직전 Wave precedent: `wave-1-6-voc-parity.md` (Phase 게이트 / batch / D9 PR 단위), `wave-1-7-voc-create-modal.md` (모달 spec 패턴)
+- ADR: `docs/adr/0004-admin-permission-model.md`, `docs/adr/0005-trash-restore-policy.md`
+- 본 Wave Open Questions: `docs/specs/plans/open-questions.md`

--- a/docs/specs/plans/wave-index.md
+++ b/docs/specs/plans/wave-index.md
@@ -13,7 +13,7 @@
 | **1.6** | `/voc` prototype 100% 일치화 — Phase A 분해 / B 토큰 / C 컴포넌트 rebuild 19 + η 4 (2026-05-04 추가) / D 검증 | 🟡 진행 중 (Phase C δ→η) | [`wave-1-6-voc-parity.md`](./wave-1-6-voc-parity.md) + [룰북](./wave-1-6-phase-c-precedent.md) |
 | **1.7** | VOC 등록 모달 정합화 — A spec → B BE → C FE → D visual                                                        | 🟡 Phase A 머지          | [`wave-1-7-voc-create-modal.md`](./wave-1-7-voc-create-modal.md)                               |
 | 2       | Dashboard + 위젯 8종                                                                                          | ⛔ Wave 1.6 종료 후      | (예정)                                                                                         |
-| 3       | Admin 4 화면 (Tag Master / Trash / External Masters / Users)                                                  | 대기                     | (예정)                                                                                         |
+| 3       | Admin 4 화면 (Tag Master / Trash / External Masters / Users)                                                  | 🟡 plan draft (사용자 승인 대기) | [`wave-3-admin.md`](./wave-3-admin.md) + ADR [`0004`](../../adr/0004-admin-permission-model.md) / [`0005`](../../adr/0005-trash-restore-policy.md) |
 | 4       | 공지/FAQ + Notice popup                                                                                       | 대기                     | (예정)                                                                                         |
 | 5       | 알림 + 셸 마감 + 시각 회귀 12 화면                                                                            | close gate               | (예정)                                                                                         |
 


### PR DESCRIPTION
## Summary

Wave 3 (Admin 4 화면) 진입 전 plan 문서 + 권한·복구 정책 ADR 초안 + 사용자 결정이 필요한 OQ 5건.

- \`docs/specs/plans/wave-3-admin.md\` — Tag Master / Trash / External Masters / Users 4 화면 범위·Phase·DOD·리스크
- \`docs/adr/0004-admin-permission-model.md\` — Admin/Manager/Dev/User × 4 화면 권한 매트릭스 (Status: Proposed)
- \`docs/adr/0005-trash-restore-policy.md\` — 복구 권한·retention·cascade·\`voc_restore_log\` 정렬 (Status: Proposed)
- \`docs/specs/plans/open-questions.md\` — Wave 3 OQ-1~5 (사용자 결정 트리거)
- \`wave-index.md\` / \`followup-bucket.md\` / \`next-session-tasks.md\` / \`claude-progress.txt\` 포인터 갱신

## Open questions (사용자 결정 필요)

1. OQ-1 — Tag Master mutate 권한: requirements.md(Admin only) ↔ feature-voc.md(Admin+Manager) 충돌
2. OQ-2 — External Masters read 권한 미명시 (refresh 만 Manager+ 명시)
3. OQ-3 — Users role/is_active audit log 위치 (\`user_role_log\` 신설 권장)
4. OQ-4 — 마이그 번호 013/014/015 표기 충돌 (next-session-tasks vs requirements)
5. OQ-5 — 사이드바 admin 그룹 항목 순서 (Result Review → Users → Tag Master → External Masters → Trash 권장)

## Test plan

- [ ] OQ 5건 사용자 결정 → ADR Status: Accepted 갱신
- [ ] Wave 3 Phase A (Tag Master) 브랜치 신설 후 W3-1·W3-2 진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)