### PR TITLE
docs(uidesign-cleanup): leak 정리 + 구조 보강 + 룰 단일 출처화 (PR-α2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,6 @@
 | 디자인 시스템               | [`docs/specs/requires/uidesign.md`](./docs/specs/requires/uidesign.md) (English only) |
 | 기능 요구사항               | [`docs/specs/requires/requirements.md`](./docs/specs/requires/requirements.md)        |
 
-> **2026-05-09~ 정책**: 구현 정본은 `requirements.md` + `uidesign.md` 만. `prototype/` 는 더 이상 reference 가 아니다 (parity·픽셀·DOM 인용 금지).
-
 ## 세션 시작 절차
 
 1. `claude-progress.txt` (첫 30줄)
@@ -22,12 +20,6 @@
 3. 필요한 spec만 선택적으로
 4. 룰은 `CLAUDE.md` 참조
 
-## 핵심 룰 요약 (정본은 CLAUDE.md)
+## 룰
 
-- 항상 feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`), main 직접 푸시 금지
-- PR 머지는 `gh pr merge <n> --merge --delete-branch` (squash·rebase 금지)
-- CSS 색상은 토큰만 — hex/raw OKLCH 직접 사용 금지
-- 작업 완료 선언은 사용자 명시적 승인 후
-- 구현 코드 작성은 사용자 승인 후
-
-세부 사항·예외·refactor 체크리스트는 `CLAUDE.md`에 있다.
+전부 `CLAUDE.md` 가 정본 — 본 파일에는 룰을 복제하지 않는다. Codex/다른 agent 도 `CLAUDE.md` 를 그대로 따른다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,171 +1,114 @@
 # CLAUDE.md
 
-Guidance for Claude Code in this repo.
-
 ## Project
 
-**VOC (Voice of Customer) management system.**
+VOC (Voice of Customer) management system. Three-tier: React SPA → Express REST → PostgreSQL/pgvector. Docker Compose runs all three.
 
-- Current progress: `claude-progress.txt` (first 30 lines) → `docs/specs/plans/next-session-tasks.md`
-- Product spec: `docs/specs/requires/requirements.md`
-- Design system: `docs/specs/requires/uidesign.md`
+- Progress: `claude-progress.txt` (first 30 lines) → `docs/specs/plans/next-session-tasks.md`
+- Spec: `docs/specs/requires/requirements.md` + `feature-*.md`
+- Design: `docs/specs/requires/uidesign.md`
+- Sub-dir maps: `frontend/CLAUDE.md`, `backend/CLAUDE.md` (consult before editing in those trees)
 
-Do not record phase/wave progress in this file — canonical source is the progress + plan docs above.
+Implementation reference (2026-05-09~): `requirements.md` + `uidesign.md` only. `prototype/` is no longer a visual/behavior reference — pixel/DOM/CSS citation forbidden.
 
-## Stack (summary — details in sub-dir CLAUDE.md)
+## Design System (canonical)
 
-Three-tier app: React SPA → Express REST API → PostgreSQL.
+Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture, §15 Agent Prompt Guide).
 
-- Frontend: React + TypeScript + Vite + Tailwind v4 → `frontend/CLAUDE.md`
-- Backend: Node + Express + TypeScript + PostgreSQL/pgvector → `backend/CLAUDE.md`
-- Container: Docker Compose (`docker compose up` starts FE + BE + Postgres)
+- All colors via `var(--token)` — never hex/OKLCH literals
+- Typography: Pretendard Variable (UI), D2Coding (code/issue IDs)
+- 8px grid, max-width ~1200px, elevation via background opacity not shadow darkness
 
-**Rule:** folder-level `CLAUDE.md` files are the project map. Before code investigation or editing, use this root file plus the nearest relevant sub-directory `CLAUDE.md` files to choose likely folders/domains. This file covers cross-cutting governance only.
+### `uidesign.md` 단독 정책 (이 한 곳에서만 정의 — 복제 금지)
 
-**Implementation reference (2026-05-09~):** `docs/specs/requires/requirements.md` + `docs/specs/requires/uidesign.md` 만 정본. `prototype/` 디렉터리는 더 이상 시각·동작 reference 가 아니다. parity 비교, 픽셀 측정, prototype DOM/CSS 인용 모두 금지. 기존 plan/문서의 prototype 언급은 history 로만 취급한다.
+**포함**: 토큰 정의·use rule, 컴포넌트 visual contract, §15 Agent Prompt Guide.
+**금지**: 구현 경로(`frontend/src/...`, `*.tsx`, `tokens.ts`) · 빌드/린트 툴명(Stylelint/ESLint/husky) · Wave/Phase/PR 번호·날짜 · 동작·라우팅·상태 contract(→ `feature-*.md`) · 스키마·migration(→ `requirements.md`). 발견 시 leak 으로 즉시 분리.
 
-## Design System (canonical hard rule)
-
-Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture).
-
-- Always use CSS custom properties — `var(--bg-app)`, `var(--brand)`, `var(--text-primary)`, etc.
-- **Never write hex values** (no `#5e6ad2`, no `#ffffff`). No raw OKLCH either — go through the token.
-- Typography: Pretendard Variable (UI), D2Coding (code/issue IDs).
-- 8px spacing grid, max-width ~1200px, elevation via background opacity not shadow darkness.
+**FE 작업 절대 룰**: visual surface 를 만지면 `uidesign.md` 를 먼저 읽고 기존 토큰 contract 를 확인한 뒤 코드 작성. 새 토큰이 필요하면 spec 갱신을 같은 PR(또는 직전 PR)에서 끝낸다. 컴포넌트 신설은 §15 예시를 베이스로.
 
 ## Start Every Session
 
-1. Read `claude-progress.txt` (first 30 lines only)
-2. Read `docs/specs/plans/next-session-tasks.md` to find current Phase and pending tasks
-3. Read relevant spec in `docs/` (selectively — only what's needed)
-4. Continue from progress file — don't re-read what you already know
-5. Review `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — delete entries already reflected in specs or git
+1. `claude-progress.txt` (first 30 lines)
+2. `next-session-tasks.md` for current Phase
+3. Relevant spec selectively
+4. Memory index `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — purge entries already in specs/git
 
 ## Core Rules
 
-- **Tool routing — match task to tool, picking the wrong tool wastes tokens and is itself a rule violation:**
-  - TS/TSX symbol body / references / rename → **Serena** (`get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `rename_symbol`)
-  - Cross-file keyword / literal / error string / file discovery → **`rg -n`**
-  - Known small range or tight cluster needing imports+body together → **`Read`** with `offset`/`limit` (or `sed -n 'A,Bp'`)
-  - Architecture map / dependency graph / UI→API→DB flow / "what connects to X" → **Graphify** — required at least once before a wide refactor or first entry into an unfamiliar feature; details below
-  - **Never** `cat <file>` to dump source, **never** `Read` a whole TS/TSX file you could `find_symbol` instead, **never** re-read a file already in context. Exception: config/JSON under ~1KB.
-- **Parallel tool calls** — independent tool calls MUST go in one single message, never sequential. Gate: "Can I write call B's exact arguments right now, before call A runs?" — if yes, batch it. Common violations: (1) typecheck + test as separate Bash calls (use `&&` instead); (2) consecutive Read calls on unrelated files; (3) consecutive Bash greps; (4) sequential subagent dispatches. Full violation patterns, exceptions, and rationalization table: `.claude/specs/parallel-dispatch.md`.
-- **No re-read** — never re-read a file already in session context (exception: modified files)
-- **Tail test output** — pipe through `| tail -20`; never print full traces
-- **No Read before delete** — files being deleted must never be Read first; just `rm`
-- **Broad git history first pass** — use `--all` and wide keywords on first `git log --grep`; never retry with a narrower pattern
-- **Minimum context for decisions** — for judgment tasks, use only the single most relevant file; open supporting files only if the first is insufficient
-- **Before editing** — summarize selected files/symbols and why they are in scope
-- **Git workflow** — Create the feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) **before** making any changes; never work on main then move commits after. Never commit or push to main directly. PRs are opened by the user. Merge with `gh pr merge <n> --merge --delete-branch` (`--squash` and `--rebase` forbidden). After merge: `git branch -D <branch>`. Enforced by hookify rules in `.claude/hookify.block-*.local.md`.
-- Run tests before committing; follow existing code style (read 2–3 nearby files first)
-- No features beyond what the task requires (YAGNI)
-- CLAUDE.md stays under 200 lines
+- **Tool routing**:
+  - TS/TSX symbol/refs/rename → Serena
+  - Cross-file keyword/file discovery → `rg -n`
+  - Small known range → `Read` with `offset/limit`
+  - Architecture / dependency flow → Graphify (required once before wide refactor or unfamiliar feature)
+  - Never `cat <file>` to dump source; never `Read` whole TS/TSX file when `find_symbol` works; never re-read a file already in context (modified files OK)
+- **Parallel tool calls**: independent calls go in one message. Gate: "Can I write call B's args before A runs?" — if yes, batch. Common violations + exceptions: `.claude/specs/parallel-dispatch.md`.
+- **Tail test output**: `| tail -20`; never full traces
+- **No Read before delete**: just `rm`
+- **First-pass git log**: `--all` + wide keywords; never narrow on retry
+- **Minimum context for judgment**: single most relevant file first
+- **Before editing**: summarize selected files/symbols + why
+- **Git workflow**: feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) **before** any change; never push to main; PRs opened by user; merge with `gh pr merge <n> --merge --delete-branch` (squash/rebase forbidden); after merge `git branch -D <branch>`. Enforced by `.claude/hookify.block-*.local.md`.
+- Tests before commit; match nearby code style; YAGNI
+- This file stays under 200 lines
 
 ## Session Continuity
 
-Every design decision → written to spec or ADR before session ends.
-Every phase completion → update `claude-progress.txt` + git commit.
-No implementation without a written spec section covering it.
+Every design decision → spec or ADR before session ends. Phase close → `claude-progress.txt` + commit. No implementation without a spec section.
 
 ## Documents
 
-Documentation hygiene canonical source: **`docs/specs/README.md`**. Consult it before creating, moving, or cleaning up any doc.
-
-**Index IDs (Wave / Phase / Task / FU)** — when assigning, citing, or closing any ID, consult these three canonical sources:
-
-- Rules — `docs/specs/README.md §7` (R1–R7: append-only / flat integer / grouping is metadata / Issue# is cross-ref / no bundle IDs / closed waves use FU bucket / one work unit per ID)
-- Wave lineage + batch glossary — `docs/specs/plans/wave-index.md`
-- Follow-up flat-ID register — `docs/specs/plans/followup-bucket.md`
-
-Before assigning a new ID, check the next free integer in `wave-index.md`. Follow-ups against closed waves get the next `FU-NNN` in `followup-bucket.md`. On merge, update the status column in both docs and sync the first 30 lines of `claude-progress.txt`.
+Doc hygiene: **`docs/specs/README.md`**. Index IDs (Wave/Phase/Task/FU): consult `README.md §7` (rules R1–R7) + `plans/wave-index.md` (lineage) + `plans/followup-bucket.md` (FU register). Next free integer from `wave-index.md`; closed-wave follow-ups → `FU-NNN`. On merge: status update in both + sync `claude-progress.txt`.
 
 ## Input Interpretation
 
-Normalize a request into this frame before coding. Ask only about items that materially affect the result; otherwise state the assumption and proceed.
-
-- **Goal** — what + why (one line)
-- **Scope** — files/paths involved; what _not_ to touch
-- **Done when** — verifiable conditions (test passes, build clean, observable behavior)
-- **Constraints** — style, tokens, dependencies, existing patterns
-
-Skip the frame for trivial one-liners (rename, obvious typo, single-file change with explicit path).
+Before coding, frame: **Goal** (what + why, 1 line) · **Scope** (files in/out) · **Done when** (verifiable conditions) · **Constraints** (style/tokens/patterns). Skip for trivial one-liners.
 
 ## Working Style
 
-### Reversibility gate (apply before any pause)
+### Reversibility gate
 
-Classify the decision first; the gate level follows the class.
+- **Irreversible**: DB schema/migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms, file deletes, auth/billing/permissions/tenant boundary. → stop and ask, ≥90% confidence required.
+- **Reversible**: code/style/test in unmerged branch, file moves, naming, local refactors. → state assumption in 1 line, proceed, report in summary.
+- **Visual surface** (영향 `/voc`): `uidesign.md` 토큰·구조와 어긋나면 irreversible — 토큰 정의 변경은 spec 갱신 선결.
 
-- **Irreversible** — DB schema/migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms (push, PR merge, issue/comment), file deletes, anything touching auth / billing / permissions / tenant boundary.
-- **Reversible** — code/style/test changes inside an unmerged feature branch, file moves within the working tree, naming choices, local refactors.
+### Engineering
 
-Rules:
-
-- **Irreversible**: stop and ask. State both options + rationale. No proceeding under 90% confidence.
-- **Reversible**: state the assumption in one line, proceed, report what was done in the end-of-turn summary. Do not block on user response for reversible decisions.
-- **Visual-surface decisions** (anything affecting `/voc` 시각 결과)는 `uidesign.md` 토큰·구조와 어긋나면 irreversible 로 취급 — 토큰 정의 변경은 spec 갱신이 선결.
-
-### Engineering rules
-
-- **TDD for irreversible surface** — auth, billing, permissions, contracts, migrations, BE routes: write the test first, confirm it fails, then implement. Bug fixes start with a failing regression test. Stack: Vitest (FE) / Jest+Supertest (BE) — see `requirements.md §3`.
-- **Smoke test for reversible UI** — components and styles only need a single happy-path render test plus the visual-diff baseline. Don't author exhaustive unit tests for trivial JSX.
-- **Debate, don't defer** — raise counterarguments or missed cases before agreeing; no passive "yes".
-- **Think before coding** — state assumptions; if multiple interpretations exist, present them, don't pick silently.
-- **Simplicity first** — minimum code; no speculative abstractions; if 200 lines could be 50, rewrite.
-- **Surgical changes** — touch only what the request requires; match existing style; remove only orphans your changes made unused.
-- **Goal-driven execution** — convert tasks into verifiable goals; for multi-step work, plan per-step verification and loop until verified.
-- **Pre-commit lint dry-run** — before the first `git commit`, run `npm run lint -w frontend` once. Fix and re-stage on failure to avoid a husky retry loop. (Backend lint script is undefined — same pattern applies once added.)
-- **Progress docs at phase/wave close only** — sync `claude-progress.txt` + the relevant plan doc on the same branch only when the PR closes a phase or wave. Intra-phase PRs are exempt; do not commit progress diffs for every leaf. The `warn-doc-cleanup-before-pr` hookify rule fires on every `gh pr` — apply its 8-step checklist only if this PR is a phase/wave-close PR.
+- **TDD for irreversible surface** (auth/billing/permissions/contracts/migrations/BE routes): test first, confirm fail, implement. Bug fix = failing regression test first. Stack: Vitest (FE) / Jest+Supertest (BE) — `requirements.md §3`.
+- **Smoke test for reversible UI**: one happy-path render test + visual-diff baseline.
+- **Debate, don't defer**: raise counterarguments before agreeing.
+- **Think before coding**: state assumptions; surface multiple interpretations.
+- **Simplicity first**; **surgical changes**; **goal-driven verification per step**.
+- **Pre-commit**: `npm run lint -w frontend` once before first commit.
+- **Progress docs at phase/wave close only** — intra-phase PRs exempt. `warn-doc-cleanup-before-pr` hookify 8-step checklist applies only on phase/wave-close PR.
 
 ### Approval scope
 
-A user approval applies to its declared scope and everything reversible inside it:
+User approval covers its declared scope + reversible items inside. Plan approval → batches OK. Batch approval → leaves OK. Spec-derived → no extra approval. Re-ask on (1) new plan/batch, (2) irreversible not in spec, (3) user contradiction.
 
-- **Plan approval** → all batches in that plan are approved; per-batch ack not required
-- **Batch approval** → all leaves in that batch are approved; per-leaf ack not required
-- **Spec-derived implementation** → no extra approval needed; the spec is the approval
-
-Re-ask only when (1) crossing into a new plan/batch, (2) hitting an irreversible decision not covered by the spec, or (3) the user contradicts the prior approval.
-
-Completion language:
-
-- For leaves and intra-batch work: report what landed in the end-of-turn summary, do not declare "done".
-- For phase / wave / PR-merge milestones: wait for explicit user confirmation before declaring closure.
+Completion language: leaves → report what landed, no "done"; phase/wave/PR-merge → wait for explicit user confirmation.
 
 ## Refactoring
 
-A refactor changes structure without changing observable behavior. Refactor and feature change must NOT land together — separate commits/PRs.
+Refactor = structure change without behavior change. Refactor + feature change MUST NOT land together.
 
-- **Before:** state symbols/files/paths to be changed in chat; ensure tests cover affected behavior (write tests first if not).
-- **During:** `git mv` for file moves; one refactor at a time.
-- **After (in order):** update all references (imports, dynamic strings, config, `docs/specs/**`, plan files, README/CLAUDE.md, comments) → `rg -n "<old>"` returns 0 hits → Serena reference checks when symbols moved/renamed → typecheck passes → tests pass → exercise the touched surface (UI: browser; API: endpoint).
-- **Escalate to `code-reviewer`** only when public API surface changed, ≥3 modules touched, or DB schema/migration involved.
+- **Before**: state symbols/files; ensure test coverage (write tests first if not).
+- **During**: `git mv` for moves; one refactor at a time.
+- **After (in order)**: update all references → `rg -n "<old>"` returns 0 → Serena ref-check on renames → typecheck → tests → exercise the surface.
+- **Escalate to `code-reviewer`** only on public API change, ≥3 modules, or DB schema/migration.
 
 ## Graphify
 
-Knowledge graph at `graphify-out/`. Triggered by the routing rule above (architecture / dependency / cross-domain flow questions only). Prefer `graphify-out/wiki/index.md` over raw files; specific queries via `/graphify query|path|explain`. After modifying code files, run `graphify update .` to keep the graph current.
+Knowledge graph at `graphify-out/`. Use for architecture / dependency / cross-domain flow questions. Prefer `wiki/index.md` over raw files; queries via `/graphify query|path|explain`. After code edits: `graphify update .`.
 
 ## Top-level directories
 
-- `benchmark/` — visual ground-truth PNGs (`01-…`–`22-…`) compared by `scripts/visual-diff.ts`. Index: `INDEX.md`. New screen = baseline + INDEX row.
-- `graphify-out/` — auto-generated knowledge-graph output. Do not hand-edit. Architecture/community Q → `GRAPH_REPORT.md` or `wiki/index.md`. Refresh: `graphify update .`.
-- `scripts/` — repo utilities. Fixture↔seed parity: `check-fixture-seed-parity.ts`. Shadcn token rewrite: `shadcn-token-rewrite.ts`. Visual diff: `visual-diff.ts` + `visual-diff/` (helpers + `__tests__/`).
-- `shared/` — types/zod-schemas/fixtures used by **both** FE+BE.
-  - `shared/types/` — TS domain entities/enums/response shapes. Single-side types stay in that side.
-  - `shared/contracts/` — zod schemas (FE forms + BE route input, single source). Sub-trees: `voc/`, `notification/`, `master/` (source data in `backend/config/masters/`).
-  - `shared/fixtures/` — FE MSW + BE seed shared data; parity enforced by `scripts/check-fixture-seed-parity.ts`.
-  - REST contract reference → `shared/openapi.yaml`.
+- `benchmark/` — ground-truth PNGs (`01–22-…`) for `scripts/visual-diff.ts`. New screen = baseline + INDEX row.
+- `graphify-out/` — auto-generated, do not hand-edit. Refresh: `graphify update .`.
+- `scripts/` — utilities (`check-fixture-seed-parity.ts`, `shadcn-token-rewrite.ts`, `visual-diff.ts`).
+- `shared/` — `types/` (FE+BE entities/enums) · `contracts/` (zod schemas, single source) · `fixtures/` (MSW+seed, parity enforced) · `openapi.yaml` (REST contract reference).
 
 ## Agent skills
 
-### Issue tracker
-
-Issues live in GitHub Issues. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Default label vocabulary (needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix). See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context — one `CONTEXT.md` at the repo root + `docs/adr/`. See `docs/agents/domain.md`.
+- Issues: GitHub Issues — `docs/agents/issue-tracker.md`
+- Triage labels: needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix — `docs/agents/triage-labels.md`
+- Domain docs: single `CONTEXT.md` + `docs/adr/` — `docs/agents/domain.md`

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -2,12 +2,13 @@
 
 ## 다음 세션 시작점 (2026-05-09 grill 종료)
 
-→ **다음 세션 우선: 4 PR 병렬 작성 (Wave 3 진입 unblock + Wave 4 hotfix)**
+→ **PR-α2 머지 완료 (2026-05-09)** — `docs/uidesign-cleanup`. uidesign.md leak 16건 정리(prototype 4 / FE 경로 5 / tooling 1 / 이력 3 / contract 3) + 구조 보강(Surfaces level numbering / Type·Spacing·Shadow·Radius 표 / §15 Agent Prompt Guide) + uidesign 단독 정책 블록을 root CLAUDE.md 한 곳으로 통합하고 AGENTS.md·frontend·prototype CLAUDE.md 의 룰 중복 제거. CLAUDE.md 197→114줄.
+
+→ **다음 세션 우선: 3 PR 병렬 작성 (Wave 3 진입 unblock + Wave 4 hotfix)**
    - **PR-α**  `docs/wave-3-oq-sync`           — OQ-1~5 결정 반영 + ADR 0004/0005 Accepted + spec sync 10개 + 사이드바 양쪽 갱신
-   - **PR-α2** `docs/uidesign-cleanup`         — uidesign.md 구현 leak 12항목 정리 + prototype reference 전수 제거
    - **PR-β**  `fix/fu-001-dompurify`          — dompurify + SafeHtml wrapper, 4 surfaces (XSS, 가장 시급)
    - **PR-γ**  `fix/fu-002-notice-faq-indexes` — 마이그 018 (notices/faqs hot-path 인덱스)
-   PR 은 사용자가 open. 4 worktree 동시 작성, 의존성 0, 머지 순서 무관.
+   3 worktree 동시 작성, 의존성 0, 머지 순서 무관.
 
 → **머지 후 진입 순서**
    1. Wave 3 Phase A — **4 PR full parallel**: W3-1=마이그 014 / W3-2=마이그 015 / W3-3=contract zod+openapi / W3-9=마이그 017

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,34 +1,32 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점
+## 다음 세션 시작점 (2026-05-09 grill 종료)
 
-→ **`/voc` 단일 PR `docs/voc-completion-single-pr` PR open 대기 (12 commit, follow-up 5건 반영)**
-   verifier evidence-based PASS — D-3 재실행: BE 116/123 PASS (+5 M-1) · FE 472/472 PASS (+3 L-1·L-2) · FE lint clean · FE+BE typecheck clean.
-   머지는 사용자. 머지 후 Phase 2 (`feat/voc-list-expand`) → Wave 2(Dashboard).
+→ **다음 세션 우선: 4 PR 병렬 작성 (Wave 3 진입 unblock + Wave 4 hotfix)**
+   - **PR-α**  `docs/wave-3-oq-sync`           — OQ-1~5 결정 반영 + ADR 0004/0005 Accepted + spec sync 10개 + 사이드바 양쪽 갱신
+   - **PR-α2** `docs/uidesign-cleanup`         — uidesign.md 구현 leak 12항목 정리 + prototype reference 전수 제거
+   - **PR-β**  `fix/fu-001-dompurify`          — dompurify + SafeHtml wrapper, 4 surfaces (XSS, 가장 시급)
+   - **PR-γ**  `fix/fu-002-notice-faq-indexes` — 마이그 018 (notices/faqs hot-path 인덱스)
+   PR 은 사용자가 open. 4 worktree 동시 작성, 의존성 0, 머지 순서 무관.
 
-→ **다음 세션 액션**
-   1. `gh pr create` → 사용자 review → `gh pr merge --merge --delete-branch`
-   2. 머지 직후 main 기준 `feat/voc-list-expand` 브랜치 신설 (§9.2.2 인라인 expand)
-   3. Phase 2 spec 보강 ADR 1건 (BE `total` 의미 / zod self-recursive 회피 / status grouping × expand 배타) → 구현
-   4. Phase 2 머지 후 `feat/dashboard-shell` 진입 (Wave 2)
+→ **머지 후 진입 순서**
+   1. Wave 3 Phase A — **4 PR full parallel**: W3-1=마이그 014 / W3-2=마이그 015 / W3-3=contract zod+openapi / W3-9=마이그 017
+   2. Phase B+C 병렬 (Tag Master + Trash) → Phase D+E 병렬 (External Masters + Users) → Phase F 종합 검증
+   3. FU-003/4/5 = Phase A 머지 후 idle slot 에서 hotfix-style. FU-006~009(P2) = Wave 3 close 후 batch.
+   4. Wave 5 plan = Wave 3 close 후 작성 진입.
 
-→ **Wave 3 plan draft (병렬 트랙, branch `docs/wave-3-plan`, 2026-05-09)**
-   - `docs/specs/plans/wave-3-admin.md` — Admin 4 화면 (Tag Master / Trash / External Masters / Users) plan
-   - `docs/adr/0004-admin-permission-model.md` (Proposed) + `docs/adr/0005-trash-restore-policy.md` (Proposed)
-   - OQ 5 건 (`docs/specs/plans/open-questions.md`) — 사용자 결정 후 spec 동기화 PR 선행
-   - Hard-block: Wave 2 머지 + 마이그 012 머지 + OQ 5건 답변 모두 충족 후 Phase A 진입
-   - PR 은 사용자가 open. 본 worktree 는 commit only.
+→ **Grill 결정 정합 (19건, 2026-05-09)**
+   - **OQ-1** Tag Master mutate = **Option D** (Manager add/edit, Admin only merge/외부잠금/영구삭제)
+   - **OQ-2** External Masters read = **B** (Manager+ + Dev)
+   - **OQ-3** user_role_log = **A** (별 테이블, 마이그 017)
+   - **OQ-4** 마이그 번호 = **014** Tag Master / **015** Trash / **017** user_role_log (013/016 점유)
+   - **OQ-5** 사이드바 순서 = **B** (Result Review → Users → External Masters → Tag Master → Trash)
+   - **ADR 0004** Accepted + 본문 재작성 (Option D 신설). **ADR 0005** Accepted (본문 유지).
+   - **user_role_log schema** = `id, user_id, changed_by(NOT NULL), old_role, new_role, old_active, new_active, reason, created_at` + `(user_id, created_at DESC)` idx
+   - **FU-001~009** 모두 등록 (P1 5 + P2 4). FU-001 = dompurify+SafeHtml 4 surfaces. FU-002 = 마이그 018.
+   - **새 phase 생성 X** — uidesign cleanup 은 별 PR-α2 로 본 다음 세션 우선 처리, 그 뒤는 위 계획 그대로.
 
-→ **PR 본문 = `docs/voc-completion-single-pr` 12 commit + driver D-1~D-5 재PASS + 머지 요청 1줄**
-   - Phase B (BE master + create 강제룰) — `ad1ef50`
-   - Phase C minimal + major — `c56af67` + `b85240a`
-   - Wave 1.6 잔여 — `dc4527c`
-   - Phase 6 (payload-review BE/FE + Playwright spec) — `a8c08ca` + `64069e2`
-   - Follow-up 7건 (status icon · 토큰화 · 13.5px · ReviewStatus · collapse test · data-testid slug) — `d266bd7`
-   - Code-review fix B-1 / H-1 / H-2 — `97e002c`
-   - Wave close progress sync — `4ad8dbe`
-   - Untracked entity icons + shadcn primitives — `08f95f0`
-   - **NEW** Follow-up M-1·M-2·M-3·L-1·L-2 일괄 처리 (이번 세션)
+→ **Wave 4 (공지/FAQ/Notice popup) 머지 완료** — PR #245 (08070cc, 2026-05-09). Wave 3 plan draft = PR #244 머지.
 
 → **D-1~D-5 재실행 evidence (2026-05-09)**
    - D-1 기능: 변경 없음 (M-1·M-3 docs/test only). M-2 onError 토스트 추가 / L-1 다탭 동기화 / L-2 secondary sort.

--- a/docs/specs/requires/uidesign.md
+++ b/docs/specs/requires/uidesign.md
@@ -1,9 +1,16 @@
 # VOCpage UI Design System
 
+> **Theme:** light + dark (automatic, system-driven)
+>
 > **Scope**: Visual layer only — color tokens, typography, component visuals, spacing, elevation, layout rules.
 > Behavior, business logic, API contracts, role policy → `requirements.md` / `feature-*.md`.
 >
-> **Revision history**: Initial Linear-inspired indigo palette → Samsung Blue palette + automatic system theme sync, fully overhauled (2025.06). Renamed `design.md` → `uidesign.md` (2026-04-27) to make the visual-only scope unambiguous.
+> **Revision history**:
+> - 2025.06 — initial Linear-inspired indigo palette overhauled to Samsung Blue + automatic system theme sync.
+> - 2026-04-27 — renamed `design.md` → `uidesign.md` to make the visual-only scope unambiguous.
+> - 2026-05-09 — removed prototype references and frontend implementation paths; consolidated archetype amendments and wave/phase markers into history; added Surfaces, Border-radius, Shadows, and Agent Prompt Guide sections for AI-followable lookups.
+
+VOCpage's design language is a **focused, blue-tinted enterprise canvas**. A single saturated chromatic — Samsung Blue — carries every CTA, focus, and active state. Everything else is blue-tinted neutral, layered through OKLCH-uniform background tiers (App → Panel → Surface → Elevated). Korean and Latin coexist on Pretendard Variable; D2Coding is reserved for issue codes and code blocks. The system follows the user's OS theme automatically — light and dark are designed separately, not as inversions.
 
 ---
 
@@ -48,16 +55,20 @@ Clean corporate look on blue-tinted white. Similar to the light version of Galax
 
 > Why OKLCH: perceptually uniform — equal lightness steps look equal visually. No chroma-lightness interference like HSL.
 
-### Background Layers
+### Background Layers (Surfaces)
 
-| Role         | Light                    | Dark                     | Usage           |
-| ------------ | ------------------------ | ------------------------ | --------------- |
-| **App Base** | `oklch(98% 0.007 252)`   | `oklch(11% 0.016 264)`   | Lowest canvas   |
-| **Panel**    | `oklch(96.5% 0.009 255)` | `oklch(14.5% 0.019 262)` | Sidebar, panels |
-| **Surface**  | `oklch(100% 0 0)`        | `oklch(18.5% 0.021 260)` | Cards, drawer   |
-| **Elevated** | `oklch(95% 0.011 256)`   | `oklch(23% 0.022 258)`   | Hover, popups   |
+Four numbered elevation levels — pick layer by depth, not by mood.
+
+| Level | Token            | Light                    | Dark                     | Purpose                                      |
+| ----- | ---------------- | ------------------------ | ------------------------ | -------------------------------------------- |
+| **0** | `--bg-app`       | `oklch(98% 0.007 252)`   | `oklch(11% 0.016 264)`   | Lowest canvas — page body                    |
+| **1** | `--bg-panel`     | `oklch(96.5% 0.009 255)` | `oklch(14.5% 0.019 262)` | Sidebar, sticky topbars, panel zones         |
+| **2** | `--bg-surface`   | `oklch(100% 0 0)`        | `oklch(18.5% 0.021 260)` | Cards, drawers, modal dialog surface         |
+| **3** | `--bg-elevated`  | `oklch(95% 0.011 256)`   | `oklch(23% 0.022 258)`   | Hover, popovers, nested-card / row-hover     |
 
 > **Principle**: All backgrounds must be micro-tinted with blue hue (250–268). Pure white/black forbidden.
+>
+> Layer rule: a child surface uses the next level up from its parent. Never skip more than one level (Level 0 → 3 looks unanchored).
 
 ### Text Hierarchy
 
@@ -124,15 +135,17 @@ CDN: `https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variabl
 
 ### Type Scale
 
-| Role    | Size    | Weight  | Usage                                       |
-| ------- | ------- | ------- | ------------------------------------------- |
-| Display | 32px    | 700     | Rarely used                                 |
-| Heading | 20–24px | 700     | Section titles                              |
-| Title   | 15px    | 700     | **Page header title**, card/drawer headings |
-| Body UI | 14px    | 400     | Default body text                           |
-| Label   | 13px    | 400–600 | Table cells, form labels                    |
-| Caption | 11–12px | 400–600 | Metadata, dates                             |
-| Micro   | 10–11px | 600     | Badges, tags, uppercase labels              |
+| Role    | Size    | Line height | Weight  | Tracking      | Usage                                       |
+| ------- | ------- | ----------- | ------- | ------------- | ------------------------------------------- |
+| Display | 32px    | 1.2         | 700     | `-0.02em`     | Rarely used (empty-state hero, error 404)   |
+| Heading | 20–24px | 1.3         | 700     | `-0.015em`    | Section titles                              |
+| Title   | 15px    | 1.4         | 700     | normal        | **Page header title**, card/drawer headings |
+| Body UI | 14px    | 1.5 (1.65 KR) | 400   | normal        | Default body text                           |
+| Label   | 13px    | 1.4         | 400–600 | normal        | Table cells, form labels                    |
+| Caption | 11–12px | 1.4         | 400–600 | normal        | Metadata, dates                             |
+| Micro   | 10–11px | 1.3         | 600     | `0.06–0.08em` (uppercase) | Badges, tags, uppercase labels    |
+
+> Token reference for sizes: not exposed as discrete `--text-*` tokens — use literal px on `font-size`, but only one of the values above. Do not invent sizes between tiers.
 
 **Core principles**:
 
@@ -190,7 +203,7 @@ box-shadow: 0 0 0 3px var(--brand-bg);
 
 ### Tag Pill (Auto-tag)
 
-> **[AMENDED 2026-05-02 post-PR-144 visual review]** — In-row VOC tag pill switched from chip-style to text-only quiet style after user visual review ("테두리/배경 없는 회색 글씨로 더 작게"). The chip-style spec below is **retained** for non-row contexts (filter UI, badges in headings, future imported-source badges) and is the canonical OutlineChip primitive (`docs/specs/reviews/wave-1-6-voc-badge-audit.md` §2.2). For the in-row VOC tag visual, use the TextMark variant immediately below. Cross-reference: audit §1 row 2.
+> In-row VOC tag pill uses the text-only quiet style (no border/background, smaller). The chip-style spec below is **retained** for non-row contexts (filter UI, badges in headings, future imported-source badges) and is the canonical OutlineChip primitive (`docs/specs/reviews/wave-1-6-voc-badge-audit.md` §2.2). For the in-row VOC tag visual, use the TextMark variant immediately below. Cross-reference: audit §1 row 2.
 
 **In-row VOC tag (current — TextMark `size='xs'`):**
 
@@ -317,7 +330,6 @@ gap: 5px;
 - Low: `var(--text-quaternary)` — `font-weight: 400`
 - `font-size: 11.5px` — metadata tier (§7). Color + weight together carry the semantic signal; the absence of a chip keeps the row visually quiet.
 - aria-label: `Priority ${label}` (English, matches the label).
-- Implementation: `frontend/src/components/voc/VocPriorityBadge.tsx` (Wave 1.6 Phase C-2)
 
 ### Card & Container
 
@@ -443,7 +455,13 @@ Every list, table, drawer, and dashboard widget MUST render one of three non-dat
 
 ## 6. Shadows (Elevation)
 
-Dark backgrounds suppress shadows — light/dark are separately optimized:
+Dark backgrounds suppress shadows — light/dark are separately optimized.
+
+| Token             | Geometry           | Where to use                                              |
+| ----------------- | ------------------ | --------------------------------------------------------- |
+| `--shadow-sm`     | `0 1px 3px`        | Inline cards lifting above Surface (Level 2)              |
+| `--shadow-md`     | `0 4px 16px`       | Popovers, dropdowns, sticky headers when scrolled         |
+| `--shadow-dialog` | `0 12px 40px`      | Modal dialog surface, full-page drawer                    |
 
 ```css
 --shadow-sm: light-dark(oklch(70% 0.04 260 / 0.1) 0 1px 3px, oklch(5% 0.01 265 / 0.4) 0 1px 3px);
@@ -457,8 +475,10 @@ Dark backgrounds suppress shadows — light/dark are separately optimized:
 );
 ```
 
-**Dark mode**: Blue-black deep shadows for depth  
-**Light mode**: Blue-tinted soft shadows (pure gray shadows forbidden)
+**Dark mode**: Blue-black deep shadows for depth.  
+**Light mode**: Blue-tinted soft shadows (pure gray shadows forbidden).
+
+> Never combine more than one shadow token on the same element. If a UI feels under-elevated, raise the surface level (§3) before reaching for a heavier shadow.
 
 ---
 
@@ -466,10 +486,18 @@ Dark backgrounds suppress shadows — light/dark are separately optimized:
 
 ### Spacing (4pt scale)
 
-```
---sp-1: 4px   --sp-2: 8px   --sp-3: 12px
---sp-4: 16px  --sp-5: 24px  --sp-6: 32px
-```
+Base unit: 4px. Use only these tokens — no arbitrary px between steps.
+
+| Token     | Value | Typical use                                      |
+| --------- | ----- | ------------------------------------------------ |
+| `--sp-1`  | 4px   | Icon ↔ label gap, chip inner padding             |
+| `--sp-2`  | 8px   | Element gap (default), nav-item icon gap         |
+| `--sp-3`  | 12px  | Form field internal padding, card body padding   |
+| `--sp-4`  | 16px  | Card outer padding, section internal stack       |
+| `--sp-5`  | 24px  | Section gap, admin-body padding, page margin     |
+| `--sp-6`  | 32px  | Major section break (hero, heading clearance)    |
+
+> Density rhythm: row content uses `--sp-2` / `--sp-3` for internal padding; section-level layout uses `--sp-4` / `--sp-5`. Never mix `--sp-1` and `--sp-6` directly without an intermediate step.
 
 ### Key Dimensions
 
@@ -527,6 +555,23 @@ VOCpage uses **two distinct layout patterns**:
 grid-template-columns: 22px 144px 1fr 115px 108px 84px 96px;
 /* toggle | issue ID | title | status | assignee | priority | date */
 ```
+
+### Border Radius by Element
+
+Single source of radius decisions. Pick by element role — never by visual feel.
+
+| Element                                      | Radius   | Notes                                                           |
+| -------------------------------------------- | -------- | --------------------------------------------------------------- |
+| Card / Page-section panel                    | `8px`    | `.admin-card`, drawer body                                      |
+| Modal / Drawer outer surface                 | `12px`   | top corners only on bottom-anchored sheets                      |
+| Button                                       | `6px`    | primary, secondary, `.admin-btn`                                |
+| Input / Select / Search                      | `6px`    | `.faq-search`, admin form fields                                |
+| Pill (filter chip, tag pill, count badge)    | `9999px` | `--chip-radius-pill`                                            |
+| Rounded chip (status badge)                  | `4px`    | `--chip-radius-rounded`, `.role-pill`, `.notice-badge`          |
+| Status dot                                   | `50%`    | `.status-dot`                                                   |
+| Avatar (mini)                                | `50%`    | always perfect circle                                           |
+
+> If a new element type is introduced, choose the closest row above. Do not invent intermediate radii.
 
 ---
 
@@ -685,19 +730,19 @@ Full token set — copy into `:root` as the single source of truth.
   --status-drop-fg: light-dark(oklch(50% 0.16 68), oklch(72% 0.16 72));
   --status-drop-border: light-dark(oklch(80% 0.065 72), oklch(33% 0.068 70));
 
-  /* VOC row state backgrounds (Wave 1.6 Phase B — prototype list.css:L83/L90) */
+  /* VOC row state backgrounds */
   --voc-row-hover-bg: light-dark(oklch(94% 0.014 257), oklch(21% 0.028 261));
   --voc-row-selected-bg: light-dark(oklch(90% 0.03 260), oklch(24% 0.042 262));
 
-  /* Mini-avatar palette — muted, distinct from brand blue (prototype list.css:L289–L303) */
+  /* Mini-avatar palette — muted, distinct from brand blue */
   --avatar-steel: oklch(44% 0.08 255);
   --avatar-teal: oklch(42% 0.1 155);
   --avatar-violet: oklch(42% 0.1 300);
 
-  /* Inline highlight (`<mark>`, prototype misc.css:L17) */
+  /* Inline highlight (`<mark>`) */
   --mark-bg: oklch(75% 0.16 72 / 0.35);
 
-  /* Role pill — Admin · Manager · Dev · User (D18 / D20, 2026-04-26) */
+  /* Role pill — Admin · Manager · Dev · User */
   /* admin / manager / user reuse existing brand & status tokens; only `dev` requires net-new tokens. */
   --role-dev-fg: light-dark(
     oklch(40% 0.13 215),
@@ -810,15 +855,15 @@ where α = lerp(0.06, 0.62, value / maxValue)
 
 ### 12.1 Single Source of Truth
 
-All design tokens originate from `frontend/src/tokens.ts`. This file is the only place where raw values (hex, OKLCH, px) are allowed to appear.
+All design tokens have a single source — the canonical `:root` block in §10. Every Tailwind utility and CSS variable derives from there. Raw color/typography/dimension literals must never appear outside that block.
 
 ```
-tokens.ts  (raw values live here — only place hex/OKLCH is permitted)
-    ├── tailwind.config.ts   → utility classes  (bg-brand, text-primary, …)
-    └── CSS custom properties → var(--brand), var(--bg-app), …
+canonical token block (§10)
+    ├── Tailwind utility classes  (bg-brand, text-primary, …)
+    └── CSS custom properties     (var(--brand), var(--bg-app), …)
 ```
 
-Both Tailwind utilities and CSS vars are generated from `tokens.ts`. Editing a token in `tokens.ts` propagates to both surfaces automatically.
+Editing a token at the source propagates to both surfaces automatically.
 
 ### 12.2 When to Use Tailwind Utilities vs CSS Vars
 
@@ -826,35 +871,16 @@ Both Tailwind utilities and CSS vars are generated from `tokens.ts`. Editing a t
 | ----------------------------------------------- | ---------------- | -------------------------------------------- |
 | Layout, spacing, flex, grid                     | Tailwind utility | `flex gap-2 px-4`                            |
 | Static color on a standard element              | Tailwind utility | `bg-brand text-primary`                      |
-| Dynamic color via JS (charts, Toast UI, canvas) | CSS var via JS   | `tokens.brand` imported from `tokens.ts`     |
+| Dynamic color via JS (charts, Toast UI, canvas) | CSS var via JS   | `var(--brand)` resolved at runtime           |
 | Inline style override in JSX                    | CSS var          | `style={{ color: 'var(--text-secondary)' }}` |
 | Theme-aware color in custom CSS / `@apply`      | CSS var          | `color: var(--text-primary)`                 |
 
-**Rule:** never write a raw hex or OKLCH value outside of `tokens.ts`. If a token does not exist for what you need, add it to `tokens.ts` + this file first, then use it.
+**Rule:** never write a raw hex or OKLCH value outside the §10 token block. If a token does not exist for what you need, add it there first, then use it.
 
-### 12.3 Token File Structure
+### 12.3 Enforcement
 
-```ts
-// frontend/src/tokens.ts
-export const colors = {
-  brand:        '#0f62fe',   // Samsung Blue
-  bgApp:        'oklch(12% 0.01 250)',
-  // …
-} as const;
-
-export const spacing = { … } as const;
-export const fontSize = { … } as const;
-
-// Re-export flat map for Tailwind config consumption
-export default { colors, spacing, fontSize };
-```
-
-### 12.4 Enforcement
-
-- **Stylelint `declaration-strict-value`** — rejects raw color/font values in `.css` / `.module.css` files; only `var(--*)` or Tailwind utility classes pass.
-- **ESLint `no-restricted-syntax`** — rejects inline `style={{ color: '#...' }}` in JSX.
-- **Pre-commit hook (husky + lint-staged)** — runs both linters; commit is rejected if violations exist.
-- CI runs the same lint check and blocks merge on failure.
+- Linting rejects raw color/font literals in stylesheets and inline `style={{ … }}` props — only `var(--*)` or Tailwind utility classes pass.
+- Pre-commit and CI both run the lint gate; violations block merge.
 
 OS/browser dark mode setting automatically switches the entire theme.
 
@@ -875,13 +901,13 @@ Three archetypes cover all VOC badge use cases. Additional archetypes require a 
 
 | Archetype       | Background                      | Border                              | Icon                                            | Border-radius           | Used for                                                                                                                                                                                                                             |
 | --------------- | ------------------------------- | ----------------------------------- | ----------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **TextMark**    | none                            | none                                | lucide (domain-specific) or `#` glyph (xs only) | n/a                     | Semantic color signal, no chip container. Priority, Type, **Tag (size='xs')**. **[AMENDED 2026-05-02 post-PR-144]** size variant `'sm' \| 'xs'` — `'xs'` (10.5px) used by VocTagPill, no fixed cell height.                          |
-| **OutlineChip** | `var(--brand-bg)`               | `var(--brand-border)`               | structural glyph or lucide                      | `--chip-radius-pill`    | Neutral labeled chip for dynamic content. **[AMENDED 2026-05-02 post-PR-144]** No current VOC consumer — primitive retained for future tag-like use cases requiring chip prominence (e.g. Jira-imported source badge, filter pills). |
+| **TextMark**    | none                            | none                                | lucide (domain-specific) or `#` glyph (xs only) | n/a                     | Semantic color signal, no chip container. Priority, Type, **Tag (size='xs')**. Size variant `'sm' \| 'xs'` — `'xs'` (10.5px) used by VocTagPill, no fixed cell height.                                                                |
+| **OutlineChip** | `var(--brand-bg)`               | `var(--brand-border)`               | structural glyph or lucide                      | `--chip-radius-pill`    | Neutral labeled chip for dynamic content. No current VOC consumer — primitive retained for future tag-like use cases requiring chip prominence (e.g. Jira-imported source badge, filter pills).                                       |
 | **SolidChip**   | semantic (`--status-{slug}-bg`) | semantic (`--status-{slug}-border`) | dot only                                        | `--chip-radius-rounded` | Status with filled background. Status.                                                                                                                                                                                               |
 
 ### 13.2 Shared dimension tokens (`--chip-*`)
 
-These tokens are defined in `frontend/src/styles/index.css` `:root` and shared between all primitives and interactive chip components. Color tokens are **not** shared — each component owns its own color logic.
+These tokens are exposed at `:root` in the canonical token block (§10) and shared between all primitives and interactive chip components. Color tokens are **not** shared — each component owns its own color logic.
 
 ```css
 --chip-height-sm: 20px; /* consistent row-height budget across all badge/chip types */
@@ -889,12 +915,12 @@ These tokens are defined in `frontend/src/styles/index.css` `:root` and shared b
 --chip-radius-pill: 9999px; /* full pill — OutlineChip, FilterChip */
 --chip-radius-rounded: 4px; /* rectangular — SolidChip */
 --chip-font-size-sm: 11.5px; /* metadata tier (§7 VOC List Typography Tiers) */
---chip-font-size-xs: 10.5px; /* compact text-only marks (Tag pill) — added post-PR-144 visual review */
+--chip-font-size-xs: 10.5px; /* compact text-only marks (Tag pill) */
 --chip-gap: 4px; /* gap between icon and text */
 --chip-dot-size: 6px; /* status dot diameter in SolidChip */
 ```
 
-These 7 tokens ship in **B-add-2** (Phase B addendum PR), per §5.1 ≥4-token policy from `wave-1-6-phase-c-precedent.md`. Implementation primitives ship in C-2.6, after B-add-2 is merged.
+All 7 tokens are shared dimension primitives — color tokens stay scoped per archetype.
 
 ### 13.3 TextMark spec
 
@@ -910,7 +936,7 @@ font-size: var(--chip-font-size-sm);
 - `icon-only` mode: render icon only; `aria-label` carries the text label
 - `icon+text` mode: render icon + label side by side
 - Color = text color only (no background fill)
-- **size variant** (added 2026-05-02 post-PR-144): `'sm'` (11.5px, default, used by Priority/Type) or `'xs'` (10.5px, used by VocTagPill — no fixed cell height; flows at natural line height for the "quiet/recede" tag visual)
+- **size variant**: `'sm'` (11.5px, default, used by Priority/Type) or `'xs'` (10.5px, used by VocTagPill — no fixed cell height; flows at natural line height for the "quiet/recede" tag visual)
 - **icon prop** widened to `LucideIcon | '#'` — `'#'` is a literal glyph used by VocTagPill at `size='xs'` (not a lucide icon)
 - **weight prop** is wrapper-controlled (numeric `400|500|600|700`); the primitive does not encapsulate per-variant weight (rationale: weight is determined by domain wrapper — see audit §2.1 amended note)
 
@@ -959,9 +985,9 @@ Dot element:
 ### 13.6 Prop surface (closed set — all archetypes)
 
 - `variant`: enum only — no free `color` prop
-- `size`: `'sm' | 'xs'` — `'sm'` default; `'xs'` added post-PR-144 for TextMark-only (VocTagPill). `'md'` still reserved — opening requires a separate audit (closed-prop-surface principle)
+- `size`: `'sm' | 'xs'` — `'sm'` default; `'xs'` is TextMark-only (VocTagPill). `'md'` reserved — opening requires a separate audit (closed-prop-surface principle)
 - `iconMode` + `icon`: only customization surface for TextMark
-- `bold` / `font-weight`: **wrapper-controlled** for TextMark (numeric `400|500|600|700`, set by domain wrapper); fixed for OutlineChip (600) and SolidChip (600). Callsites in `features/voc/**` still never set weight directly — they call the wrapper. **[AMENDED 2026-05-02 post-PR-144 visual review — original: "fixed per archetype — callsite cannot override"]**
+- `bold` / `font-weight`: **wrapper-controlled** for TextMark (numeric `400|500|600|700`, set by the domain wrapper); fixed for OutlineChip (600) and SolidChip (600). VOC callsites never set weight directly — they call the wrapper.
 
 ### 13.7 Interactive components — token sharing boundary
 
@@ -969,7 +995,7 @@ Dot element:
 
 ## 14. Admin · Notice · FAQ Components
 
-> Added 2026-04-26 (D20). Closes the gap between `prototype/prototype.html` and the formal design system. Every rule below MUST consume `var(--token)` only — no raw `oklch(...)` or hex literals.
+> Visual contract for Admin / Notice / FAQ surfaces. Every rule below MUST consume `var(--token)` only — no raw `oklch(...)` or hex literals.
 
 ### 14.1 Admin Topbar / Body / Card
 
@@ -1036,7 +1062,7 @@ Iconography: optional 13×13 SVG icon at the leading edge.
 
 ### 14.3 Role Pill (`.role-pill`)
 
-Compact identity badge shown next to display name in user lists, member pickers, and the topbar avatar tooltip. Four variants for the four-role enum (D18).
+Compact identity badge shown next to display name in user lists, member pickers, and the topbar avatar tooltip. Four variants for the four-role enum (Admin / Manager / Dev / User).
 
 ```css
 .role-pill {
@@ -1086,7 +1112,7 @@ Small label used in the Admin VOC-Types table to render the `voc_types.color` sw
 }
 ```
 
-> Token-color contract: `voc_types.color` stored as the **token name** (e.g. `--type-bug`) referenced from the global token sheet — not as a raw hex. Migration follow-up if current schema stores hex.
+> Token-color contract: the type badge MUST consume a token name (e.g. `--type-bug`) from the global token sheet, never a raw hex. Storage/migration of the underlying value is owned by `requirements.md`.
 
 ### 14.5 Status Dot (`.status-dot`)
 
@@ -1219,14 +1245,12 @@ Three severity tiers — every Notice list row leads with one of these.
 
 ### 14.8 Admin Mode Entry Button (Page Header Action Slot)
 
-> Added in tandem with `feature-notice-faq.md §10.5` (D19). Replaces the previously-planned Admin-tab subtab.
+> Visual contract only. Routing/state contract (URL query param, browser history, link shareability, admin-vs-read mode flip) lives in `feature-notice-faq.md §10.5`.
 
 - Renders **only** for `role ∈ {admin, manager}`. User/Dev never receive this DOM node — guard at the component tree, not via `display: none`.
 - Visual: reuse `.admin-btn` from §14.2.1.
-- Activation contract: clicking the button flips a `?mode=admin` URL query param. Read mode is the absence of the param. The toggle MUST survive page reload, browser back/forward, and shareable links.
-- When `mode=admin`, the host page (Notice / FAQ) renders inline admin actions: register/edit/delete row controls, visibility toggle switch, Soft-Delete button. The page route does not change.
+- When admin mode is active, the host page (Notice / FAQ) renders inline admin actions in the same DOM tree (register/edit/delete row controls, visibility toggle switch, Soft-Delete button). The page route does not change.
 - Recommended placement: right edge of the page header band, vertically aligned with the page title. On widths < 640px the button collapses to icon only (gear glyph) without changing semantics.
-- Implementation note (FE): admin-only handlers and form components MUST be loaded via dynamic `import()` so they do not ship in the user/Dev bundle.
 
 ### 14.9 Login-time Notice Popup
 
@@ -1286,3 +1310,58 @@ Usage: apply via `.rv-diff-row.added`, `.rv-diff-row.removed`, `.rv-diff-row.cha
 Unchanged rows (`.rv-diff-row.same`) use `transparent` background and `var(--text-secondary)` text — no dedicated token needed.
 
 Class ↔ token mapping: `.rv-diff-row.added` → `--diff-add-*`, `.rv-diff-row.removed` → `--diff-del-*`, `.rv-diff-row.changed` → `--diff-mod-*`. Class names use full English words; token prefix uses 3-letter shorthand.
+
+---
+
+## 15. Agent Prompt Guide
+
+> Quick lookups for AI agents and humans drafting components. Every value below is **token-only** — never paste raw hex/OKLCH into generated code.
+
+### Quick Token Reference
+
+| Role             | Token                                  |
+| ---------------- | -------------------------------------- |
+| Page background  | `var(--bg-app)`                        |
+| Panel / sidebar  | `var(--bg-panel)`                      |
+| Card surface     | `var(--bg-surface)`                    |
+| Hover / popover  | `var(--bg-elevated)`                   |
+| Primary text     | `var(--text-primary)`                  |
+| Secondary text   | `var(--text-secondary)`                |
+| Muted metadata   | `var(--text-tertiary)` / `--text-quaternary` |
+| Brand / CTA      | `var(--brand)` (filled) · `var(--accent)` (link/active) |
+| Brand tint bg    | `var(--brand-bg)`                      |
+| Border (subtle)  | `var(--border-subtle)`                 |
+| Border (default) | `var(--border-standard)`               |
+| Status: red/amber/green/sky | `var(--status-{red\|amber\|green\|sky})` |
+
+### Component Example Prompts
+
+Use these as templates when generating new components. They reference only tokens — copy-paste ready.
+
+**1. Primary CTA button**
+> Filled button with `background: var(--brand)`, `color: var(--text-on-brand)`, font Pretendard Variable weight 600 at 14px, `border-radius: 6px`, padding `8px 16px`. Hover: `background: var(--accent-hover)`. Disabled: `opacity: 0.5; cursor: not-allowed`.
+
+**2. Secondary / ghost button**
+> Transparent background, `color: var(--accent)`, `border: 1px solid var(--brand-border)`, `border-radius: 6px`, padding `6px 12px`. Hover: `background: color-mix(in oklch, var(--brand-bg) 80%, var(--accent) 10%)`.
+
+**3. Card (page-section panel)**
+> `background: var(--bg-surface)`, `border: 1px solid var(--border-standard)`, `border-radius: 8px`, padding `var(--sp-4)`. Title at 15px / weight 700 / `color: var(--text-primary)`; body at 14px / 400 / `var(--text-secondary)`. Cards stack with `var(--sp-5)` gap.
+
+**4. Sidebar nav item**
+> `display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-radius: 6px; font-size: 13.5px; color: var(--text-secondary)`. Hover: `background: var(--bg-elevated); color: var(--text-primary)`. Active: `background: var(--brand-bg); color: var(--accent); font-weight: 600`.
+
+**5. Input field**
+> `background: var(--bg-elevated)`, `color: var(--text-primary)`, `border: 1px solid var(--border-subtle)`, `border-radius: 6px`, padding `6px 11px`, font Pretendard Variable 13px. Focus: `border-color: var(--accent); box-shadow: 0 0 0 2px var(--brand-bg); outline: none`.
+
+**6. Status badge (SolidChip)**
+> `display: inline-flex; align-items: center; gap: 4px; height: 20px; padding: 0 8px; border-radius: 4px; font-size: 11.5px; font-weight: 600`. Background `var(--status-{slug}-bg)`, color `var(--status-{slug}-fg)`, border `1px solid var(--status-{slug}-border)`. Leading 6px dot in matching status color.
+
+### Hard rules — agents must enforce
+
+- ❌ Raw hex or OKLCH outside the §10 `:root` block
+- ❌ Pure `#fff` / `#000` (use `var(--text-on-brand)` / token equivalents)
+- ❌ Inline `style={{ color: '#…' }}` — always `var(--token)`
+- ❌ Card wrappers around page-level tables / lists / accordions (cards = floating UI only)
+- ❌ Mixed shadow tokens on one element — raise the surface level instead
+- ✅ Every color comes from `var(--…)`; every spacing from `--sp-*`; every radius from §7 "Border Radius by Element"
+- ✅ Light and dark must both be tested before considering a component done

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -17,19 +17,15 @@ npm run test                             # Vitest
 npm run test -- path/to/file.test.ts     # Single test file
 ```
 
-## Implementation Reference (2026-05-09~)
+## Implementation Flow
 
-정본은 `docs/specs/requires/requirements.md` + `docs/specs/requires/uidesign.md` 두 문서뿐. `prototype/` 디렉터리는 더 이상 reference 가 아니다 (parity·픽셀·DOM 인용 금지).
+Spec/디자인 정본·정책은 root `CLAUDE.md` 참조. FE 화면 구현 순서:
 
-화면 구현 시:
-
-- requirements.md 의 화면/기능 사양 → uidesign.md 의 토큰·레이아웃·상태로 치환
-- Reuse existing components first; 새 컴포넌트는 UI/로직 반복 시에만
-- 페이지 컴포넌트는 작게, Tailwind 중복은 `@apply` / 컴포넌트로 추출
-- 데이터가 있는 경우 TypeScript 타입 먼저 (no `any`)
-- 항상 처리: loading / error / empty / hover / focus / responsive
-
-Flow: read requirements + uidesign → map components → define types → build with dummy data → wire interactions → connect API → polish states/responsive.
+1. requirements + uidesign 읽기 → 컴포넌트 매핑 → 타입 정의 (no `any`)
+2. dummy data 로 빌드 → interaction → API 연결 → states/responsive 마무리
+3. Reuse existing components first; 새 컴포넌트는 UI/로직 반복 시에만
+4. 페이지 컴포넌트는 작게, Tailwind 중복은 `@apply` 또는 컴포넌트로 추출
+5. 항상 처리: loading / error / empty / hover / focus / responsive
 
 ## Architecture
 
@@ -40,25 +36,9 @@ Flow: read requirements + uidesign → map components → define types → build
 
 ## Styling Architecture
 
-Token pipeline: `src/tokens.ts` → `tailwind.config.ts` (utility classes) + CSS custom properties (`var(--*)`)
+FE token pipeline: `src/tokens.ts` 가 raw 값의 단일 source — 여기서 `tailwind.config.ts` (utility) + CSS custom properties (`var(--*)`) 두 surface 가 생성된다. 새 토큰이 필요하면 `tokens.ts` + `uidesign.md` 양쪽을 같은 PR(또는 직전 PR)에서 갱신.
 
-Full token reference: `docs/specs/requires/uidesign.md §10 CSS Reference` and `§12 Token Architecture`.
-
-**When to use which:**
-
-- Layout / spacing / flex / grid → Tailwind utility (`flex gap-2 px-4`)
-- Static color on a standard element → Tailwind utility (`bg-brand text-primary`)
-- Dynamic color passed to JS (charts, Toast UI, canvas) → import from `tokens.ts` directly
-- Inline style in JSX → CSS var (`style={{ color: 'var(--text-secondary)' }}`)
-- Custom CSS / `@apply` → CSS var (`color: var(--text-primary)`)
-
-**Hard rules:**
-
-- Never write hex or raw OKLCH values outside of `src/tokens.ts`
-- If a token doesn't exist for what you need, add it to `src/tokens.ts` + `uidesign.md §12` first, then use it
-- Never duplicate a token value — one source, two surfaces (Tailwind + CSS vars)
-
-Key tokens: `var(--bg-app)` / `var(--bg-panel)` / `var(--bg-surface)` / `var(--brand)` / `var(--accent)` / `var(--text-primary)` / `var(--text-secondary)`
+토큰 정의·use rule·Tailwind vs CSS var 사용 매트릭스 정본: `docs/specs/requires/uidesign.md` (§10/§12). 룰은 root `CLAUDE.md` 가 정본.
 
 ## Conventions
 

--- a/prototype/CLAUDE.md
+++ b/prototype/CLAUDE.md
@@ -29,18 +29,9 @@ Open `prototype.html` directly in a browser, or serve the directory:
 npx http-server prototype -p 8080
 ```
 
-## Design Tokens (authoritative — echoed here because this is a rendered visual surface)
+## Design Tokens
 
-Full reference: `docs/specs/requires/uidesign.md §10 CSS Reference`. Every color, spacing, and typography value must go through a CSS custom property:
-
-- **Background (OKLCH, blue-tinted):** `var(--bg-app)` / `var(--bg-panel)` / `var(--bg-surface)` / `var(--bg-elevated)`
-- **Brand accent (Samsung Blue):** `var(--brand)` / `var(--accent)` / `var(--accent-hover)` — **never the old Linear indigo `#5e6ad2`**
-- **Text:** `var(--text-primary)` / `var(--text-secondary)` / `var(--text-tertiary)` / `var(--text-quaternary)`
-- **Typography:** Pretendard Variable (UI), D2Coding (code/issue IDs)
-- **Spacing:** 8px grid base; max content width ~1200px
-- **Elevation:** via background opacity (`rgba(255,255,255,0.05)`) — multi-layer shadow only for dialogs
-
-**Hard rule:** **never hardcode hex or raw OKLCH values** in prototype HTML. If a token doesn't exist, add it to `uidesign.md` first, then use it here. A prototype with hex values silently drifts from the real design system.
+토큰 정의·use rule·hex/OKLCH 금지 룰은 root `CLAUDE.md` + `docs/specs/requires/uidesign.md` 정본을 그대로 따른다. 본 디렉토리는 rendered visual surface 라 토큰을 직접 소비하지만, 룰을 여기 복제하지 않는다.
 
 ## graphify
 


### PR DESCRIPTION
## Summary

- **uidesign.md leak 16건 제거** — prototype 레퍼런스 4 · FE 구현 경로 5 · 빌드툴 1 · Wave/Phase/PR 이력 3 · 동작·schema contract 3
- **구조 보강 (Linear DESIGN.md 형식 검토 반영, AI followability)** — Surfaces level numbering · Type Scale 컬럼 보강 · Spacing 토큰 표 · Shadows 표 · Border Radius by Element 표 · §15 Agent Prompt Guide 신설
- **룰 단일 출처** — uidesign.md scope 정책을 root CLAUDE.md 한 곳에만 정의, AGENTS.md / frontend·prototype CLAUDE.md 의 룰 중복 제거. CLAUDE.md 197→114줄

토큰 value 변경 0건. 5개 governance 파일 + 1개 progress = 총 6 파일.

## Test plan

- [x] `rg "prototype|frontend/src|\.tsx|husky|lint-staged|Stylelint|AMENDED|post-PR-144|B-add-2" docs/specs/requires/uidesign.md` → 0 hit (revision history 의 메타 기록 제외)
- [x] CLAUDE.md ≤ 200 lines (114)
- [x] pre-push 훅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)