### PR TITLE
fix(w3-3): recover codex P1 fixes lost during PR #252 merge race

### DIFF
--- a/backend/src/__tests__/admin-contract.test.ts
+++ b/backend/src/__tests__/admin-contract.test.ts
@@ -179,4 +179,15 @@ describe('admin contract — user domain', () => {
     expectRequiredSubset('UserRoleLogEntry', Admin.UserRoleLogEntry as unknown as AnyZodObject);
     expectNullableSubset('UserRoleLogEntry', Admin.UserRoleLogEntry as unknown as AnyZodObject);
   });
+  test('AdminUserPatch openapi anyOf constraint mirrors zod refine (at least one of role/is_active)', () => {
+    // If this fails, openapi allows {} which zod .refine() rejects at runtime.
+    const schema = doc.components?.schemas?.['AdminUserPatch'] as SchemaShape & {
+      anyOf?: Array<{ required?: string[] }>;
+    };
+    expect(schema).toBeDefined();
+    expect(schema.anyOf).toBeDefined();
+    const covered = (schema.anyOf ?? []).flatMap((s) => s.required ?? []);
+    expect(covered).toContain('role');
+    expect(covered).toContain('is_active');
+  });
 });

--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -1778,8 +1778,9 @@ paths:
                 $ref: '#/components/schemas/TrashListResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
+        '404':
+          # ADR 0004 §3: Trash hidden from non-admin as 404 ("존재 자체 은닉"), not 403.
+          $ref: '#/components/responses/NotFound'
 
   /admin/vocs/{id}/restore-log:
     parameters:
@@ -3352,7 +3353,11 @@ components:
         total: { type: integer, minimum: 0 }
 
     AdminUserPatch:
+      # At least one of `role` / `is_active` required (mirrors zod .refine()).
       type: object
+      anyOf:
+        - required: [role]
+        - required: [is_active]
       properties:
         role: { $ref: '#/components/schemas/UserRole' }
         is_active: { type: boolean }


### PR DESCRIPTION
## Summary

Recovers two codex P1 fixes that were lost when a force-push race overwrote commit `0724825` during the PR #252 merge cycle.

- `AdminUserPatch` openapi schema: add `anyOf:[required:[role], required:[is_active]]` to mirror the zod `.refine()` invariant (parity test added).
- `GET /admin/vocs/trash` response: 403 → 404 per ADR 0004 §3 ("존재 자체 은닉").

Both originated from the codex adversarial review on PR #252 and were applied locally by the W3-3 agent but never landed on main due to a force-push from a parallel session that didn't include them.

## Test plan
- [x] BE typecheck + jest (pre-push hook green: 18 suites / 188 passed)
- [ ] CI: build-fe / build-be / fixture-seed-parity / fonts (lint-root pre-existing fail tolerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)