### PR TITLE
docs: CLAUDE.md fully English + hook fires on merge only

### DIFF
--- a/.claude/hookify.warn-doc-cleanup-before-pr.local.md
+++ b/.claude/hookify.warn-doc-cleanup-before-pr.local.md
@@ -2,26 +2,23 @@
 name: warn-doc-cleanup-before-pr
 enabled: true
 event: bash
-pattern: gh\s+pr\s+(create|merge)
+pattern: gh\s+pr\s+merge
 ---
 
-**Pre-PR doc cleanup reminder** (canonical: `docs/specs/README.md`)
+**Pre-merge doc cleanup reminder** — fires only on `gh pr merge`.
 
-**Scope: phase-close or wave-close PRs only.** Intra-phase / leaf / batch PRs are exempt — skip steps 1–7 and run only step 8 (typecheck/lint). This keeps the doc-sync cost off every leaf PR (see Working Style "Progress docs at phase/wave close only" in root `CLAUDE.md`).
+**Scope: phase-close / wave-close PR only.** Intra-phase / leaf / batch PR is exempt — skip the checklist and just verify typecheck / lint / test.
 
 If this PR closes a phase or a wave, do this once before the merge:
 
-1. Update first 30 lines of `claude-progress.txt` — reflect this PR in the next-session entry point. Remove phase entries no longer needed (active context only).
-2. Update `docs/specs/plans/next-session-tasks.md` — ✅ closed items, state next entry point.
-3. `git mv` review docs under `docs/specs/reviews/` to `docs/specs/archive/reviews/` if no longer needed (archives are not canonical).
-4. `git mv` finished plans under `docs/specs/plans/` to `docs/specs/archive/plans/`.
-5. If a merged phase is quoted by an active doc, inline the fact or keep only a link (no archive citations).
-6. Append a one-line Changelog entry to the relevant `phase-*.md` (date + ID + summary).
-7. **CLAUDE.md 8-keep set** — only `root`, `.claude`, `frontend`, `backend`, `frontend/src`, `backend/src`, `docs`, `prototype`. Update one of these only if its `## Role` / `## When to look where` changed in this PR.
-   - No new leaf CLAUDE.md outside the 8-keep set — fold any directory guidance into the nearest ancestor.
-   - No stub on delete — `→ ancestor.md` one-liners are auto-loaded noise.
-8. Re-verify typecheck/lint clean.
+1. `claude-progress.txt` (first 30 lines) — reflect this PR, point to the next entry, drop entries that are no longer active context.
+2. `docs/specs/plans/next-session-tasks.md` — mark closed items ✅, state the next entry point.
+3. `git mv` reviews / plans whose decision has been absorbed into canonical spec (`requires/`) or an ADR to `docs/specs/archive/{reviews,plans}/`.
+4. If a merged phase is cited by an active doc, inline the fact or keep a single link. Never cite archive paths as canonical.
+5. Add a one-line summary (date + ID + outcome) to the active wave plan (`wave-3-admin.md` etc.) §Changelog or to the PR description. Do not create new changelog files — git log + PR description is the source of truth.
+6. **CLAUDE.md 7-keep set** — `root` · `.claude` · `frontend` · `frontend/src` · `backend` · `backend/src` · `prototype`. Update a sub-CLAUDE.md only if its `## Role` / `## When to look where` actually changed in this PR. No new leaf CLAUDE.md outside the 7-keep set. On delete, do not leave stubs (`→ ancestor.md`).
+7. Re-verify typecheck / lint / test green (`.claude/CLAUDE.md` test batch).
 
-**Exceptions:** `docs/<topic>` branch or trivial 1-line fixes may skip. User decides.
+**Exceptions:** `docs/<topic>` branch or trivial 1-line fixes — user decides whether to skip.
 
-**Fires once before `gh pr create` or `gh pr merge`.** If done already, ignore.
+If already done, ignore.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,45 +9,45 @@ VOC (Voice of Customer) management system. Three-tier: React SPA → Express RES
 - Design: `docs/specs/requires/uidesign.md`
 - Sub-dir maps: `frontend/CLAUDE.md`, `backend/CLAUDE.md` (consult before editing in those trees)
 
-Implementation reference (2026-05-09~): `requirements.md` + `uidesign.md` only. `prototype/` is no longer a visual/behavior reference — pixel/DOM/CSS citation forbidden.
+Implementation reference (2026-05-09~): `requirements.md` + `uidesign.md` only. `prototype/` is no longer a visual / behavior reference — pixel / DOM / CSS citation forbidden.
 
 ## Design System (canonical)
 
 Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture, §15 Agent Prompt Guide).
 
-- All colors via `var(--token)` — never hex/OKLCH literals
-- Typography: Pretendard Variable (UI), D2Coding (code/issue IDs)
+- All colors via `var(--token)` — never hex / OKLCH literals
+- Typography: Pretendard Variable (UI), D2Coding (code / issue IDs)
 - 8px grid, max-width ~1200px, elevation via background opacity not shadow darkness
 
-### `uidesign.md` 단독 정책 (이 한 곳에서만 정의 — 복제 금지)
+### `uidesign.md` exclusivity (defined here only — no duplication)
 
-**포함**: 토큰 정의·use rule, 컴포넌트 visual contract, §15 Agent Prompt Guide.
-**금지**: 구현 경로(`frontend/src/...`, `*.tsx`, `tokens.ts`) · 빌드/린트 툴명(Stylelint/ESLint/husky) · Wave/Phase/PR 번호·날짜 · 동작·라우팅·상태 contract(→ `feature-*.md`) · 스키마·migration(→ `requirements.md`). 발견 시 leak 으로 즉시 분리.
+**In scope:** token definitions and use rules, component visual contracts, §15 Agent Prompt Guide.
+**Out of scope:** implementation paths (`frontend/src/...`, `*.tsx`, `tokens.ts`) · build / lint tool names (Stylelint / ESLint / husky) · Wave / Phase / PR numbers / dates · behavior / routing / state contracts (→ `feature-*.md`) · schema / migration (→ `requirements.md`). If found, treat as a leak and split immediately.
 
-**FE 작업 절대 룰**: visual surface 를 만지면 `uidesign.md` 를 먼저 읽고 기존 토큰 contract 를 확인한 뒤 코드 작성. 새 토큰이 필요하면 spec 갱신을 같은 PR(또는 직전 PR)에서 끝낸다. 컴포넌트 신설은 §15 예시를 베이스로.
+**FE absolute rule:** when touching a visual surface, read `uidesign.md` first to confirm existing token contracts, then write code. New tokens require a spec update in the same PR (or the PR immediately preceding). New components start from a §15 example.
 
 ## Start Every Session
 
 1. `claude-progress.txt` (first 30 lines)
-2. `next-session-tasks.md` for current Phase
+2. `next-session-tasks.md` for the current Phase
 3. Relevant spec selectively
-4. Memory index `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — purge entries already in specs/git
+4. Memory index `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — purge entries already in specs / git
 
 ## Core Rules
 
 - **Tool routing**:
-  - TS/TSX symbol/refs/rename → Serena
-  - Cross-file keyword/file discovery → `rg -n`
-  - Small known range → `Read` with `offset/limit`
+  - TS / TSX symbol / refs / rename → Serena
+  - Cross-file keyword / file discovery → `rg -n`
+  - Small known range → `Read` with `offset / limit`
   - Architecture / dependency flow → Graphify (required once before wide refactor or unfamiliar feature)
-  - Never `cat <file>` to dump source; never `Read` whole TS/TSX file when `find_symbol` works; never re-read a file already in context (modified files OK)
+  - Never `cat <file>` to dump source; never `Read` whole TS / TSX file when `find_symbol` works; never re-read a file already in context (modified files OK)
 - **Parallel tool calls**: independent calls go in one message. Gate: "Can I write call B's args before A runs?" — if yes, batch. Common violations + exceptions: `.claude/specs/parallel-dispatch.md`.
 - **Tail test output**: `| tail -20`; never full traces
 - **No Read before delete**: just `rm`
 - **First-pass git log**: `--all` + wide keywords; never narrow on retry
 - **Minimum context for judgment**: single most relevant file first
-- **Before editing**: summarize selected files/symbols + why
-- **Git workflow**: feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) **before** any change; never push to main; PRs opened by user; merge with `gh pr merge <n> --merge --delete-branch` (squash/rebase forbidden); after merge `git branch -D <branch>`. Enforced by `.claude/hookify.block-*.local.md`.
+- **Before editing**: summarize selected files / symbols + why
+- **Git workflow**: feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) **before** any change; never push to main; PRs opened by user; merge with `gh pr merge <n> --merge --delete-branch` (squash / rebase forbidden); after merge `git branch -D <branch>`. Enforced by `.claude/hookify.block-*.local.md`.
 - Tests before commit; match nearby code style; YAGNI
 - This file stays under 200 lines
 
@@ -57,44 +57,44 @@ Every design decision → spec or ADR before session ends. Phase close → `clau
 
 ## Documents
 
-진행 상황 = `claude-progress.txt` (첫 30줄, current pointer) + `docs/specs/plans/next-session-tasks.md` (활성 작업 + 이연) + `docs/specs/plans/wave-3-admin.md` (활성 Wave 상세) + `docs/specs/plans/followup-bucket.md` (closed-wave 후속 FU-NNN). 영구 spec = `docs/specs/requires/`. 과거 이력은 git log + PR description (별도 파일 보관 금지). ID = Wave/Phase 정수 append-only, sub-decimal 금지, batch 그룹은 plan 표 column 일 뿐 ID 아님, closed wave 후속은 FU-NNN. 머지 시 `next-session-tasks.md` + `claude-progress.txt` 동기화.
+Progress = `claude-progress.txt` (first 30 lines, current pointer) + `docs/specs/plans/next-session-tasks.md` (active work + deferred) + `docs/specs/plans/wave-3-admin.md` (active wave detail) + `docs/specs/plans/followup-bucket.md` (closed-wave follow-ups, FU-NNN). Permanent specs = `docs/specs/requires/`. Past history lives in git log + PR descriptions — never in standalone changelog files. ID rules: Wave / Phase are append-only integers; sub-decimals forbidden; batch labels are plan-table column metadata, never part of the ID; closed-wave follow-ups go to `FU-NNN`. On merge: sync `next-session-tasks.md` + `claude-progress.txt`.
 
 ## Input Interpretation
 
-Before coding, frame: **Goal** (what + why, 1 line) · **Scope** (files in/out) · **Done when** (verifiable conditions) · **Constraints** (style/tokens/patterns). Skip for trivial one-liners.
+Before coding, frame: **Goal** (what + why, 1 line) · **Scope** (files in / out) · **Done when** (verifiable conditions) · **Constraints** (style / tokens / patterns). Skip for trivial one-liners.
 
 ## Working Style
 
 ### Reversibility gate
 
-- **Irreversible**: DB schema/migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms, file deletes, auth/billing/permissions/tenant boundary. → stop and ask, ≥90% confidence required.
-- **Reversible**: code/style/test in unmerged branch, file moves, naming, local refactors. → state assumption in 1 line, proceed, report in summary.
-- **Visual surface** (영향 `/voc`): `uidesign.md` 토큰·구조와 어긋나면 irreversible — 토큰 정의 변경은 spec 갱신 선결.
+- **Irreversible**: DB schema / migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms, file deletes, auth / billing / permissions / tenant boundary. → stop and ask, ≥90% confidence required.
+- **Reversible**: code / style / test in unmerged branch, file moves, naming, local refactors. → state assumption in 1 line, proceed, report in summary.
+- **Visual surface** (affecting `/voc`): if it diverges from `uidesign.md` tokens / structure, it is irreversible — token-definition changes require a spec update first.
 
 ### Engineering
 
-- **TDD for irreversible surface** (auth/billing/permissions/contracts/migrations/BE routes): test first, confirm fail, implement. Bug fix = failing regression test first. Stack: Vitest (FE) / Jest+Supertest (BE) — `requirements.md §3`.
+- **TDD for irreversible surface** (auth / billing / permissions / contracts / migrations / BE routes): test first, confirm fail, implement. Bug fix = failing regression test first. Stack: Vitest (FE) / Jest + Supertest (BE) — `requirements.md §3`.
 - **Smoke test for reversible UI**: one happy-path render test + visual-diff baseline.
 - **Debate, don't defer**: raise counterarguments before agreeing.
 - **Think before coding**: state assumptions; surface multiple interpretations.
 - **Simplicity first**; **surgical changes**; **goal-driven verification per step**.
 - **Pre-commit**: `npm run lint -w frontend` once before first commit.
-- **Progress docs at phase/wave close only** — intra-phase PRs exempt. `warn-doc-cleanup-before-pr` hookify 8-step checklist applies only on phase/wave-close PR.
+- **Progress docs at phase / wave close only** — intra-phase PRs exempt. The `warn-doc-cleanup-before-pr` hookify checklist applies on `gh pr merge` for phase / wave-close PRs only.
 
 ### Approval scope
 
-User approval covers its declared scope + reversible items inside. Plan approval → batches OK. Batch approval → leaves OK. Spec-derived → no extra approval. Re-ask on (1) new plan/batch, (2) irreversible not in spec, (3) user contradiction.
+User approval covers its declared scope + reversible items inside. Plan approval → batches OK. Batch approval → leaves OK. Spec-derived → no extra approval. Re-ask on (1) new plan / batch, (2) irreversible not in spec, (3) user contradiction.
 
-Completion language: leaves → report what landed, no "done"; phase/wave/PR-merge → wait for explicit user confirmation.
+Completion language: leaves → report what landed, no "done"; phase / wave / PR-merge → wait for explicit user confirmation.
 
 ## Refactoring
 
 Refactor = structure change without behavior change. Refactor + feature change MUST NOT land together.
 
-- **Before**: state symbols/files; ensure test coverage (write tests first if not).
+- **Before**: state symbols / files; ensure test coverage (write tests first if not).
 - **During**: `git mv` for moves; one refactor at a time.
 - **After (in order)**: update all references → `rg -n "<old>"` returns 0 → Serena ref-check on renames → typecheck → tests → exercise the surface.
-- **Escalate to `code-reviewer`** only on public API change, ≥3 modules, or DB schema/migration.
+- **Escalate to `code-reviewer`** only on public API change, ≥3 modules, or DB schema / migration.
 
 ## Graphify
 
@@ -105,7 +105,7 @@ Knowledge graph at `graphify-out/`. Use for architecture / dependency / cross-do
 - `benchmark/` — ground-truth PNGs (`01–22-…`) for `scripts/visual-diff.ts`. New screen = baseline + INDEX row.
 - `graphify-out/` — auto-generated, do not hand-edit. Refresh: `graphify update .`.
 - `scripts/` — utilities (`check-fixture-seed-parity.ts`, `shadcn-token-rewrite.ts`, `visual-diff.ts`).
-- `shared/` — `types/` (FE+BE entities/enums) · `contracts/` (zod schemas, single source) · `fixtures/` (MSW+seed, parity enforced) · `openapi.yaml` (REST contract reference).
+- `shared/` — `types/` (FE + BE entities / enums) · `contracts/` (zod schemas, single source) · `fixtures/` (MSW + seed, parity enforced) · `openapi.yaml` (REST contract reference).
 
 ## Agent skills
 


### PR DESCRIPTION
## Summary

- Root `CLAUDE.md` rewritten fully in English (was mixed Korean/English). 114 lines, under 200-line cap.
- `warn-doc-cleanup-before-pr` hook narrowed to `gh pr merge` only (drop `gh pr create`).
- Hook content updated post-cleanup PR #256: removed reference to deleted `specs/README.md`, dropped step 6 changelog-append (phase plans archived; git log + PR description is the source of truth), 8-keep set → 7-keep (no `docs/CLAUDE.md`).
- Hook also rewritten in English to match.

## Test plan

- [x] frontend lint + typecheck (pre-push hook)
- [x] frontend vitest 525 PASS
- [x] backend typecheck + jest 191 PASS
- [x] no Korean characters in `CLAUDE.md` or the hook (`rg [가-힣]` returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)