### PR TITLE
docs(claude-md): consolidate sections, English-only, drop stale status

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,18 +1,16 @@
 # .claude/CLAUDE.md
 
-**Root `CLAUDE.md` is authoritative.** This file contains only tool-specific supplements — not governance, not session ritual, not doc structure. If a rule appears in both files, root wins.
+Tool-specific supplements only. Root `CLAUDE.md` is authoritative — if a rule appears in both, root wins.
 
-## Token-Saving Protocol
+## Token-Saving
 
-- Use `limit=30` (or similar) when reading progress/state files
-- Check `git diff` for changes instead of re-reading full files
-- Reference external docs via links (don't duplicate into context)
-- **Test batch** — verify per workspace in a single call:
-  - FE: `npm run typecheck -w frontend && npm run test -w frontend -- --run | tail -20`
-  - BE: `npm run typecheck -w backend && npm run test -w backend | tail -20`
-  - If both sides touched, run the two commands as parallel bash in one message (root §"Parallel tool calls").
-  - Do not split tsc and vitest into separate calls.
+- Use `limit=30` (or similar) when reading progress / state files.
+- Check `git diff` for changes instead of re-reading full files.
+- Reference external docs via links — never duplicate into context.
 
-## Pointers
+## Test Batch (per workspace, single call)
 
-- Canonical docs → `docs/specs/` (the `requires/`, `plans/`, `reviews/` layout in root governs )
+- FE: `npm run typecheck -w frontend && npm run test -w frontend -- --run | tail -20`
+- BE: `npm run typecheck -w backend && npm run test -w backend | tail -20`
+- Both sides touched → run the two commands as parallel bash in one message (root §Engineering Rules).
+- Do not split `tsc` and Vitest / Jest into separate calls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,114 +1,95 @@
 # CLAUDE.md
 
-## Project
+## 1. Project & Documents
 
 VOC (Voice of Customer) management system. Three-tier: React SPA → Express REST → PostgreSQL/pgvector. Docker Compose runs all three.
 
-- Progress: `claude-progress.txt` (first 30 lines) → `docs/specs/plans/next-session-tasks.md`
-- Spec: `docs/specs/requires/requirements.md` + `feature-*.md`
-- Design: `docs/specs/requires/uidesign.md`
-- Sub-dir maps: `frontend/CLAUDE.md`, `backend/CLAUDE.md` (consult before editing in those trees)
+**Canonical sources:**
 
-Implementation reference (2026-05-09~): `requirements.md` + `uidesign.md` only. `prototype/` is no longer a visual / behavior reference — pixel / DOM / CSS citation forbidden.
+- Progress: `claude-progress.txt` (first 30 lines) + `docs/specs/plans/next-session-tasks.md` (active + deferred) + `docs/specs/plans/wave-3-admin.md` (active wave) + `docs/specs/plans/followup-bucket.md` (closed-wave follow-ups, `FU-NNN`).
+- Spec: `docs/specs/requires/requirements.md` + `feature-*.md`.
+- Design: `docs/specs/requires/uidesign.md`.
+- Sub-dir maps: `frontend/CLAUDE.md`, `backend/CLAUDE.md` (consult before editing in those trees).
 
-## Design System (canonical)
+**Implementation reference (2026-05-09~):** `requirements.md` + `uidesign.md` only. `prototype/` is no longer a visual / behavior reference — pixel / DOM / CSS citation forbidden.
 
-Full spec: `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture, §15 Agent Prompt Guide).
+**Document rules:**
 
-- All colors via `var(--token)` — never hex / OKLCH literals
-- Typography: Pretendard Variable (UI), D2Coding (code / issue IDs)
-- 8px grid, max-width ~1200px, elevation via background opacity not shadow darkness
+- Permanent specs in `docs/specs/requires/`. Past history lives in git log + PR descriptions — never in standalone changelog files.
+- ID rules: Wave / Phase are append-only integers; sub-decimals forbidden; batch labels are plan-table column metadata, never part of the ID.
+- On merge: sync `next-session-tasks.md` + `claude-progress.txt`.
+- `CLAUDE.md` / `MEMORY.md` writing: English only, objective and unambiguous, no supplementary commentary or hedging. Root `CLAUDE.md` stays under 200 lines.
 
-### `uidesign.md` exclusivity (defined here only — no duplication)
-
-**In scope:** token definitions and use rules, component visual contracts, §15 Agent Prompt Guide.
-**Out of scope:** implementation paths (`frontend/src/...`, `*.tsx`, `tokens.ts`) · build / lint tool names (Stylelint / ESLint / husky) · Wave / Phase / PR numbers / dates · behavior / routing / state contracts (→ `feature-*.md`) · schema / migration (→ `requirements.md`). If found, treat as a leak and split immediately.
-
-**FE absolute rule:** when touching a visual surface, read `uidesign.md` first to confirm existing token contracts, then write code. New tokens require a spec update in the same PR (or the PR immediately preceding). New components start from a §15 example.
-
-## Start Every Session
-
-1. `claude-progress.txt` (first 30 lines)
-2. `next-session-tasks.md` for the current Phase
-3. Relevant spec selectively
-4. Memory index `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — purge entries already in specs / git
-
-## Core Rules
-
-- **Tool routing**:
-  - TS / TSX symbol / refs / rename → Serena
-  - Cross-file keyword / file discovery → `rg -n`
-  - Small known range → `Read` with `offset / limit`
-  - Architecture / dependency flow → Graphify (required once before wide refactor or unfamiliar feature)
-  - Never `cat <file>` to dump source; never `Read` whole TS / TSX file when `find_symbol` works; never re-read a file already in context (modified files OK)
-- **Parallel tool calls**: independent calls go in one message. Gate: "Can I write call B's args before A runs?" — if yes, batch. Common violations + exceptions: `.claude/specs/parallel-dispatch.md`.
-- **Tail test output**: `| tail -20`; never full traces
-- **No Read before delete**: just `rm`
-- **First-pass git log**: `--all` + wide keywords; never narrow on retry
-- **Minimum context for judgment**: single most relevant file first
-- **Before editing**: summarize selected files / symbols + why
-- **Git workflow**: feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) **before** any change; never push to main; PRs opened by user; merge with `gh pr merge <n> --merge --delete-branch` (squash / rebase forbidden); after merge `git branch -D <branch>`. Enforced by `.claude/hookify.block-*.local.md`.
-- Tests before commit; match nearby code style; YAGNI
-- This file stays under 200 lines
-
-## Session Continuity
-
-Every design decision → spec or ADR before session ends. Phase close → `claude-progress.txt` + commit. No implementation without a spec section.
-
-## Documents
-
-Progress = `claude-progress.txt` (first 30 lines, current pointer) + `docs/specs/plans/next-session-tasks.md` (active work + deferred) + `docs/specs/plans/wave-3-admin.md` (active wave detail) + `docs/specs/plans/followup-bucket.md` (closed-wave follow-ups, FU-NNN). Permanent specs = `docs/specs/requires/`. Past history lives in git log + PR descriptions — never in standalone changelog files. ID rules: Wave / Phase are append-only integers; sub-decimals forbidden; batch labels are plan-table column metadata, never part of the ID; closed-wave follow-ups go to `FU-NNN`. On merge: sync `next-session-tasks.md` + `claude-progress.txt`.
-
-## Input Interpretation
-
-Before coding, frame: **Goal** (what + why, 1 line) · **Scope** (files in / out) · **Done when** (verifiable conditions) · **Constraints** (style / tokens / patterns). Skip for trivial one-liners.
-
-## Working Style
-
-### Reversibility gate
-
-- **Irreversible**: DB schema / migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms, file deletes, auth / billing / permissions / tenant boundary. → stop and ask, ≥90% confidence required.
-- **Reversible**: code / style / test in unmerged branch, file moves, naming, local refactors. → state assumption in 1 line, proceed, report in summary.
-- **Visual surface** (affecting `/voc`): if it diverges from `uidesign.md` tokens / structure, it is irreversible — token-definition changes require a spec update first.
-
-### Engineering
-
-- **TDD for irreversible surface** (auth / billing / permissions / contracts / migrations / BE routes): test first, confirm fail, implement. Bug fix = failing regression test first. Stack: Vitest (FE) / Jest + Supertest (BE) — `requirements.md §3`.
-- **Smoke test for reversible UI**: one happy-path render test + visual-diff baseline.
-- **Debate, don't defer**: raise counterarguments before agreeing.
-- **Think before coding**: state assumptions; surface multiple interpretations.
-- **Simplicity first**; **surgical changes**; **goal-driven verification per step**.
-- **Pre-commit**: `npm run lint -w frontend` once before first commit.
-- **Progress docs at phase / wave close only** — intra-phase PRs exempt. The `warn-doc-cleanup-before-pr` hookify checklist applies on `gh pr merge` for phase / wave-close PRs only.
-
-### Approval scope
-
-User approval covers its declared scope + reversible items inside. Plan approval → batches OK. Batch approval → leaves OK. Spec-derived → no extra approval. Re-ask on (1) new plan / batch, (2) irreversible not in spec, (3) user contradiction.
-
-Completion language: leaves → report what landed, no "done"; phase / wave / PR-merge → wait for explicit user confirmation.
-
-## Refactoring
-
-Refactor = structure change without behavior change. Refactor + feature change MUST NOT land together.
-
-- **Before**: state symbols / files; ensure test coverage (write tests first if not).
-- **During**: `git mv` for moves; one refactor at a time.
-- **After (in order)**: update all references → `rg -n "<old>"` returns 0 → Serena ref-check on renames → typecheck → tests → exercise the surface.
-- **Escalate to `code-reviewer`** only on public API change, ≥3 modules, or DB schema / migration.
-
-## Graphify
-
-Knowledge graph at `graphify-out/`. Use for architecture / dependency / cross-domain flow questions. Prefer `wiki/index.md` over raw files; queries via `/graphify query|path|explain`. After code edits: `graphify update .`.
-
-## Top-level directories
+**Top-level directories:**
 
 - `benchmark/` — ground-truth PNGs (`01–22-…`) for `scripts/visual-diff.ts`. New screen = baseline + INDEX row.
 - `graphify-out/` — auto-generated, do not hand-edit. Refresh: `graphify update .`.
 - `scripts/` — utilities (`check-fixture-seed-parity.ts`, `shadcn-token-rewrite.ts`, `visual-diff.ts`).
 - `shared/` — `types/` (FE + BE entities / enums) · `contracts/` (zod schemas, single source) · `fixtures/` (MSW + seed, parity enforced) · `openapi.yaml` (REST contract reference).
 
-## Agent skills
+## 2. Session Workflow
 
-- Issues: GitHub Issues — `docs/agents/issue-tracker.md`
-- Triage labels: needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix — `docs/agents/triage-labels.md`
-- Domain docs: single `CONTEXT.md` + `docs/adr/` — `docs/agents/domain.md`
+**Start every session:**
+
+1. `claude-progress.txt` (first 30 lines).
+2. `next-session-tasks.md` for the current Phase.
+3. Relevant spec selectively.
+4. Memory index `~/.claude/projects/-Users-hyojung-Desktop-2026-vocpage/memory/MEMORY.md` — purge entries already in specs / git.
+
+**Input framing (before coding):** state **Goal** (what + why, 1 line) · **Scope** (files in / out) · **Done when** (verifiable conditions) · **Constraints** (style / tokens / patterns). Skip for trivial one-liners.
+
+**Approval scope:** user approval covers its declared scope + reversible items inside. Plan approval → batches OK. Batch approval → leaves OK. Spec-derived → no extra approval. Re-ask on (1) new plan / batch, (2) irreversible not in spec, (3) user contradiction.
+
+**Completion language:** leaves → report what landed, no "done"; phase / wave / PR-merge → wait for explicit user confirmation.
+
+**Session continuity:** every design decision → spec or ADR before session ends. Phase close → `claude-progress.txt` + commit. No implementation without a spec section.
+
+## 3. Engineering Rules
+
+**Tool routing:**
+
+- TS / TSX symbol / refs / rename → Serena.
+- Cross-file keyword / file discovery → `rg -n`.
+- Small known range → `Read` with `offset / limit`.
+- Architecture / dependency flow → Graphify (required once before wide refactor or unfamiliar feature). Knowledge graph at `graphify-out/`; prefer `wiki/index.md` over raw files; queries via `/graphify query|path|explain`. After code edits: `graphify update .`.
+- Never `cat <file>` to dump source; never `Read` whole TS / TSX file when `find_symbol` works; never re-read a file already in context (modified files OK).
+
+**Execution:**
+
+- Parallel tool calls: independent calls go in one message. Gate: "Can I write call B's args before A runs?" — if yes, batch. Common violations + exceptions: `.claude/specs/parallel-dispatch.md`.
+- Tail test output: `| tail -20`; never full traces.
+- No `Read` before delete: just `rm`.
+- First-pass git log: `--all` + wide keywords; never narrow on retry.
+- Minimum context for judgment: single most relevant file first.
+- Before editing: summarize selected files / symbols + why.
+
+**Reversibility gate:**
+
+- **Irreversible**: DB schema / migration, public API contract (`shared/openapi.yaml`, `shared/contracts/**`), merged commits, external comms, file deletes, auth / billing / permissions / tenant boundary. → stop and ask, ≥90% confidence required.
+- **Reversible**: code / style / test in unmerged branch, file moves, naming, local refactors. → state assumption in 1 line, proceed, report in summary.
+- **Visual surface** (affecting `/voc`): if it diverges from `uidesign.md` tokens / structure, it is irreversible — token-definition changes require a spec update first.
+
+**Testing & quality:**
+
+- TDD for irreversible surface (auth / billing / permissions / contracts / migrations / BE routes): test first, confirm fail, implement. Bug fix = failing regression test first. Stack: Vitest (FE) / Jest + Supertest (BE) — `requirements.md §3`.
+- Smoke test for reversible UI: one happy-path render test + visual-diff baseline.
+- Debate, don't defer: raise counterarguments before agreeing.
+- Think before coding: state assumptions; surface multiple interpretations.
+- Simplicity first; surgical changes; goal-driven verification per step. YAGNI. Match nearby code style.
+- Pre-commit: `npm run lint -w frontend` once before first commit. Tests before commit.
+- Progress docs at phase / wave close only — intra-phase PRs exempt. The `warn-doc-cleanup-before-pr` hookify checklist applies on `gh pr merge` for phase / wave-close PRs only.
+
+**Refactoring** (structure change without behavior change; never combined with feature change):
+
+- Before: state symbols / files; ensure test coverage (write tests first if not).
+- During: `git mv` for moves; one refactor at a time.
+- After (in order): update all references → `rg -n "<old>"` returns 0 → Serena ref-check on renames → typecheck → tests → exercise the surface.
+- Escalate to `code-reviewer` only on public API change, ≥3 modules, or DB schema / migration.
+
+**Git workflow:** feature branch (`docs/<topic>` / `feat/<topic>` / `fix/<topic>`) before any change; never push to main; PRs opened by user; merge with `gh pr merge <n> --merge --delete-branch` (squash / rebase forbidden); after merge `git branch -D <branch>`. Enforced by `.claude/hookify.block-*.local.md`.
+
+## 4. Agent Skills
+
+- Issues: GitHub Issues — `docs/agents/issue-tracker.md`.
+- Triage labels: needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix — `docs/agents/triage-labels.md`.
+- Domain docs: single `CONTEXT.md` + `docs/adr/` — `docs/agents/domain.md`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,12 +1,8 @@
 # backend/CLAUDE.md
 
-Express REST API for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
+Express REST API for the VOC management system. Read root `CLAUDE.md` first.
 
-**Stack:** Node.js + Express + TypeScript, PostgreSQL with pgvector extension (`pgvector/pgvector:pg16`), zod v4 (shared/ 계약 — FE와 단일 schema 공유, 라우트 입력 검증), Jest + Supertest (test), tsx (dev runner). **TDD 필수** (root CLAUDE.md). 전체 OSS·버전: `docs/specs/requires/requirements.md §3`.
-
-## Status
-
-Phase 8 Wave 1.5-β merged (POST /api/vocs + history routes). `src/` layout follows route → controller → service → repository: `index.ts`, `db.ts`, `logger.ts`, `auth/` (mockLogin only — `validateADSession` is a stub for Phase 9), `routes/`, `controllers/`, `services/`, `repository/`, `middleware/`, `validators/`. Migrations 001-013 applied (013 = dev role + voc origin metadata). Next: Wave 2 — see `docs/specs/plans/next-session-tasks.md`.
+**Stack:** Node.js + Express + TypeScript, PostgreSQL with pgvector (`pgvector/pgvector:pg16`), zod v4 (shared `shared/contracts/` schema for FE+BE input validation), Jest + Supertest, tsx (dev runner). Full version list: `docs/specs/requires/requirements.md §3`.
 
 ## Commands
 
@@ -16,63 +12,43 @@ npm run test                                     # Jest
 npm run test -- --testPathPattern=filename       # Single test
 ```
 
-## Implementation Reference (2026-05-09~)
+## Implementation Reference
 
-정본은 `docs/specs/requires/requirements.md` (+ 보조 `feature-*.md`, `dashboard.md`). `prototype/` 디렉터리는 더 이상 backend reference 가 아니다 — 도메인 추론·DB 스키마·API blueprint 모두 spec 만 본다.
+Sources of truth: `docs/specs/requires/requirements.md` (+ `feature-*.md`, `dashboard.md`). `prototype/` is not a backend reference — domain inference, DB schema, and API blueprints all come from spec only.
 
-엔드포인트 작성 전 정의:
+Before writing an endpoint, define:
 
-- Domain entities + relationships, required/optional fields, enums/statuses
-- API contract (route, method, request/response shape, status codes, error shape)
-- Validation rules, auth/permission rules, error cases
+- Domain entities + relationships, required / optional fields, enums / statuses.
+- API contract — route, method, request / response shape, status codes, error shape.
+- Validation rules, auth / permission rules, error cases.
 
 Rules:
 
-- API는 **product behavior** 기준 — UI label 이 아닌 business concept 으로 모델링
-- route → service → repository, 비즈니스 로직은 route handler 밖
-- 모든 외부 입력 검증; status code · error shape 안정적
-- FE 상태 지원: pagination, filtering, sorting, loading-friendly responses, empty/error
-- 모호한 string / 제네릭 모델 / UI 배지마다 컬럼 두는 식의 설계 금지
+- Model APIs by **product behavior** (business concept) — never by UI label.
+- Layering: `routes/` → `services/` → `repository/`. Business logic lives outside route handlers.
+- Validate every external input. Stable status codes + error shape.
+- Support FE state needs: pagination, filtering, sorting, loading-friendly responses, empty / error.
+- Forbidden: ambiguous strings, generic catch-all models, one column per UI badge.
 
-Flow: read requirements/feature-\*.md → entities/types → API contract → service → persistence → validation/errors → FE integration 확인.
+Flow: read `requirements.md` / `feature-*.md` → entities + types → API contract → service → persistence → validation / errors → verify FE integration.
 
-## Architecture
+## Architecture & Schema
 
-Planned (Phase 8 implementation):
+Behavioral contracts (auto-tagging, AD session middleware, sub-task propagation, permission matrix `assertCanManageVoc(user, voc, action)`) and full DB schema DDL live in `docs/specs/requires/requirements.md` and `feature-voc.md §8.4-bis`. Do not duplicate behavioral rules into code comments — link to the spec section.
 
-- REST CRUD for VOCs, comments, attachments, tags.
-- Auth: dev uses `POST /api/auth/mock-login` (4 roles: admin/manager/dev/user). `validateADSession` / OIDC = Phase 9.
-- Auto-tagging service: keyword/regex rules from `tag_rules` → assigns tags on VOC creation.
-- Hierarchical queries via `parent_id` self-join on `vocs` (sub-task trees).
-- `assertCanManageVoc(user, voc, action)` is the single permission helper — see `feature-voc.md §8.4-bis`.
+Notable schema points (full DDL in spec):
 
-## Database Schema
-
-- **PostgreSQL + pgvector extension** — Docker image `pgvector/pgvector:pg16`. Initial migration must run `CREATE EXTENSION IF NOT EXISTS vector;` before any table DDL.
-- `vocs` — core entity; `parent_id` self-join for sub-tasks. Includes `embedding vector(1536) NULL` column reserved for future similarity search / RAG — **MVP does not populate or query this column**. HNSW index added in a later migration when the feature lands.
-- `tags` + `voc_tags` — M:N tag relationship.
-- `tag_rules` — keyword/regex patterns driving auto-tagging.
-- `users` — identity; linked to AD session on login.
-- `comments` — FK → `vocs.id`.
-- `attachments` — FK → `vocs.id`; file metadata only, blob in object storage.
-- `users.role` — enum `admin`/`manager`/`dev`/`user` (migration 012).
-- `notices` / `faqs` / `faq_categories` — content tables (migration 005).
-- `voc_internal_notes` — admin/manager-only annotations (User → 404 fail-closed).
-- `voc_payload_reviews` — Result Review flow with `review_status` enum.
-
-Full schema DDL and column-level spec: `docs/specs/requires/requirements.md` (data model section).
-
-## Business Rules (cross-reference)
-
-Behavioral contracts (what auto-tagging does, what the AD session middleware rejects, sub-task propagation rules) live in `docs/specs/requires/requirements.md`. **Do not duplicate behavioral rules into code comments** — link to the spec section.
+- `vocs.embedding vector(1536) NULL` — reserved for future similarity search; MVP does not populate or query. HNSW index added in a later migration.
+- `vocs.parent_id` self-join for sub-task hierarchy.
+- Initial migration runs `CREATE EXTENSION IF NOT EXISTS vector;` before any table DDL.
 
 ## Conventions
 
-Backend-relevant convention files in `docs/specs/requires/`: `api-conventions.md` (response envelope target, auth split boundary) · `routing-conventions.md §10.1` (route list) · `test-conventions.md §17.2` (shared/fixtures parity rules).
+Backend-relevant files in `docs/specs/requires/`: `api-conventions.md` (response envelope, auth split) · `routing-conventions.md §10.1` (route list) · `test-conventions.md §17.2` (shared / fixtures parity).
 
 ## Sub-tree map
 
-- `config/` — static config loaded at boot. `config/masters/` = master data JSON/CSV (VOC types/statuses/departments). Schema: `shared/contracts/master/`. Spec: `external-masters.md`. Adding/changing master = file here + matching `shared/fixtures/`.
-- `migrations/` — sequential SQL (`NNN_description.sql`). Current = latest numbered (013 = dev role + voc origin metadata). pgvector `CREATE EXTENSION` runs first before any DDL.
-- `seeds/` — DB seed for dev/test, mirrors `shared/fixtures/`. Parity check: `scripts/check-fixture-seed-parity.ts`.
+- `config/` — static config loaded at boot. `config/masters/` = master data JSON / CSV (VOC types / statuses / departments). Schema: `shared/contracts/master/`. Spec: `external-masters.md`. Adding / changing a master = file here + matching `shared/fixtures/`.
+- `migrations/` — sequential SQL (`NNN_description.sql`). pgvector `CREATE EXTENSION` runs first, before any DDL.
+- `seeds/` — DB seed for dev / test, mirrors `shared/fixtures/`. Parity check: `scripts/check-fixture-seed-parity.ts`.
 - `src/` — see `src/CLAUDE.md`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,12 +1,8 @@
 # frontend/CLAUDE.md
 
-React SPA for the VOC management system. Read root `CLAUDE.md` first for cross-cutting governance.
+React SPA for the VOC management system. Read root `CLAUDE.md` first.
 
-**Stack:** React + TypeScript, Vite, Tailwind CSS v4, Toast UI Editor (rich text), shadcn/ui (Radix 카피본) + Lucide, @tanstack/react-query v5, @tanstack/react-table v8, react-hook-form + zod (shared/), sonner, date-fns + react-day-picker, recharts (lazy), MSW v2, Vitest. **TDD 필수** (root CLAUDE.md). 전체 OSS·버전: `docs/specs/requires/requirements.md §3`.
-
-## Status
-
-`/voc` 단일 PR 통합 완성 작업 중 (정본: `docs/specs/plans/voc-completion.md` — 다음 세션 신설). Current `src/` tree: `main.tsx`, `router.tsx`, `tokens.ts`, `pages/`, `api/`, `components/{common,voc,layout,ui}/`, `features/`, `contexts/`, `hooks/`, `lib/`, `mocks/` (MSW v2 handlers), `styles/`, `test/`. Next: Wave 2 (Dashboard).
+**Stack:** React + TypeScript, Vite, Tailwind v4, Toast UI Editor (rich text), shadcn/ui (Radix) + Lucide, @tanstack/react-query v5, @tanstack/react-table v8, react-hook-form + zod (`shared/`), sonner, date-fns + react-day-picker, recharts (lazy), MSW v2, Vitest. Full version list: `docs/specs/requires/requirements.md §3`.
 
 ## Commands
 
@@ -19,37 +15,50 @@ npm run test -- path/to/file.test.ts     # Single test file
 
 ## Implementation Flow
 
-Spec/디자인 정본·정책은 root `CLAUDE.md` 참조. FE 화면 구현 순서:
+Per FE screen (spec sources: root `CLAUDE.md`):
 
-1. requirements + uidesign 읽기 → 컴포넌트 매핑 → 타입 정의 (no `any`)
-2. dummy data 로 빌드 → interaction → API 연결 → states/responsive 마무리
-3. Reuse existing components first; 새 컴포넌트는 UI/로직 반복 시에만
-4. 페이지 컴포넌트는 작게, Tailwind 중복은 `@apply` 또는 컴포넌트로 추출
-5. 항상 처리: loading / error / empty / hover / focus / responsive
+1. Read `requirements.md` + `uidesign.md` → map components → define types (no `any`).
+2. Build with dummy data → wire interactions → connect API → finalize states / responsive.
+3. Reuse existing components first; new components only when UI / logic repeats.
+4. Keep page components small; extract Tailwind repetition into components or `@apply`.
+5. Always handle: loading / error / empty / hover / focus / responsive.
 
 ## Architecture
 
 - **Views:** VOC list (table with hierarchical accordion rows), side drawer for detail (preserves list context), modal for VOC creation with Toast UI rich text editor.
 - **Key hooks:** `useVOCFilter`, `useAutoTag`, `useDrawer`.
-- **State:** React Context or Redux for global filter/selection.
+- **State:** React Context or Redux for global filter / selection.
 - **Base components:** Radix UI primitives — ghost buttons, translucent cards, border-focused inputs.
 
 ## Styling Architecture
 
-FE token pipeline: `src/tokens.ts` 가 raw 값의 단일 source — 여기서 `tailwind.config.ts` (utility) + CSS custom properties (`var(--*)`) 두 surface 가 생성된다. 새 토큰이 필요하면 `tokens.ts` + `uidesign.md` 양쪽을 같은 PR(또는 직전 PR)에서 갱신.
+FE token pipeline: `src/tokens.ts` is the raw-value SSOT — it generates `tailwind.config.ts` (utility) + CSS custom properties (`var(--*)`).
 
-토큰 정의·use rule·Tailwind vs CSS var 사용 매트릭스 정본: `docs/specs/requires/uidesign.md` (§10/§12). 룰은 root `CLAUDE.md` 가 정본.
+Token definitions, use rules, and the Tailwind-vs-CSS-var matrix live in `docs/specs/requires/uidesign.md` (§10 CSS Reference, §12 Token Architecture, §15 Agent Prompt Guide).
+
+**Visual rules:**
+
+- All colors via `var(--token)` — never hex / OKLCH literals.
+- Typography: Pretendard Variable (UI), D2Coding (code / issue IDs).
+- 8px grid, max-width ~1200px, elevation via background opacity, not shadow darkness.
+
+**FE absolute rule:** when touching a visual surface, read `uidesign.md` first to confirm existing token contracts, then write code. New tokens require updating `tokens.ts` + `uidesign.md` in the same PR (or the PR immediately preceding). New components start from a §15 example.
+
+**`uidesign.md` exclusivity (defined there only — no duplication):**
+
+- **In scope:** token definitions and use rules, component visual contracts, §15 Agent Prompt Guide.
+- **Out of scope:** implementation paths (`frontend/src/...`, `*.tsx`, `tokens.ts`) · build / lint tool names (Stylelint / ESLint / husky) · Wave / Phase / PR numbers / dates · behavior / routing / state contracts (→ `feature-*.md`) · schema / migration (→ `requirements.md`). If found, treat as a leak and split immediately.
 
 ## Conventions
 
-Before writing FE code, scan `docs/specs/requires/*-conventions.md` filenames — pick the matching one. Read with `limit=2` first — line 2 is `When to read` — then read in full only if relevant.
+Before writing FE code, scan `docs/specs/requires/*-conventions.md` filenames — pick the matching one. Read with `limit=2` first (line 2 = `When to read`), then read in full only if relevant.
 
-All files in `docs/specs/requires/`: `naming-conventions.md` · `state-management-conventions.md` · `api-conventions.md` · `routing-conventions.md` · `error-loading-conventions.md` · `form-conventions.md` · `table-filter-conventions.md` · `datetime-conventions.md` · `test-conventions.md` · `env-conventions.md`.
+Files in `docs/specs/requires/`: `naming-conventions.md` · `state-management-conventions.md` · `api-conventions.md` · `routing-conventions.md` · `error-loading-conventions.md` · `form-conventions.md` · `table-filter-conventions.md` · `datetime-conventions.md` · `test-conventions.md` · `env-conventions.md`.
 
 ## Sub-tree map (non-src)
 
-- `docs/` — FE-local notes/screenshots. Canonical specs = root `docs/specs/`. Wave-scoped FE evidence → `docs/screenshots/<wave>/`.
-- `e2e/` — Playwright (page-spanning flows, real-browser regressions: focus/keyboard/scroll). Component/unit tests → Vitest under `src/**/__tests__/`.
-- `eslint-rules/` — project-local custom ESLint (e.g. token-purity: no hex/raw OKLCH outside `src/tokens.ts`). Wired in `.eslintrc.base.js`.
+- `docs/` — FE-local notes / screenshots. Canonical specs = root `docs/specs/`. Wave-scoped FE evidence → `docs/screenshots/<wave>/`.
+- `e2e/` — Playwright (page-spanning flows, real-browser regressions: focus / keyboard / scroll). Component / unit tests → Vitest under `src/**/__tests__/`.
+- `eslint-rules/` — project-local custom ESLint (e.g. token-purity: no hex / raw OKLCH outside `src/tokens.ts`). Wired in `.eslintrc.base.js`.
 - `public/` — Vite static assets, served verbatim from site root. Self-hosted webfonts (Pretendard Variable UI, D2Coding code) in `public/fonts/`, referenced by `@font-face` in `src/styles/`. Typography spec: `uidesign.md`.
 - `src/` — see `src/CLAUDE.md`.

--- a/prototype/CLAUDE.md
+++ b/prototype/CLAUDE.md
@@ -1,47 +1,32 @@
 # prototype/CLAUDE.md
 
-Static HTML prototypes for visual exploration. Read root `CLAUDE.md` first for cross-cutting governance.
+Static HTML visual sandbox — dashboard mockups, widget experiments, layout studies. Read root `CLAUDE.md` first.
 
-## Purpose
+**Not a reference (2026-05-09~):** `prototype/` is no longer a visual / behavior reference. No pixel / DOM / CSS citation. Implementation references are `requirements.md` + `uidesign.md` only. Active reviews → `docs/specs/reviews/`; archived → `docs/specs/archive/reviews/`. Token / typography / grid rules live in `uidesign.md` — not duplicated here.
 
-This directory is a **visual sandbox** for design reviews — dashboard mockups, widget experiments, layout studies. Outputs feed into `docs/specs/requires/uidesign.md` (정본) — 활성 리뷰는 `docs/specs/reviews/`, 완료된 것은 `docs/specs/archive/reviews/`.
+**Throwaway scope:**
 
-## Throwaway Scope
-
-- Prototype HTML is **not** production code. Do not wire it to backend APIs.
-- When a prototype graduates to implementation, the real version goes into `frontend/` — the prototype stays as a reference snapshot.
-- No bundler / no transpile. The prototype loads as static HTML with `<link>` to split CSS files under `css/` and classic `<script>` tags loading modules under `js/` (Stage A-2 / A-4 split, see `docs/specs/archive/plans/prototype-phase7-wave3-plan.md`).
-- `package.json` exists only for Playwright-driven smoke verification (`scripts/`); no app-level build step.
-
-## Layout
-
-- `prototype.html` — single entry document (~929 lines, intentionally not split further).
-- `css/` — split modules (`admin/`, `components/`, `layout/`); each file ≤500 lines.
-- `js/` — 16+ modules; data exposed on `window` via explicit aliases in `data.js` (classic-script gotcha — `const NOTICES` etc. don't auto-attach).
-- `screenshots/` — captured reference snapshots.
-- `scripts/` — Playwright + tooling helpers.
+- Not production code. Do not wire to backend APIs.
+- When a prototype graduates to implementation, the real version goes into `frontend/`; the prototype stays as a snapshot.
+- No bundler / no transpile. Static HTML with `<link>` to split CSS under `css/` and classic `<script>` tags loading modules under `js/`.
+- `package.json` exists only for Playwright smoke verification under `scripts/`. No app-level build.
 
 ## Preview
 
-Open `prototype.html` directly in a browser, or serve the directory:
+Open `prototype.html` directly, or serve the directory:
 
 ```bash
 npx http-server prototype -p 8080
 ```
 
-## Design Tokens
+After modifying prototype files, run `graphify update .` from project root.
 
-토큰 정의·use rule·hex/OKLCH 금지 룰은 root `CLAUDE.md` + `docs/specs/requires/uidesign.md` 정본을 그대로 따른다. 본 디렉토리는 rendered visual surface 라 토큰을 직접 소비하지만, 룰을 여기 복제하지 않는다.
+## Layout & Sub-tree map
 
-## graphify
-
-After modifying prototype HTML files, run `graphify update .` from the project root to keep the knowledge graph current.
-
-## Sub-tree map
-
-- `css/` — split modules (each ≤500 lines). Spec: `uidesign.md §10`. Tokens defined at top of the prototype CSS chain.
-  - `css/admin/` — admin-page-only styles (tag rules, system menu, VOC type, users, notices, FAQ admin). Cross-page → `components/` or `layout/`.
-  - `css/components/` — reusable component styles (cards, buttons, badges, drawers, modals, tables). Visual reference for an FE component being implemented.
-  - `css/layout/` — app shell, grid, structural layout (navbar, sidebar, page frame proportions).
-- `js/` — 16+ classic-script modules. Mock data (source of truth for prototype-driven UX) → `data.js`; data exposed on `window` via explicit aliases (classic-script gotcha — `const NOTICES` doesn't auto-attach). Stage A-2/A-4 split rationale → `docs/specs/archive/plans/prototype-phase7-wave3-plan.md`.
-- `scripts/` — Playwright smoke verification + tooling helpers. Generated graph artifacts → `graphify-out/`.
+- `prototype.html` — single entry document (~929 lines, intentionally not split further).
+- `css/admin/` — admin-page-only styles (tag rules, system menu, VOC type, users, notices, FAQ admin). Cross-page → `components/` or `layout/`.
+- `css/components/` — reusable component styles (cards, buttons, badges, drawers, modals, tables). Visual reference for an FE component being implemented.
+- `css/layout/` — app shell, grid, structural layout (navbar, sidebar, page frame proportions). Each CSS file ≤500 lines.
+- `js/` — 16+ classic-script modules. Mock data → `data.js`; data exposed on `window` via explicit aliases (classic-script gotcha — `const NOTICES` does not auto-attach).
+- `screenshots/` — captured reference snapshots.
+- `scripts/` — Playwright smoke verification + tooling helpers.


### PR DESCRIPTION
## Summary

Audit + reorganize all 7 `CLAUDE.md` files. Translate Korean to English (per new root rule), drop sections that rot or duplicate spec, collapse over-fragmented headings.

- **Root** — 11 sections → 4 (Project & Documents / Session Workflow / Engineering Rules / Agent Skills); Design System block moved to `frontend/`; add English-only writing rule for `CLAUDE.md` / `MEMORY.md`.
- **frontend/** — translate Korean, drop stale Status, absorb Design System (visual rules + `uidesign.md` exclusivity).
- **backend/** — translate Korean, drop stale Status, collapse duplicated schema list and Architecture / Business Rules into spec pointers.
- **prototype/** — fold Purpose / Throwaway / Tokens / graphify into a single intro; merge Layout + Sub-tree map.
- **.claude/** — drop dangling `Pointers` section, normalize headings.
- **frontend/src/**, **backend/src/** — already clean, untouched.

Net: 5 files changed, +140 / -191. Total CLAUDE.md tree: 328 lines (was ~390).

## Test plan

- [x] `tsc` typecheck (FE + BE) passed via lint-staged on commit.
- [x] Each file reviewed for Korean residue, stale references, and duplication against `requirements.md` / `uidesign.md`.
- [x] Root stays under the 200-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)