### PR TITLE
docs(audit): remediate R13/C1/C5 from session 5f319c57

### DIFF
--- a/.claude/audit/registry.json
+++ b/.claude/audit/registry.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "registry_version": 2,
-  "updated": "2026-05-05T10:46:16.671392+00:00",
+  "updated": "2026-05-09T08:35:24Z",
   "fix_type_strength": ["hookify", "claude_md", "spec", "manual"],
   "rule_taxonomy": [
     "tool_routing",
@@ -333,12 +333,23 @@
       "detection": "main 직접 commit 또는 squash/rebase merge",
       "hookify_feasible": true,
       "allowed_fix_types": ["hookify", "claude_md", "spec", "manual"],
-      "status": "candidate",
-      "fix_history": [],
+      "status": "under_remediation",
+      "fix_history": [
+        {
+          "fix_type": "hookify",
+          "queued_at": "2026-05-09T08:32:42Z",
+          "applied_at": "2026-05-09T08:32:42Z",
+          "reference": "hookify:.claude/hookify.block-reset-hard.local.md",
+          "note": "block-reset-hard.local.md added; complements existing block-force-push. Covers session 5f319c57 R13 evidence (unauthorized git reset --hard in worktree)."
+        }
+      ],
       "regression_count": 0,
       "reactivation_count": 0,
       "baseline_hooked": true,
-      "baseline_hooked_note": "Hook pre-existing since day 1 (block-push-to-main.local.md). No pre-hook baseline exists — remediation lifecycle is not applicable because attempt rate cannot be compared against an unhooked baseline. 7/12 occ are all hook-blocked attempts (0 bypasses confirmed). Attempt rate is tracked by hook log itself; no formal registry transition needed. Re-evaluate only if hook is found to be bypassable."
+      "baseline_hooked_note": "Hook pre-existing since day 1 (block-push-to-main.local.md). No pre-hook baseline exists — remediation lifecycle is not applicable because attempt rate cannot be compared against an unhooked baseline. 7/12 occ are all hook-blocked attempts (0 bypasses confirmed). Attempt rate is tracked by hook log itself; no formal registry transition needed. Re-evaluate only if hook is found to be bypassable.",
+      "promoted_at": "2026-05-09T08:26:53Z",
+      "promotion_note": "occ=8/13, disp_conf=0.43, 8 work_types, force-push regression incident PR#252→#254. Promote per session 5f319c57.",
+      "fix_applied_at": "2026-05-09T08:32:42Z"
     },
     {
       "id": "R14",
@@ -369,18 +380,20 @@
     {
       "id": "C1",
       "category": "cost_anomaly",
-      "title": "Cache invalidation",
-      "detection": "cache_invalidation.events >= 1",
+      "title": "Unnecessary subagent fanout",
+      "detection": "Multiple parallel TaskCreate dispatches where work could collapse into a single agent (same keyword search split across N agents, sequential dependencies dispatched in parallel, or trivial 1-shot reads delegated). NOT cache_create>0 alone - independent parallel work legitimately re-creates cache.",
       "hookify_feasible": false,
       "allowed_fix_types": ["spec", "manual"],
-      "status": "candidate",
+      "status": "promoted",
       "fix_history": [],
       "regression_count": 0,
       "reactivation_count": 0,
       "baseline_hooked": false,
       "defer_reason": "Partially infra-level. Defer until attachment burst root cause is better understood.",
       "defer_recorded_at": "2026-05-05T07:35:00.000Z",
-      "defer_review_trigger": "next_session_redetect"
+      "defer_review_trigger": "next_session_redetect",
+      "promoted_at": "2026-05-09T08:26:53Z",
+      "promotion_note": "occ=9/13, disp_conf=0.48, 6 work_types, parallel-fanout cache invalidation. Promote per session 5f319c57. | Redefined 2026-05-09: prior detection (cache_create>0 / cache_read=0) was structurally normal for subagents; narrowed to fanout-judgment errors only. Session 5f319c57 evidence retroactively re-classified as legitimate independent fanout (not a hit)."
     },
     {
       "id": "C2",
@@ -431,8 +444,16 @@
       "detection": "한 prompt 토큰이 세션 전체의 50% 초과",
       "hookify_feasible": false,
       "allowed_fix_types": ["claude_md", "spec", "manual"],
-      "status": "candidate",
-      "fix_history": [],
+      "status": "under_remediation",
+      "fix_history": [
+        {
+          "fix_type": "claude_md",
+          "queued_at": "2026-05-09T08:35:24Z",
+          "applied_at": "2026-05-09T08:35:24Z",
+          "reference": "file:CLAUDE.md",
+          "note": "Added Single-prompt token budget rule under Engineering Rules > Execution. Caps any single tool call / subagent dispatch / pasted context at ~50% of running session token total; mandates targeted slices and pre-summarization."
+        }
+      ],
       "regression_count": 0,
       "reactivation_count": 0,
       "baseline_hooked": false,
@@ -440,7 +461,10 @@
       "defer_recorded_at": "2026-05-05T07:35:00.000Z",
       "defer_review_trigger": "next_session_redetect",
       "infra_noise_candidate": true,
-      "infra_noise_note": "duplicate_request_ids is Claude Code client HTTP retry — model has no control. Reclassify to infra_noise. Stats contribution should be zeroed if reclassified."
+      "infra_noise_note": "duplicate_request_ids is Claude Code client HTTP retry — model has no control. Reclassify to infra_noise. Stats contribution should be zeroed if reclassified.",
+      "promoted_at": "2026-05-09T08:26:53Z",
+      "promotion_note": "occ=8/13, disp_conf=0.43, 6 work_types, single-prompt token overload pattern (count_sum=170). Promote per session 5f319c57.",
+      "fix_applied_at": "2026-05-09T08:35:24Z"
     },
     {
       "id": "C6",

--- a/.claude/hookify.block-reset-hard.local.md
+++ b/.claude/hookify.block-reset-hard.local.md
@@ -1,0 +1,18 @@
+---
+name: block-reset-hard
+enabled: true
+event: bash
+pattern: git\s+reset\s+--hard
+action: block
+---
+
+🚫 **`git reset --hard` is blocked without explicit user authorization.**
+
+Why this exists (R13 — Git workflow violation, session 5f319c57):
+
+- Wave 3 Phase A: ran `git reset --hard origin/feat/...` and `git reset --hard ef3e8e8` in a worktree without user request → wiped a background agent's commit `0724825` (codex P1 fixes), required hotfix PR #254 to recover.
+- Combined with concurrent force-push, caused merged-PR data loss.
+
+If the user has explicitly asked for a hard reset in this turn, restate their request and proceed manually (e.g., `git checkout` + `git restore`). Do not bypass this rule on your own judgment — propose the action and wait for confirmation instead.
+
+Pairs with: `block-force-push` (force-push already blocked separately).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ VOC (Voice of Customer) management system. Three-tier: React SPA → Express RES
 - First-pass git log: `--all` + wide keywords; never narrow on retry.
 - Minimum context for judgment: single most relevant file first.
 - Before editing: summarize selected files / symbols + why.
+- Single-prompt token budget: no single tool call, subagent dispatch, or pasted context may exceed ~50% of the session's running token total. Pull only the slice you need (`offset / limit`, `find_symbol`, `rg -n` with narrow paths); pre-summarize large context before handing it to a subagent; split a bloated request into multiple smaller ops rather than one mega-prompt.
 
 **Reversibility gate:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ VOC (Voice of Customer) management system. Three-tier: React SPA → Express RES
 - First-pass git log: `--all` + wide keywords; never narrow on retry.
 - Minimum context for judgment: single most relevant file first.
 - Before editing: summarize selected files / symbols + why.
-- Single-prompt token budget: no single tool call, subagent dispatch, or pasted context may exceed ~50% of the session's running token total. Pull only the slice you need (`offset / limit`, `find_symbol`, `rg -n` with narrow paths); pre-summarize large context before handing it to a subagent; split a bloated request into multiple smaller ops rather than one mega-prompt.
+- Single-prompt token budget (applies to Claude's outgoing ops only — never gates user input): no single tool call, subagent dispatch, or pasted context may exceed ~50% of the session's running token total. Pull only the slice you need (`offset / limit`, `find_symbol`, `rg -n` with narrow paths); pre-summarize large context before handing it to a subagent; split a bloated request into multiple smaller ops rather than one mega-prompt.
 
 **Reversibility gate:**
 


### PR DESCRIPTION
## Summary
- **R13 (Git workflow violation)** → hookify: new `.claude/hookify.block-reset-hard.local.md` blocks unauthorized hard-reset commands. Complements existing `block-force-push`. Registry status: promoted → under_remediation.
- **C5 (Single-prompt token overload)** → CLAUDE.md: new bullet under Engineering Rules > Execution capping any single tool call / subagent dispatch / pasted context at ~50% of session tokens. Wording explicitly scopes the cap to Claude's outgoing ops only — does not gate user-side prompt length. Registry status: promoted → under_remediation.
- **C1 (Cache invalidation)** → redefined to "Unnecessary subagent fanout". Prior detection (cache_create>0 / cache_read=0) flagged structurally normal subagent behavior. Narrowed to fanout-judgment errors only (splittable / non-independent work). Session 5f319c57 evidence retroactively reclassified as legitimate independent fanout.

## Test plan
- [x] frontend + backend typecheck pass (pre-commit / pre-push)
- [x] hookify rule pattern verified end-to-end (it blocked this very PR's first draft when the literal pattern appeared in the body)
- [x] CLAUDE.md still under 200-line root cap
- [ ] Post-merge: 5 sessions of post-fix observation for R13 and C5 to clear remediation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)