### PR TITLE
fix(test): FU-011 require → import in 3 BE test files

### DIFF
--- a/backend/src/__tests__/faq-categories.test.ts
+++ b/backend/src/__tests__/faq-categories.test.ts
@@ -3,6 +3,7 @@
  * Spec: docs/specs/requires/feature-notice-faq.md §10.4.4, §10.5.
  */
 import request from 'supertest';
+import * as faqsRepoModule from '../repository/faqs';
 import { createTestApp } from './helpers/app';
 import type { FaqCategory } from '../../../shared/contracts/faq';
 
@@ -63,8 +64,7 @@ jest.mock('../repository/faqs', () => {
   };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const repoMock = require('../repository/faqs') as {
+const repoMock = faqsRepoModule as unknown as {
   __resetCats(seed: FaqCategory[], hasItems?: boolean): void;
 };
 

--- a/backend/src/__tests__/faqs.test.ts
+++ b/backend/src/__tests__/faqs.test.ts
@@ -3,6 +3,7 @@
  * Spec: docs/specs/requires/feature-notice-faq.md §10.4, §10.5.
  */
 import request from 'supertest';
+import * as faqsRepoModule from '../repository/faqs';
 import { createTestApp } from './helpers/app';
 import type { Faq } from '../../../shared/contracts/faq';
 
@@ -57,8 +58,7 @@ jest.mock('../repository/faqs', () => {
         if (opts.q) {
           const q = opts.q.toLowerCase();
           rows = rows.filter(
-            (r) =>
-              r.question.toLowerCase().includes(q) || r.answer.toLowerCase().includes(q),
+            (r) => r.question.toLowerCase().includes(q) || r.answer.toLowerCase().includes(q),
           );
         }
         return { rows, total: rows.length };
@@ -119,8 +119,7 @@ jest.mock('../repository/faqs', () => {
   };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const repoMock = require('../repository/faqs') as { __reset(seed: Faq[]): void };
+const repoMock = faqsRepoModule as unknown as { __reset(seed: Faq[]): void };
 
 beforeEach(() => {
   repoMock.__reset([FAQ_A, FAQ_HIDDEN, FAQ_DELETED]);

--- a/backend/src/__tests__/notices.test.ts
+++ b/backend/src/__tests__/notices.test.ts
@@ -5,6 +5,7 @@
  * U3=A pattern: jest.mock('../repository/notices') for module-level isolation.
  */
 import request from 'supertest';
+import * as noticesRepoModule from '../repository/notices';
 import { createTestApp } from './helpers/app';
 import type { Notice } from '../../../shared/contracts/notice';
 
@@ -117,8 +118,7 @@ jest.mock('../repository/notices', () => {
   };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const repoMock = require('../repository/notices') as {
+const repoMock = noticesRepoModule as unknown as {
   __reset(seed: Notice[]): void;
   __all(): Notice[];
 };


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-var-requires` 3건 정리 — `lint-root` pre-existing 실패 해소.

- `backend/src/__tests__/faqs.test.ts`
- `backend/src/__tests__/notices.test.ts`
- `backend/src/__tests__/faq-categories.test.ts`

`require('../repository/...')` → `import * as ... from '../repository/...'` + 타입 캐스팅. `jest.mock()` 은 babel-jest 가 imports 보다 먼저 hoist 하므로 동일 동작 유지.

## Verification

- `npx eslint . --max-warnings=0` — 0 errors
- `npm run typecheck -w backend` — clean
- `npm run test -w backend -- --testPathPattern='(faqs|notices|faq-categories)'` — 42 pass

## Refs

- `docs/specs/plans/followup-bucket.md` FU-011 (P1, Phase B 진입 전 처리)

## Test plan

- [x] lint-root 통과
- [x] backend typecheck 통과
- [x] 영향받은 3 test 파일 42 tests 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)