### PR TITLE
feat(admin): External Masters admin screen (W3-6)

### DIFF
--- a/backend/config/masters/db-stub.json
+++ b/backend/config/masters/db-stub.json
@@ -1,0 +1,5 @@
+{
+  "db_tables": ["users", "vocs", "comments"],
+  "jobs": ["nightly_backup", "weekly_report"],
+  "sps": ["sp_get_voc", "sp_update_status"]
+}

--- a/backend/config/masters/equipment-stub.json
+++ b/backend/config/masters/equipment-stub.json
@@ -1,0 +1,6 @@
+{
+  "equipment": ["Press-A", "Lathe-B", "Mill-C"],
+  "maker": ["OEM Korea", "기계공업", "Alpha Tech"],
+  "model": ["PR-100", "LT-200", "ML-300"],
+  "process": ["용접", "절삭", "조립"]
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,11 +15,16 @@ import { faqsRouter } from './routes/faqs';
 import { faqCategoriesRouter } from './routes/faq-categories';
 import { adminTagsRouter } from './routes/admin-tags';
 import { adminTrashRouter } from './routes/admin-trash';
+import { adminMastersRouter } from './routes/admin-masters';
+import { initMasterCache } from './services/admin/external-masters';
 import { errorHandler } from './middleware/errorHandler';
 import logger from './logger';
 
 // Fail fast if AUTH_MODE is misconfigured — throws before server starts
 createAuthMiddleware();
+
+// Boot master cache (cold-start safe — never throws)
+initMasterCache();
 
 const isProduction = process.env.NODE_ENV === 'production';
 if (isProduction && !process.env.SESSION_SECRET) {
@@ -71,6 +76,7 @@ app.use('/api/faqs', faqsRouter);
 app.use('/api/faq-categories', faqCategoriesRouter);
 app.use('/api/admin', adminTagsRouter);
 app.use('/api/admin', adminTrashRouter);
+app.use('/api/admin', adminMastersRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/routes/__tests__/admin-masters.test.ts
+++ b/backend/src/routes/__tests__/admin-masters.test.ts
@@ -1,0 +1,233 @@
+/**
+ * admin-masters.test.ts — Wave 3 Phase D (W3-6) TDD suite.
+ *
+ * Irreversible surface tested (mandatory per CLAUDE.md §Engineering Rules):
+ *  1. Permission matrix — 4 roles × 2 actions (GET status / POST refresh)
+ *  2. Cooldown 429 — refresh blocked within 5-min window per user
+ *  3. Atomic-swap rollback — kept_loaded_at preserved on failure
+ *  4. Cold-start badge — mode=cold when no snapshot
+ *  5. Snapshot badge — mode=snapshot when loaded from snapshot fallback
+ *
+ * Spec: requirements.md §16.3, external-masters.md §0/§6/§7/§8
+ * Permission (ADR 0004 + OQ-2 Option B):
+ *   GET  /api/admin/masters/status  — admin / manager / dev
+ *   POST /api/admin/masters/refresh — admin / manager only (not dev, not user)
+ */
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+
+process.env.AUTH_MODE = 'mock';
+
+// Mock the master cache service before importing the router
+jest.mock('../../services/admin/external-masters', () => ({
+  getMasterStatus: jest.fn(),
+  triggerRefresh: jest.fn(),
+}));
+
+import { adminMastersRouter } from '../admin-masters';
+import * as masterSvc from '../../services/admin/external-masters';
+
+const mockSvc = masterSvc as jest.Mocked<typeof masterSvc>;
+
+// ---------------------------------------------------------------------------
+// App factory — injects mock session user by role
+// ---------------------------------------------------------------------------
+function makeApp(role: 'admin' | 'manager' | 'dev' | 'user') {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  const roleToUser: Record<string, object> = {
+    admin:   { id: '00000000-0000-4000-8000-0000000000a1', role: 'admin',   name: 'Mock Admin' },
+    manager: { id: '00000000-0000-4000-8000-0000000000b1', role: 'manager', name: 'Mock Manager' },
+    dev:     { id: '00000000-0000-4000-8000-0000000000c1', role: 'dev',     name: 'Mock Dev' },
+    user:    { id: '00000000-0000-4000-8000-0000000000d1', role: 'user',    name: 'Mock User' },
+  };
+  app.use((req, _res, next) => {
+    (req.session as Record<string, unknown>).user = roleToUser[role];
+    next();
+  });
+  app.use('/api/admin', adminMastersRouter);
+  return app;
+}
+
+const NOW = '2026-05-09T10:00:00.000Z';
+const COOLDOWN_UNTIL = '2026-05-09T10:05:00.000Z';
+
+const sampleStatus = {
+  loaded_at: NOW,
+  cooldown_until: null as string | null,
+  mode: 'live' as const,
+  sources: {
+    equipment: { loaded_at: NOW },
+    db:        { loaded_at: NOW },
+    program:   { loaded_at: NOW },
+  },
+};
+
+const sampleRefreshOk = {
+  swapped: true,
+  loaded_at: NOW,
+  sources: {
+    equipment: { loaded_at: NOW },
+    db:        { loaded_at: NOW },
+  },
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ───────────────────────────────────────────────────────────────────────────
+// §1 GET /api/admin/masters/status — permission matrix
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/masters/status — permission matrix', () => {
+  it('admin → 200', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce(sampleStatus);
+    const res = await request(makeApp('admin')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+    expect(res.body.loaded_at).toBe(NOW);
+  });
+
+  it('manager → 200', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce(sampleStatus);
+    const res = await request(makeApp('manager')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+  });
+
+  it('dev → 200 (OQ-2 Option B: dev read-only allowed)', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce(sampleStatus);
+    const res = await request(makeApp('dev')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+  });
+
+  it('user → 403', async () => {
+    const res = await request(makeApp('user')).get('/api/admin/masters/status');
+    expect(res.status).toBe(403);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// §2 POST /api/admin/masters/refresh — permission matrix
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/masters/refresh — permission matrix', () => {
+  it('admin → 200', async () => {
+    mockSvc.triggerRefresh.mockResolvedValueOnce(sampleRefreshOk);
+    const res = await request(makeApp('admin')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(200);
+    expect(res.body.swapped).toBe(true);
+  });
+
+  it('manager → 200', async () => {
+    mockSvc.triggerRefresh.mockResolvedValueOnce(sampleRefreshOk);
+    const res = await request(makeApp('manager')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(200);
+  });
+
+  it('dev → 403 (read-only: no refresh)', async () => {
+    const res = await request(makeApp('dev')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(403);
+    expect(mockSvc.triggerRefresh).not.toHaveBeenCalled();
+  });
+
+  it('user → 403', async () => {
+    const res = await request(makeApp('user')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(403);
+    expect(mockSvc.triggerRefresh).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// §3 Cooldown 429 — within 5-min window per user
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('Cooldown 429 — refresh blocked within 5-min window', () => {
+  it('returns 429 with kept_loaded_at when cooldown active', async () => {
+    const cooldownError = Object.assign(
+      new Error('쿨다운 중입니다. 5분 후 다시 시도하세요.'),
+      {
+        code: 'RATE_LIMITED',
+        cooldown_until: COOLDOWN_UNTIL,
+        kept_loaded_at: NOW,
+      },
+    );
+    mockSvc.triggerRefresh.mockRejectedValueOnce(cooldownError);
+    const res = await request(makeApp('manager')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('RATE_LIMITED');
+    expect(res.body.details.cooldown_until).toBe(COOLDOWN_UNTIL);
+    expect(res.body.details.kept_loaded_at).toBe(NOW);
+  });
+
+  it('returns 200 after cooldown clears', async () => {
+    mockSvc.triggerRefresh.mockResolvedValueOnce(sampleRefreshOk);
+    const res = await request(makeApp('manager')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(200);
+    expect(res.body.swapped).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// §4 Atomic-swap rollback — kept_loaded_at preserved on failure
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('Atomic-swap rollback — kept_loaded_at preserved on partial failure', () => {
+  it('returns 503 with swapped=false and kept_loaded_at when refresh fails', async () => {
+    const swapError = Object.assign(
+      new Error('외부 마스터 로드 실패: equipment MSSQL 연결 오류'),
+      {
+        code: 'EXTERNAL_MASTER_UNAVAILABLE',
+        kept_loaded_at: NOW,
+      },
+    );
+    mockSvc.triggerRefresh.mockRejectedValueOnce(swapError);
+    const res = await request(makeApp('manager')).post('/api/admin/masters/refresh');
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('EXTERNAL_MASTER_UNAVAILABLE');
+    expect(res.body.details.kept_loaded_at).toBe(NOW);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// §5 Status — mode badges (cold-start / snapshot)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('Status mode badges', () => {
+  it('returns mode=cold when no snapshot loaded (cold-start)', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce({
+      ...sampleStatus,
+      loaded_at: null,
+      mode: 'cold',
+    });
+    const res = await request(makeApp('admin')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('cold');
+  });
+
+  it('returns mode=snapshot when loaded from disk fallback', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce({
+      ...sampleStatus,
+      mode: 'snapshot',
+    });
+    const res = await request(makeApp('admin')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('snapshot');
+  });
+
+  it('returns mode=live when fully loaded from external sources', async () => {
+    mockSvc.getMasterStatus.mockReturnValueOnce({
+      ...sampleStatus,
+      mode: 'live',
+    });
+    const res = await request(makeApp('admin')).get('/api/admin/masters/status');
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('live');
+  });
+});

--- a/backend/src/routes/admin-masters.ts
+++ b/backend/src/routes/admin-masters.ts
@@ -1,0 +1,81 @@
+/**
+ * Admin External Masters routes — Wave 3 Phase D (W3-6)
+ *
+ * Permission matrix (ADR 0004 + OQ-2 Option B):
+ *   Read   GET  /api/admin/masters/status  — admin / manager / dev
+ *   Mutate POST /api/admin/masters/refresh — admin / manager only (dev → 403)
+ *
+ * Spec: requirements.md §16.3, external-masters.md §0/§6
+ * Error codes: requirements.md §6.1
+ *   RATE_LIMITED              → 429 (5-min cooldown)
+ *   EXTERNAL_MASTER_UNAVAILABLE → 503 (atomic swap failed)
+ */
+import { Router, type RequestHandler, type Request, type Response, type NextFunction } from 'express';
+import { createAuthMiddleware } from '../auth';
+import { requireRole } from '../middleware/requireRole';
+import * as svc from '../services/admin/external-masters';
+import type { AuthUser } from '../auth/types';
+
+const auth: RequestHandler = (req, res, next) => createAuthMiddleware()(req, res, next);
+
+export const adminMastersRouter = Router();
+
+adminMastersRouter.use(auth);
+
+// ─── GET /api/admin/masters/status ─────────────────────────────────────────
+// Read: admin / manager / dev  (user → 403)
+
+adminMastersRouter.get(
+  '/masters/status',
+  requireRole('admin', 'manager', 'dev'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const user = req.user as AuthUser;
+      const status = svc.getMasterStatus(user.id);
+      res.json(status);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── POST /api/admin/masters/refresh ───────────────────────────────────────
+// Mutate: admin / manager only  (dev → 403, user → 403)
+
+adminMastersRouter.post(
+  '/masters/refresh',
+  requireRole('admin', 'manager'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const user = req.user as AuthUser;
+      const result = await svc.triggerRefresh(user.id);
+      res.json(result);
+    } catch (err: unknown) {
+      if (typeof err === 'object' && err !== null && 'code' in err) {
+        const typed = err as { code: string; cooldown_until?: string; kept_loaded_at?: string | null; message: string };
+        if (typed.code === 'RATE_LIMITED') {
+          res.status(429).json({
+            code: 'RATE_LIMITED',
+            message: typed.message,
+            details: {
+              cooldown_until: typed.cooldown_until ?? null,
+              kept_loaded_at: typed.kept_loaded_at ?? null,
+            },
+          });
+          return;
+        }
+        if (typed.code === 'EXTERNAL_MASTER_UNAVAILABLE') {
+          res.status(503).json({
+            code: 'EXTERNAL_MASTER_UNAVAILABLE',
+            message: typed.message,
+            details: {
+              kept_loaded_at: typed.kept_loaded_at ?? null,
+            },
+          });
+          return;
+        }
+      }
+      next(err);
+    }
+  },
+);

--- a/backend/src/services/admin/external-masters.ts
+++ b/backend/src/services/admin/external-masters.ts
@@ -1,0 +1,303 @@
+/**
+ * external-masters.ts — Wave 3 Phase D (W3-6)
+ *
+ * In-process global cache for 3 external master data sources:
+ *   - equipment: MSSQL (stub via config/masters/equipment-stub.json until schema confirmed)
+ *   - db:        MSSQL (stub via config/masters/db-stub.json until schema confirmed)
+ *   - program:   config/masters/programs.json — boot-only, not refreshable
+ *
+ * Spec: requirements.md §16.3, external-masters.md §3/§4/§5/§7/§8
+ * ADR 0004 + OQ-2 Option B:
+ *   Read   = admin / manager / dev
+ *   Refresh= admin / manager only
+ *
+ * Key invariants:
+ *   - Atomic swap: all 3 sources must succeed before cache is replaced.
+ *     If any fails, existing memory is preserved (kept_loaded_at).
+ *   - Cooldown: 5 min per user ID. Rejects with RATE_LIMITED (429).
+ *   - Cold-start: if no snapshot and no live load succeeds → mode='cold',
+ *     all fields unverified. Server does NOT fail to boot.
+ *   - Snapshot fallback: if boot-time load fails but snapshot file exists
+ *     → mode='snapshot'.
+ */
+import fs from 'fs';
+import path from 'path';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type MasterMode = 'live' | 'snapshot' | 'cold';
+
+interface EquipmentCache {
+  equipment: string[];
+  maker: string[];
+  model: string[];
+  process: string[];
+}
+
+interface DbCache {
+  db_tables: string[];
+  jobs: string[];
+  sps: string[];
+}
+
+interface ProgramCache {
+  programs: string[];
+}
+
+interface SourceEntry<T> {
+  data: T;
+  loaded_at: string;
+  kept_loaded_at?: string;
+}
+
+interface MasterCache {
+  equipment: SourceEntry<EquipmentCache> | null;
+  db: SourceEntry<DbCache> | null;
+  program: SourceEntry<ProgramCache> | null;
+  mode: MasterMode;
+  loaded_at: string | null;
+}
+
+export interface MasterStatusResult {
+  loaded_at: string | null;
+  cooldown_until: string | null;
+  mode: MasterMode;
+  sources: {
+    equipment: { loaded_at: string; kept_loaded_at?: string } | null;
+    db: { loaded_at: string; kept_loaded_at?: string } | null;
+    program: { loaded_at: string } | null;
+  };
+}
+
+export interface MasterRefreshResult {
+  swapped: boolean;
+  loaded_at: string;
+  sources: {
+    equipment: { loaded_at: string };
+    db: { loaded_at: string };
+  };
+}
+
+// ─── Paths ───────────────────────────────────────────────────────────────────
+
+const MASTERS_DIR = path.resolve(__dirname, '../../../config/masters');
+const SNAPSHOT_PATH = path.join(MASTERS_DIR, 'snapshot.json');
+const PROGRAMS_PATH = path.join(MASTERS_DIR, 'programs.json');
+const EQUIPMENT_STUB_PATH = path.join(MASTERS_DIR, 'equipment-stub.json');
+const DB_STUB_PATH = path.join(MASTERS_DIR, 'db-stub.json');
+
+// ─── In-process global cache ──────────────────────────────────────────────────
+
+let _cache: MasterCache = {
+  equipment: null,
+  db: null,
+  program: null,
+  mode: 'cold',
+  loaded_at: null,
+};
+
+/** Per-user cooldown map: userId → ISO timestamp of last refresh */
+const _cooldownMap = new Map<string, string>();
+
+const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+// ─── Loader stubs (replace with real MSSQL queries when schema is confirmed) ──
+
+function loadEquipmentStub(): EquipmentCache {
+  const raw = fs.readFileSync(EQUIPMENT_STUB_PATH, 'utf-8');
+  return JSON.parse(raw) as EquipmentCache;
+}
+
+function loadDbStub(): DbCache {
+  const raw = fs.readFileSync(DB_STUB_PATH, 'utf-8');
+  return JSON.parse(raw) as DbCache;
+}
+
+function loadPrograms(): ProgramCache {
+  const raw = fs.readFileSync(PROGRAMS_PATH, 'utf-8');
+  const list = JSON.parse(raw) as string[];
+  return { programs: list };
+}
+
+// ─── Boot initialisation ──────────────────────────────────────────────────────
+
+/**
+ * Called once at server boot. Attempts to load from live stubs; falls back to
+ * snapshot file on failure; falls to cold-start if neither is available.
+ * Never throws — boot must succeed regardless.
+ */
+export function initMasterCache(): void {
+  try {
+    const now = new Date().toISOString();
+
+    const equipData = loadEquipmentStub();
+    const dbData = loadDbStub();
+    const progData = loadPrograms();
+
+    _cache = {
+      equipment: { data: equipData, loaded_at: now },
+      db: { data: dbData, loaded_at: now },
+      program: { data: progData, loaded_at: now },
+      mode: 'live',
+      loaded_at: now,
+    };
+
+    // Persist snapshot for future fallback
+    _persistSnapshot(now);
+    return;
+  } catch {
+    // Live load failed — try snapshot
+  }
+
+  try {
+    _loadFromSnapshot();
+    return;
+  } catch {
+    // Snapshot also missing/corrupt — cold-start
+  }
+
+  _cache = { equipment: null, db: null, program: null, mode: 'cold', loaded_at: null };
+}
+
+function _loadFromSnapshot(): void {
+  const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf-8');
+  const snap = JSON.parse(raw) as {
+    equipment: EquipmentCache & { loaded_at: string };
+    db: DbCache & { loaded_at: string };
+    program: ProgramCache & { loaded_at: string };
+    loaded_at: string;
+  };
+
+  _cache = {
+    equipment: { data: snap.equipment, loaded_at: snap.equipment.loaded_at },
+    db: { data: snap.db, loaded_at: snap.db.loaded_at },
+    program: { data: snap.program, loaded_at: snap.program.loaded_at },
+    mode: 'snapshot',
+    loaded_at: snap.loaded_at,
+  };
+}
+
+function _persistSnapshot(loadedAt: string): void {
+  if (!_cache.equipment || !_cache.db || !_cache.program) return;
+  const snap = {
+    equipment: { ..._cache.equipment.data, loaded_at: _cache.equipment.loaded_at },
+    db: { ..._cache.db.data, loaded_at: _cache.db.loaded_at },
+    program: { ..._cache.program.data, loaded_at: _cache.program.loaded_at },
+    mode: 'live',
+    loaded_at: loadedAt,
+  };
+  try {
+    fs.writeFileSync(SNAPSHOT_PATH, JSON.stringify(snap, null, 2), 'utf-8');
+  } catch {
+    // snapshot write failure is non-fatal
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function getMasterStatus(userId: string): MasterStatusResult {
+  const cooldownEntry = _cooldownMap.get(userId);
+  let cooldown_until: string | null = null;
+  if (cooldownEntry) {
+    const remaining = new Date(cooldownEntry).getTime() + COOLDOWN_MS - Date.now();
+    if (remaining > 0) {
+      cooldown_until = new Date(new Date(cooldownEntry).getTime() + COOLDOWN_MS).toISOString();
+    }
+  }
+
+  return {
+    loaded_at: _cache.loaded_at,
+    cooldown_until,
+    mode: _cache.mode,
+    sources: {
+      equipment: _cache.equipment
+        ? { loaded_at: _cache.equipment.loaded_at, ...(_cache.equipment.kept_loaded_at ? { kept_loaded_at: _cache.equipment.kept_loaded_at } : {}) }
+        : null,
+      db: _cache.db
+        ? { loaded_at: _cache.db.loaded_at, ...(_cache.db.kept_loaded_at ? { kept_loaded_at: _cache.db.kept_loaded_at } : {}) }
+        : null,
+      program: _cache.program
+        ? { loaded_at: _cache.program.loaded_at }
+        : null,
+    },
+  };
+}
+
+/**
+ * Trigger a manual refresh of the two refreshable sources (equipment + db).
+ * Cooldown: 5 min per user.
+ * Atomic swap: all must succeed or existing cache is kept.
+ *
+ * Throws typed errors for route layer to map to HTTP status:
+ *   { code: 'RATE_LIMITED', cooldown_until, kept_loaded_at }  → 429
+ *   { code: 'EXTERNAL_MASTER_UNAVAILABLE', kept_loaded_at }   → 503
+ */
+export async function triggerRefresh(userId: string): Promise<MasterRefreshResult> {
+  // Cooldown check
+  const lastRefresh = _cooldownMap.get(userId);
+  if (lastRefresh) {
+    const elapsed = Date.now() - new Date(lastRefresh).getTime();
+    if (elapsed < COOLDOWN_MS) {
+      const cooldown_until = new Date(new Date(lastRefresh).getTime() + COOLDOWN_MS).toISOString();
+      const kept_loaded_at = _cache.loaded_at;
+      throw Object.assign(
+        new Error('쿨다운 중입니다. 5분 후 다시 시도하세요.'),
+        { code: 'RATE_LIMITED', cooldown_until, kept_loaded_at },
+      );
+    }
+  }
+
+  // Attempt atomic load of both refreshable sources
+  const now = new Date().toISOString();
+  let newEquip: EquipmentCache;
+  let newDb: DbCache;
+
+  try {
+    newEquip = loadEquipmentStub();
+    newDb = loadDbStub();
+  } catch (err) {
+    const kept_loaded_at = _cache.loaded_at;
+    // Preserve existing kept_loaded_at on equipment/db if previously set
+    if (_cache.equipment && kept_loaded_at) {
+      _cache.equipment.kept_loaded_at = kept_loaded_at;
+    }
+    if (_cache.db && kept_loaded_at) {
+      _cache.db.kept_loaded_at = kept_loaded_at;
+    }
+    throw Object.assign(
+      new Error(`외부 마스터 로드 실패: ${String(err)}`),
+      { code: 'EXTERNAL_MASTER_UNAVAILABLE', kept_loaded_at },
+    );
+  }
+
+  // Both succeeded — atomically swap cache
+  _cache.equipment = { data: newEquip, loaded_at: now };
+  _cache.db = { data: newDb, loaded_at: now };
+  _cache.loaded_at = now;
+  _cache.mode = 'live';
+
+  // Record cooldown for this user
+  _cooldownMap.set(userId, now);
+
+  // Persist new snapshot asynchronously (non-blocking, non-fatal)
+  setImmediate(() => _persistSnapshot(now));
+
+  return {
+    swapped: true,
+    loaded_at: now,
+    sources: {
+      equipment: { loaded_at: now },
+      db: { loaded_at: now },
+    },
+  };
+}
+
+/** Expose raw cache data for downstream VOC field verification. */
+export function getCacheData() {
+  return {
+    equipment: _cache.equipment?.data ?? null,
+    db: _cache.db?.data ?? null,
+    program: _cache.program?.data ?? null,
+    mode: _cache.mode,
+  };
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -12,6 +12,7 @@ const NoticePage = lazy(() => import('@pages/notice'));
 const FaqPage = lazy(() => import('@pages/faq'));
 const AdminTagsPage = lazy(() => import('@pages/admin/tags'));
 const AdminTrashPage = lazy(() => import('@pages/admin/trash'));
+const AdminMastersPage = lazy(() => import('@pages/admin/masters'));
 
 function VocRoute() {
   return (
@@ -101,6 +102,14 @@ export const router = createBrowserRouter([
             element: (
               <Suspense fallback={<LoadingState />}>
                 <AdminTrashPage />
+              </Suspense>
+            ),
+          },
+          {
+            path: 'masters',
+            element: (
+              <Suspense fallback={<LoadingState />}>
+                <AdminMastersPage />
               </Suspense>
             ),
           },

--- a/frontend/src/features/admin/external-masters/api/useMastersApi.ts
+++ b/frontend/src/features/admin/external-masters/api/useMastersApi.ts
@@ -1,0 +1,86 @@
+/**
+ * External Masters admin API hooks — Wave 3 Phase D (W3-6).
+ * Spec: requirements.md §16.3, external-masters.md §0/§6
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+// ─── Types (mirrors shared/contracts/admin/master.ts) ────────────────────────
+
+export type MasterMode = 'live' | 'snapshot' | 'cold';
+
+export interface SourceEntry {
+  loaded_at: string;
+  kept_loaded_at?: string;
+}
+
+export interface MasterStatusResponse {
+  loaded_at: string | null;
+  cooldown_until: string | null;
+  mode: MasterMode;
+  sources: {
+    equipment: SourceEntry | null;
+    db: SourceEntry | null;
+    program: SourceEntry | null;
+  };
+}
+
+export interface MasterRefreshResponse {
+  swapped: boolean;
+  loaded_at: string;
+  sources: {
+    equipment: { loaded_at: string };
+    db: { loaded_at: string };
+  };
+}
+
+export interface RefreshError {
+  status: number;
+  code: string;
+  message: string;
+  details?: {
+    cooldown_until?: string | null;
+    kept_loaded_at?: string | null;
+  };
+}
+
+// ─── Fetchers ─────────────────────────────────────────────────────────────────
+
+async function fetchMasterStatus(): Promise<MasterStatusResponse> {
+  const res = await fetch('/api/admin/masters/status');
+  if (!res.ok) throw new Error(`Status fetch failed: ${res.status}`);
+  return res.json() as Promise<MasterStatusResponse>;
+}
+
+async function postRefresh(): Promise<MasterRefreshResponse> {
+  const res = await fetch('/api/admin/masters/refresh', { method: 'POST' });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+    throw Object.assign(
+      new Error((body.message as string) ?? 'Refresh failed'),
+      { status: res.status, code: body.code, details: body.details },
+    );
+  }
+  return res.json() as Promise<MasterRefreshResponse>;
+}
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+export const MASTERS_STATUS_KEY = ['admin', 'masters', 'status'] as const;
+
+export function useMasterStatus() {
+  return useQuery({
+    queryKey: MASTERS_STATUS_KEY,
+    queryFn: fetchMasterStatus,
+    staleTime: 30_000, // 30 s — UI still reflects real mode quickly
+  });
+}
+
+export function useRefreshMasters() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: postRefresh,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: MASTERS_STATUS_KEY });
+    },
+  });
+}

--- a/frontend/src/features/admin/external-masters/index.ts
+++ b/frontend/src/features/admin/external-masters/index.ts
@@ -1,0 +1,2 @@
+export { MastersTable } from './ui/MastersTable';
+export { useMasterStatus, useRefreshMasters } from './api/useMastersApi';

--- a/frontend/src/features/admin/external-masters/ui/MasterSourceRow.tsx
+++ b/frontend/src/features/admin/external-masters/ui/MasterSourceRow.tsx
@@ -1,0 +1,64 @@
+/**
+ * MasterSourceRow — one row in the masters status table.
+ * Spec: requirements.md §16.3
+ */
+import type { SourceEntry } from '../api/useMastersApi';
+
+interface MasterSourceRowProps {
+  label: string;
+  source: SourceEntry | null;
+  refreshable: boolean;
+}
+
+function formatTs(iso: string) {
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export function MasterSourceRow({ label, source, refreshable }: MasterSourceRowProps) {
+  const cell: React.CSSProperties = {
+    padding: '12px 16px',
+    borderBottom: '1px solid var(--border-subtle)',
+    fontSize: '14px',
+    color: 'var(--text-primary)',
+    verticalAlign: 'middle',
+  };
+
+  return (
+    <tr>
+      <td style={cell}>{label}</td>
+      <td style={cell}>
+        {refreshable
+          ? <span style={{ color: 'var(--text-secondary)' }}>MSSQL (stub)</span>
+          : <span style={{ color: 'var(--text-secondary)' }}>JSON 파일</span>}
+      </td>
+      <td style={cell}>
+        {refreshable
+          ? <span style={{ color: 'var(--status-green)', fontWeight: 500 }}>가능</span>
+          : <span style={{ color: 'var(--text-tertiary)' }}>불가 (서버 재시작)</span>}
+      </td>
+      <td style={cell}>
+        {source ? (
+          <span title={source.loaded_at}>{formatTs(source.loaded_at)}</span>
+        ) : (
+          <span style={{ color: 'var(--text-tertiary)', fontStyle: 'italic' }}>미로드</span>
+        )}
+      </td>
+      <td style={cell}>
+        {source?.kept_loaded_at ? (
+          <span title={source.kept_loaded_at} style={{ color: 'var(--status-yellow)' }}>
+            {formatTs(source.kept_loaded_at)}
+          </span>
+        ) : (
+          <span style={{ color: 'var(--text-tertiary)' }}>—</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/features/admin/external-masters/ui/MastersTable.tsx
+++ b/frontend/src/features/admin/external-masters/ui/MastersTable.tsx
@@ -1,0 +1,163 @@
+/**
+ * MastersTable — external masters status table + refresh action.
+ * Spec: requirements.md §16.3, external-masters.md §0/§6/§8
+ *
+ * Shows:
+ *  - ModeBadge (live / snapshot / cold)
+ *  - Per-source loaded_at / kept_loaded_at
+ *  - Refresh button (Manager+ only; cooldown UX)
+ */
+import { toast } from 'sonner';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@shared/ui/button';
+import { ModeBadge } from './ModeBadge';
+import { MasterSourceRow } from './MasterSourceRow';
+import { useMasterStatus, useRefreshMasters } from '../api/useMastersApi';
+import type { RefreshError } from '../api/useMastersApi';
+
+const HEADERS = ['마스터', '원천', 'Refresh', '최종 로드', '이전 로드 (유지)'];
+
+interface MastersTableProps {
+  canRefresh: boolean; // admin or manager
+}
+
+export function MastersTable({ canRefresh }: MastersTableProps) {
+  const { data, isPending, isError, refetch } = useMasterStatus();
+  const refresh = useRefreshMasters();
+
+  async function handleRefresh() {
+    try {
+      const result = await refresh.mutateAsync();
+      if (result.swapped) {
+        toast.success('마스터 데이터 갱신 완료', {
+          description: `로드 시각: ${result.loaded_at}`,
+        });
+      }
+    } catch (err: unknown) {
+      const e = err as RefreshError;
+      if (e.status === 429) {
+        const until = e.details?.cooldown_until
+          ? ` (${new Date(e.details.cooldown_until).toLocaleTimeString('ko-KR')}까지)`
+          : '';
+        toast.warning(`쿨다운 중입니다${until}`, {
+          description: '5분 후 다시 시도하세요.',
+        });
+      } else if (e.status === 503) {
+        toast.error('외부 마스터 로드 실패', {
+          description: '기존 데이터를 유지합니다. 시스템 상태를 확인하세요.',
+        });
+      } else {
+        toast.error('갱신 실패', { description: e.message ?? '알 수 없는 오류' });
+      }
+    }
+  }
+
+  if (isPending) {
+    return (
+      <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '14px' }}>
+        불러오는 중…
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div style={{ padding: '48px', textAlign: 'center' }}>
+        <p style={{ color: 'var(--status-red)', fontSize: '14px', marginBottom: '12px' }}>
+          마스터 상태를 불러오지 못했습니다.
+        </p>
+        <Button variant="outline" onClick={() => void refetch()}>다시 시도</Button>
+      </div>
+    );
+  }
+
+  const isWithinCooldown = data.cooldown_until
+    ? new Date(data.cooldown_until).getTime() > Date.now()
+    : false;
+
+  const cooldownLabel = isWithinCooldown && data.cooldown_until
+    ? `쿨다운 (${new Date(data.cooldown_until).toLocaleTimeString('ko-KR')}까지)`
+    : undefined;
+
+  return (
+    <div>
+      {/* Header row: mode badge + refresh button */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
+        <ModeBadge mode={data.mode} />
+        {data.mode === 'cold' && (
+          <span style={{ fontSize: '13px', color: 'var(--status-red)' }}>
+            스냅샷 파일이 없습니다. 수동 Refresh 후 정상화됩니다.
+          </span>
+        )}
+        {data.mode === 'snapshot' && (
+          <span style={{ fontSize: '13px', color: 'var(--status-yellow)' }}>
+            디스크 스냅샷에서 로드 중입니다. Refresh로 최신 데이터를 가져오세요.
+          </span>
+        )}
+        {canRefresh && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={refresh.isPending || isWithinCooldown}
+            onClick={() => void handleRefresh()}
+            style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '6px' }}
+            title={cooldownLabel}
+          >
+            <RefreshCw size={14} className={refresh.isPending ? 'animate-spin' : ''} />
+            {refresh.isPending ? '갱신 중…' : cooldownLabel ?? '전체 Refresh'}
+          </Button>
+        )}
+      </div>
+
+      {/* Status table */}
+      <div style={{ overflowX: 'auto', borderRadius: '8px', border: '1px solid var(--border-subtle)' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: 'var(--surface-subtle)' }}>
+              {HEADERS.map((h) => (
+                <th
+                  key={h}
+                  style={{
+                    padding: '10px 16px',
+                    textAlign: 'left',
+                    fontSize: '12px',
+                    fontWeight: 600,
+                    color: 'var(--text-secondary)',
+                    borderBottom: '1px solid var(--border-subtle)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <MasterSourceRow
+              label="설비 마스터"
+              source={data.sources.equipment}
+              refreshable={true}
+            />
+            <MasterSourceRow
+              label="DB 마스터"
+              source={data.sources.db}
+              refreshable={true}
+            />
+            <MasterSourceRow
+              label="프로그램 마스터"
+              source={data.sources.program}
+              refreshable={false}
+            />
+          </tbody>
+        </table>
+      </div>
+
+      {/* Global loaded_at */}
+      {data.loaded_at && (
+        <p style={{ marginTop: '8px', fontSize: '12px', color: 'var(--text-tertiary)' }}>
+          전체 최종 로드: {new Date(data.loaded_at).toLocaleString('ko-KR')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin/external-masters/ui/ModeBadge.tsx
+++ b/frontend/src/features/admin/external-masters/ui/ModeBadge.tsx
@@ -1,0 +1,37 @@
+/**
+ * ModeBadge — snapshot / cold-start / live status badge.
+ * Spec: requirements.md §16.3, external-masters.md §8
+ * Tokens: var(--*) only. No raw hex.
+ */
+import type { MasterMode } from '../api/useMastersApi';
+
+interface ModeBadgeProps {
+  mode: MasterMode;
+}
+
+const BADGE_STYLES: Record<MasterMode, { label: string; bg: string; color: string }> = {
+  live:     { label: '정상',          bg: 'var(--status-green-subtle)', color: 'var(--status-green)' },
+  snapshot: { label: '스냅샷 모드',   bg: 'var(--status-yellow-subtle)', color: 'var(--status-yellow)' },
+  cold:     { label: '콜드 스타트 모드', bg: 'var(--status-red-subtle)', color: 'var(--status-red)' },
+};
+
+export function ModeBadge({ mode }: ModeBadgeProps) {
+  const s = BADGE_STYLES[mode];
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 8px',
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: 600,
+        lineHeight: '18px',
+        background: s.bg,
+        color: s.color,
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/AdminMastersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminMastersPage.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * AdminMastersPage — role-guard, status display, and refresh action tests (W3-6).
+ * Pattern mirrors AdminTrashPage.test.tsx.
+ * Spec: requirements.md §16.3, external-masters.md §0
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ---- Module-level mocks ----
+const mockRole = vi.fn();
+vi.mock('@entities/user/model/useRole', () => ({ useRole: () => mockRole() }));
+
+const mockUseMasterStatus = vi.fn();
+const mockRefreshMutateAsync = vi.fn();
+
+vi.mock('@features/admin/external-masters/api/useMastersApi', () => ({
+  useMasterStatus: () => mockUseMasterStatus(),
+  useRefreshMasters: () => ({
+    mutateAsync: mockRefreshMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// MastersTable mock — renders predictable DOM based on mocked hook
+vi.mock('@features/admin/external-masters', () => ({
+  MastersTable: ({ canRefresh }: { canRefresh: boolean }) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const status = mockUseMasterStatus();
+    if (status.isPending) return <div>불러오는 중…</div>;
+    if (status.isError) return <div>마스터 상태를 불러오지 못했습니다.</div>;
+    const mode = status.data?.mode ?? 'cold';
+    return (
+      <div>
+        <span data-testid="mode-badge">{mode}</span>
+        <span>설비 마스터</span>
+        <span>DB 마스터</span>
+        <span>프로그램 마스터</span>
+        {canRefresh && (
+          <button
+            onClick={() => void mockRefreshMutateAsync()}
+            data-testid="refresh-btn"
+          >
+            전체 Refresh
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+import AdminMastersPage from '../masters';
+
+// ---- Role fixtures ----
+const adminRole  = { role: 'admin'   as const, isAdmin: true,  isManager: false, isDev: false, isUser: false };
+const managerRole= { role: 'manager' as const, isAdmin: false, isManager: true,  isDev: false, isUser: false };
+const devRole    = { role: 'dev'     as const, isAdmin: false, isManager: false, isDev: true,  isUser: false };
+const userRole   = { role: 'user'    as const, isAdmin: false, isManager: false, isDev: false, isUser: true  };
+
+const LIVE_STATUS = {
+  isPending: false,
+  isError: false,
+  data: { loaded_at: '2026-04-26T12:36:07.262Z', cooldown_until: null, mode: 'live' as const, sources: {} },
+};
+
+const COLD_STATUS = {
+  isPending: false,
+  isError: false,
+  data: { loaded_at: null, cooldown_until: null, mode: 'cold' as const, sources: {} },
+};
+
+const SNAPSHOT_STATUS = {
+  isPending: false,
+  isError: false,
+  data: { loaded_at: '2026-04-26T12:36:07.262Z', cooldown_until: null, mode: 'snapshot' as const, sources: {} },
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/admin/masters']}>
+          <Routes>
+            <Route path="/admin/masters" element={children} />
+            <Route path="/voc" element={<div>VOC Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseMasterStatus.mockReturnValue(LIVE_STATUS);
+});
+
+// ─── Role guard ───────────────────────────────────────────────────────────────
+
+describe('Role guard — FE redirect', () => {
+  it('admin → renders page', async () => {
+    mockRole.mockReturnValue(adminRole);
+    const { Wrapper } = { Wrapper: makeWrapper() };
+    render(<AdminMastersPage />, { wrapper: Wrapper });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toBeInTheDocument());
+  });
+
+  it('manager → renders page', async () => {
+    mockRole.mockReturnValue(managerRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toBeInTheDocument());
+  });
+
+  it('dev → renders page (read-only, OQ-2 Option B)', async () => {
+    mockRole.mockReturnValue(devRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toBeInTheDocument());
+  });
+
+  it('user → redirected to /voc', async () => {
+    mockRole.mockReturnValue(userRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByText('VOC Page')).toBeInTheDocument());
+  });
+});
+
+// ─── Mode badges ─────────────────────────────────────────────────────────────
+
+describe('Mode badges', () => {
+  it('shows live mode', async () => {
+    mockRole.mockReturnValue(adminRole);
+    mockUseMasterStatus.mockReturnValue(LIVE_STATUS);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toHaveTextContent('live'));
+  });
+
+  it('shows cold-start mode', async () => {
+    mockRole.mockReturnValue(adminRole);
+    mockUseMasterStatus.mockReturnValue(COLD_STATUS);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toHaveTextContent('cold'));
+  });
+
+  it('shows snapshot mode', async () => {
+    mockRole.mockReturnValue(adminRole);
+    mockUseMasterStatus.mockReturnValue(SNAPSHOT_STATUS);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toHaveTextContent('snapshot'));
+  });
+});
+
+// ─── Refresh button — canRefresh ─────────────────────────────────────────────
+
+describe('Refresh button permission', () => {
+  it('admin sees refresh button', async () => {
+    mockRole.mockReturnValue(adminRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('refresh-btn')).toBeInTheDocument());
+  });
+
+  it('manager sees refresh button', async () => {
+    mockRole.mockReturnValue(managerRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('refresh-btn')).toBeInTheDocument());
+  });
+
+  it('dev does NOT see refresh button (read-only)', async () => {
+    mockRole.mockReturnValue(devRole);
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(screen.getByTestId('mode-badge')).toBeInTheDocument());
+    expect(screen.queryByTestId('refresh-btn')).not.toBeInTheDocument();
+  });
+
+  it('refresh button calls mutateAsync', async () => {
+    mockRole.mockReturnValue(adminRole);
+    mockRefreshMutateAsync.mockResolvedValueOnce({
+      swapped: true,
+      loaded_at: '2026-04-26T12:36:07.262Z',
+      sources: { equipment: { loaded_at: '2026-04-26T12:36:07.262Z' }, db: { loaded_at: '2026-04-26T12:36:07.262Z' } },
+    });
+    render(<AdminMastersPage />, { wrapper: makeWrapper() });
+    await waitFor(() => screen.getByTestId('refresh-btn'));
+    await userEvent.click(screen.getByTestId('refresh-btn'));
+    expect(mockRefreshMutateAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/admin/masters.tsx
+++ b/frontend/src/pages/admin/masters.tsx
@@ -1,0 +1,28 @@
+/**
+ * /admin/masters — External Masters admin page (W3-6)
+ * Role guard: admin / manager / dev (OQ-2 Option B). User → /voc redirect.
+ * BE 403 is secondary defense.
+ * Spec: requirements.md §16.3, external-masters.md §0
+ */
+import { Navigate } from 'react-router-dom';
+import { PageLayout, PageHeader } from '@widgets/app-shell';
+import { useRole } from '@entities/user/model/useRole';
+import { MastersTable } from '@features/admin/external-masters';
+
+export default function AdminMastersPage() {
+  const { isAdmin, isManager, isDev } = useRole();
+
+  // User → redirect; dev gets read-only view (OQ-2 Option B)
+  if (!(isAdmin || isManager || isDev)) {
+    return <Navigate to="/voc" replace />;
+  }
+
+  // Only admin/manager may trigger refresh (dev is read-only)
+  const canRefresh = isAdmin || isManager;
+
+  return (
+    <PageLayout header={<PageHeader title="외부 마스터" />}>
+      <MastersTable canRefresh={canRefresh} />
+    </PageLayout>
+  );
+}

--- a/frontend/src/test/mocks/handlers/admin-masters.ts
+++ b/frontend/src/test/mocks/handlers/admin-masters.ts
@@ -1,0 +1,19 @@
+/**
+ * MSW handlers — admin external masters (W3-6)
+ * Spec: requirements.md §16.3, external-masters.md §0/§6
+ */
+import { http, HttpResponse } from 'msw';
+import {
+  MASTER_STATUS_LIVE,
+  MASTER_REFRESH_OK,
+} from '../../../../../shared/fixtures/admin-masters.fixtures';
+
+export const adminMastersHandlers = [
+  http.get('/api/admin/masters/status', () => {
+    return HttpResponse.json(MASTER_STATUS_LIVE);
+  }),
+
+  http.post('/api/admin/masters/refresh', () => {
+    return HttpResponse.json(MASTER_REFRESH_OK);
+  }),
+];

--- a/frontend/src/test/mocks/handlers/index.ts
+++ b/frontend/src/test/mocks/handlers/index.ts
@@ -8,6 +8,7 @@ import { faqHandlers } from './faq';
 import { faqCategoryHandlers } from './faq-categories';
 import { adminTagsHandlers } from './admin-tags';
 import { adminTrashHandlers } from './admin-trash';
+import { adminMastersHandlers } from './admin-masters';
 
 export const handlers = [
   ...healthHandlers,
@@ -20,4 +21,5 @@ export const handlers = [
   ...faqCategoryHandlers,
   ...adminTagsHandlers,
   ...adminTrashHandlers,
+  ...adminMastersHandlers,
 ];

--- a/shared/fixtures/admin-masters.fixtures.ts
+++ b/shared/fixtures/admin-masters.fixtures.ts
@@ -1,0 +1,98 @@
+/**
+ * @module shared/fixtures/admin-masters.fixtures
+ *
+ * External Masters admin fixtures for:
+ *  - FE MSW handlers (frontend/src/test/mocks/handlers/admin-masters.ts)
+ *  - BE Jest tests (mock service injection)
+ *
+ * Spec: requirements.md §16.3, external-masters.md §0/§6/§8
+ * Covers: live / snapshot / cold-start modes + cooldown state
+ */
+
+export const MASTER_LOADED_AT = '2026-04-26T12:36:07.262Z';
+export const MASTER_COOLDOWN_UNTIL = '2026-04-26T12:41:07.262Z';
+
+// ─── Status fixtures ──────────────────────────────────────────────────────────
+
+/** Live mode — all 3 sources freshly loaded, no cooldown */
+export const MASTER_STATUS_LIVE = {
+  loaded_at: MASTER_LOADED_AT,
+  cooldown_until: null,
+  mode: 'live' as const,
+  sources: {
+    equipment: { loaded_at: MASTER_LOADED_AT },
+    db:        { loaded_at: MASTER_LOADED_AT },
+    program:   { loaded_at: MASTER_LOADED_AT },
+  },
+};
+
+/** Snapshot mode — loaded from disk fallback, no cooldown */
+export const MASTER_STATUS_SNAPSHOT = {
+  loaded_at: MASTER_LOADED_AT,
+  cooldown_until: null,
+  mode: 'snapshot' as const,
+  sources: {
+    equipment: { loaded_at: MASTER_LOADED_AT, kept_loaded_at: MASTER_LOADED_AT },
+    db:        { loaded_at: MASTER_LOADED_AT, kept_loaded_at: MASTER_LOADED_AT },
+    program:   { loaded_at: MASTER_LOADED_AT },
+  },
+};
+
+/** Cold-start mode — no snapshot, all fields unverified */
+export const MASTER_STATUS_COLD = {
+  loaded_at: null,
+  cooldown_until: null,
+  mode: 'cold' as const,
+  sources: {
+    equipment: null,
+    db:        null,
+    program:   null,
+  },
+};
+
+/** Live mode with active cooldown */
+export const MASTER_STATUS_WITH_COOLDOWN = {
+  ...MASTER_STATUS_LIVE,
+  cooldown_until: MASTER_COOLDOWN_UNTIL,
+};
+
+// ─── Refresh result fixtures ──────────────────────────────────────────────────
+
+/** Successful refresh */
+export const MASTER_REFRESH_OK = {
+  swapped: true,
+  loaded_at: MASTER_LOADED_AT,
+  sources: {
+    equipment: { loaded_at: MASTER_LOADED_AT },
+    db:        { loaded_at: MASTER_LOADED_AT },
+  },
+};
+
+/** Failed refresh — atomic swap rejected, kept_loaded_at preserved */
+export const MASTER_REFRESH_FAILED = {
+  swapped: false,
+  loaded_at: MASTER_LOADED_AT,
+  sources: {
+    equipment: { loaded_at: MASTER_LOADED_AT },
+    db:        { loaded_at: MASTER_LOADED_AT },
+  },
+};
+
+// ─── Error fixtures ───────────────────────────────────────────────────────────
+
+export const MASTER_ERROR_RATE_LIMITED = {
+  code: 'RATE_LIMITED',
+  message: '쿨다운 중입니다. 5분 후 다시 시도하세요.',
+  details: {
+    cooldown_until: MASTER_COOLDOWN_UNTIL,
+    kept_loaded_at: MASTER_LOADED_AT,
+  },
+};
+
+export const MASTER_ERROR_UNAVAILABLE = {
+  code: 'EXTERNAL_MASTER_UNAVAILABLE',
+  message: '외부 마스터 로드 실패: MSSQL 연결 오류',
+  details: {
+    kept_loaded_at: MASTER_LOADED_AT,
+  },
+};


### PR DESCRIPTION
## Summary

Implements the `/admin/masters` External Masters admin screen end-to-end (Wave 3 Phase D — W3-6).

**Spec refs:** `requirements.md §16.3`, `external-masters.md §0/§6/§7/§8`, `wave-3-admin.md W3-6`

- `GET /api/admin/masters/status` — read for admin / manager / dev (OQ-2 Option B)
- `POST /api/admin/masters/refresh` — mutate for admin / manager only (dev → 403)
- 5-min cooldown per user → 429 `RATE_LIMITED` with `cooldown_until` + `kept_loaded_at`
- Atomic swap: all 3 sources must succeed or existing cache is preserved → 503 `EXTERNAL_MASTER_UNAVAILABLE`
- Boot-time cache init: live → snapshot file fallback → cold-start (never throws)
- Live / snapshot / cold-start mode badges per §16.3
- Stub loaders for equipment (MSSQL TBD per external-masters.md §7) and db masters
- FE page at `/admin/masters` with role guard (user → redirect, dev → read-only, admin/manager → full refresh)

## Permission matrix (ADR 0004 + OQ-2 Option B)

| Action | admin | manager | dev | user |
|--------|-------|---------|-----|------|
| GET status | ✅ | ✅ | ✅ (read-only) | 403 |
| POST refresh | ✅ | ✅ | 403 | 403 |

## Test counts

- **BE (Jest):** 14 new tests (admin-masters.test.ts) — permission matrix 4×2, cooldown 429, atomic-swap 503, mode badges (live/snapshot/cold)
- **FE (Vitest):** 11 new tests (AdminMastersPage.test.tsx) — role guard, mode badges, refresh button permission, refresh click

Total: BE 276 (269 pass + 7 todo), FE 561 (72 files) — all green.

## Spec ambiguities resolved

- **Equipment MSSQL schema TBD** (external-masters.md §3): implemented as stub loader (`config/masters/equipment-stub.json`) per §7 strategy. Loader interface is identical to real impl — swap one function when schema confirmed.
- **`program` master in status response**: included in `GET status` sources, excluded from `POST refresh` response, per contract in `shared/contracts/admin/master.ts`.
- **Lint pre-existing errors**: `UsersTable.tsx` and `AdminUsersPage.test.tsx` max-lines errors exist on base branch (W3-7 files, confirmed via git stash). W3-6 new files are lint-clean.

## Deferred items (FU candidates)

- **Concurrent refresh race condition** (wave-3-admin.md §8 risk): currently in-memory cooldown per user. Multi-instance race → DB advisory lock or Redis mutex. Deferred to NextGen (equipment schema also TBD).
- **Visual-diff baseline**: `benchmark/` infra requires a running browser. Deferred — document as FU candidate per task instructions.
- **Real MSSQL connection** for equipment + db masters: unblocked once schema confirmed (external-masters.md §3 TBD).

## Test plan

- [ ] `npm run typecheck -w backend` — clean
- [ ] `npm run test -w backend -- --testPathPattern=admin-masters` — 14/14 pass
- [ ] `npm run typecheck -w frontend` — clean
- [ ] `npm run test -w frontend -- --run` — 561/561 pass (72 files)
- [ ] W3-6 new files eslint clean (pre-existing W3-7 lint errors on base branch excluded)
- [ ] `npx tsx scripts/check-fixture-seed-parity.ts` — OK (21 keys / 25 columns)
- [ ] Pre-push hook passed all checks before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)