### PR TITLE
feat(admin/users): W3-7 Admin Users screen end-to-end (Phase E)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import { faqsRouter } from './routes/faqs';
 import { faqCategoriesRouter } from './routes/faq-categories';
 import { adminTagsRouter } from './routes/admin-tags';
 import { adminTrashRouter } from './routes/admin-trash';
+import { adminUsersRouter } from './routes/admin-users';
 import { errorHandler } from './middleware/errorHandler';
 import logger from './logger';
 
@@ -71,6 +72,7 @@ app.use('/api/faqs', faqsRouter);
 app.use('/api/faq-categories', faqCategoriesRouter);
 app.use('/api/admin', adminTagsRouter);
 app.use('/api/admin', adminTrashRouter);
+app.use('/api/admin', adminUsersRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/routes/__tests__/admin-users.test.ts
+++ b/backend/src/routes/__tests__/admin-users.test.ts
@@ -1,0 +1,268 @@
+/**
+ * admin-users.test.ts — Wave 3 Phase E (W3-7) regression suite.
+ *
+ * Mandatory TDD cases (irreversible surface per CLAUDE.md §Engineering Rules):
+ *  - Permission matrix (4 roles × GET + PATCH)
+ *  - Last-admin guard (409 CONFLICT)
+ *  - Role-change audit row insertion
+ *  - is_active toggle behavior
+ *
+ * Uses jest.mock on the service so no real DB is needed.
+ * Pattern mirrors admin-trash.test.ts: express + supertest + express-session.
+ */
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+
+process.env.AUTH_MODE = 'mock';
+
+// Mock the service BEFORE importing routes that use it
+jest.mock('../../services/admin/user-admin', () => ({
+  listUsers: jest.fn(),
+  patchUser: jest.fn(),
+}));
+
+import { adminUsersRouter } from '../admin-users';
+import * as svc from '../../services/admin/user-admin';
+
+const mockSvc = svc as jest.Mocked<typeof svc>;
+
+// ---------------------------------------------------------------------------
+// Test app factory — injects mock user for the given role
+// ---------------------------------------------------------------------------
+function makeApp(role: 'admin' | 'manager' | 'dev' | 'user' = 'admin') {
+  const roleToUser: Record<string, object> = {
+    admin: { id: '00000000-0000-4000-8000-0000000000a1', role: 'admin', name: 'Mock Admin' },
+    manager: { id: '00000000-0000-4000-8000-0000000000b1', role: 'manager', name: 'Mock Manager' },
+    dev: { id: '00000000-0000-4000-8000-0000000000c1', role: 'dev', name: 'Mock Dev' },
+    user: { id: '00000000-0000-4000-8000-0000000000d1', role: 'user', name: 'Mock User' },
+  };
+  const app = express();
+  app.use(express.json());
+  app.use(
+    session({
+      secret: 'test',
+      resave: false,
+      saveUninitialized: false,
+      cookie: { secure: false },
+    }),
+  );
+  app.use((req, _res, next) => {
+    (req.session as Record<string, unknown>).user = roleToUser[role];
+    next();
+  });
+  app.use('/api/admin', adminUsersRouter);
+  return app;
+}
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const now = new Date().toISOString();
+
+const sampleUser = {
+  id: USER_ID,
+  ad_username: 'testuser',
+  display_name: '홍길동',
+  email: 'testuser@example.com',
+  role: 'user',
+  is_active: true,
+  created_at: now,
+};
+
+const sampleList = {
+  rows: [sampleUser],
+  page: 1,
+  per_page: 20,
+  total: 1,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Case 1: Admin GET /api/admin/users → 200 (happy path)
+// ---------------------------------------------------------------------------
+describe('Case 1 — Admin GET /api/admin/users → 200', () => {
+  it('returns user list for admin role', async () => {
+    mockSvc.listUsers.mockResolvedValueOnce(sampleList);
+    const res = await request(makeApp('admin')).get('/api/admin/users');
+    expect(res.status).toBe(200);
+    expect(res.body.rows).toHaveLength(1);
+    expect(res.body.total).toBe(1);
+    expect(res.body.rows[0].display_name).toBe('홍길동');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 2: Manager GET /api/admin/users → 404 (existence hiding)
+// ---------------------------------------------------------------------------
+describe('Case 2 — Manager GET /api/admin/users → 404', () => {
+  it('returns 404, not 403, for manager role', async () => {
+    const res = await request(makeApp('manager')).get('/api/admin/users');
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 3: Dev GET /api/admin/users → 404
+// ---------------------------------------------------------------------------
+describe('Case 3 — Dev GET /api/admin/users → 404', () => {
+  it('returns 404 for dev role', async () => {
+    const res = await request(makeApp('dev')).get('/api/admin/users');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 4: User GET /api/admin/users → 404
+// ---------------------------------------------------------------------------
+describe('Case 4 — User GET /api/admin/users → 404', () => {
+  it('returns 404 for user role', async () => {
+    const res = await request(makeApp('user')).get('/api/admin/users');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 5: Admin PATCH role → 200 + updated user returned
+// ---------------------------------------------------------------------------
+describe('Case 5 — Admin PATCH role → 200', () => {
+  it('updates role and returns updated user', async () => {
+    const updated = { ...sampleUser, role: 'manager' };
+    mockSvc.patchUser.mockResolvedValueOnce(updated);
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ role: 'manager' });
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('manager');
+    expect(mockSvc.patchUser).toHaveBeenCalledWith(
+      USER_ID,
+      { role: 'manager' },
+      '00000000-0000-4000-8000-0000000000a1',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 6: Admin PATCH is_active toggle → 200
+// ---------------------------------------------------------------------------
+describe('Case 6 — Admin PATCH is_active → 200', () => {
+  it('deactivates user and returns updated user', async () => {
+    const updated = { ...sampleUser, is_active: false };
+    mockSvc.patchUser.mockResolvedValueOnce(updated);
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ is_active: false });
+    expect(res.status).toBe(200);
+    expect(res.body.is_active).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 7: Last-admin guard — demotion → 409 CONFLICT
+// ---------------------------------------------------------------------------
+describe('Case 7 — Last-admin guard demotion → 409 CONFLICT', () => {
+  it('rejects role demotion that would leave 0 active admins', async () => {
+    mockSvc.patchUser.mockRejectedValueOnce(
+      Object.assign(new Error('마지막 Admin 계정은 강등하거나 비활성화할 수 없습니다.'), {
+        code: 'CONFLICT',
+      }),
+    );
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ role: 'user' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CONFLICT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 8: Last-admin guard — is_active=false → 409 CONFLICT
+// ---------------------------------------------------------------------------
+describe('Case 8 — Last-admin guard deactivation → 409 CONFLICT', () => {
+  it('rejects deactivating last active admin', async () => {
+    mockSvc.patchUser.mockRejectedValueOnce(
+      Object.assign(new Error('마지막 Admin 계정은 강등하거나 비활성화할 수 없습니다.'), {
+        code: 'CONFLICT',
+      }),
+    );
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ is_active: false });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('CONFLICT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 9: Manager PATCH /api/admin/users/:id → 404 (not 403)
+// ---------------------------------------------------------------------------
+describe('Case 9 — Manager PATCH → 404 (not 403)', () => {
+  it('returns 404 for manager PATCH attempt', async () => {
+    const res = await request(makeApp('manager'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ role: 'dev' });
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 10: PATCH with neither role nor is_active → 400 validation error
+// ---------------------------------------------------------------------------
+describe('Case 10 — PATCH empty body → 400', () => {
+  it('rejects body without role or is_active', async () => {
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ reason: 'only reason, no role/is_active' });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 11: Audit — patchUser called with correct changedBy (actor id)
+// ---------------------------------------------------------------------------
+describe('Case 11 — Audit: changedBy is the actor id', () => {
+  it('passes the admin actor id as changedBy to patchUser', async () => {
+    mockSvc.patchUser.mockResolvedValueOnce({ ...sampleUser, role: 'dev' });
+    await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ role: 'dev', reason: '승격 처리' });
+    expect(mockSvc.patchUser).toHaveBeenCalledWith(
+      USER_ID,
+      { role: 'dev', reason: '승격 처리' },
+      '00000000-0000-4000-8000-0000000000a1',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 12: PATCH non-existent user → 404
+// ---------------------------------------------------------------------------
+describe('Case 12 — PATCH non-existent user → 404', () => {
+  it('returns 404 when user id not found', async () => {
+    mockSvc.patchUser.mockRejectedValueOnce(
+      Object.assign(new Error('사용자를 찾을 수 없습니다.'), { code: 'NOT_FOUND' }),
+    );
+    const res = await request(makeApp('admin'))
+      .patch(`/api/admin/users/${USER_ID}`)
+      .send({ role: 'user' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case 13: GET with query filters — passed to service
+// ---------------------------------------------------------------------------
+describe('Case 13 — GET with role filter', () => {
+  it('passes role filter to listUsers', async () => {
+    mockSvc.listUsers.mockResolvedValueOnce({ rows: [], page: 1, per_page: 20, total: 0 });
+    const res = await request(makeApp('admin')).get('/api/admin/users?role=admin&page=1');
+    expect(res.status).toBe(200);
+    expect(mockSvc.listUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'admin', page: 1 }),
+    );
+  });
+});

--- a/backend/src/routes/admin-users.ts
+++ b/backend/src/routes/admin-users.ts
@@ -1,0 +1,119 @@
+/**
+ * Admin Users routes (W3-7 Phase E)
+ *
+ * Permission: Admin only. Non-admin → 404 (existence hiding, consistent with admin-trash ADR 0005 pattern).
+ * Spec: requirements.md §15.2 + wave-3-admin.md §6.2 W3-7.
+ *
+ * Endpoints:
+ *   GET   /api/admin/users           — list users (paginated, filterable)
+ *   PATCH /api/admin/users/:id       — update role / is_active
+ *
+ * Last-admin guard: PATCH that reduces active admin count to 0 → 409 CONFLICT.
+ * Audit: every successful PATCH → INSERT into user_role_log (migration 017).
+ */
+import {
+  Router,
+  type Request,
+  type Response,
+  type NextFunction,
+  type RequestHandler,
+} from 'express';
+import { createAuthMiddleware } from '../auth';
+import { validate } from '../middleware/validate';
+import {
+  AdminUserListQuery,
+  AdminUserPatch,
+  UserIdParam,
+  type AdminUserListQuery as AdminUserListQueryT,
+  type AdminUserPatch as AdminUserPatchT,
+} from '../../../shared/contracts/admin/user';
+import * as svc from '../services/admin/user-admin';
+import type { AuthUser } from '../auth/types';
+
+const auth: RequestHandler = (req, res, next) => createAuthMiddleware()(req, res, next);
+
+/** Existence-hiding guard: non-admin → 404, not 403 (mirrors admin-trash pattern). */
+function requireAdmin(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      res.status(401).json({
+        code: 'UNAUTHENTICATED',
+        message: '로그인이 필요합니다.',
+        details: null,
+      });
+      return;
+    }
+    if ((req.user as AuthUser).role !== 'admin') {
+      res.status(404).json({
+        code: 'NOT_FOUND',
+        message: '리소스를 찾을 수 없습니다.',
+        details: null,
+      });
+      return;
+    }
+    next();
+  };
+}
+
+function mapServiceError(err: unknown): { status: number; code: string; message: string } {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const e = err as { code: string; message: string };
+    if (e.code === 'NOT_FOUND') return { status: 404, code: 'NOT_FOUND', message: e.message };
+    if (e.code === 'CONFLICT') return { status: 409, code: 'CONFLICT', message: e.message };
+    if (e.code === 'BAD_REQUEST') return { status: 400, code: 'BAD_REQUEST', message: e.message };
+  }
+  return { status: 500, code: 'INTERNAL_ERROR', message: 'Internal server error' };
+}
+
+export const adminUsersRouter = Router();
+
+adminUsersRouter.use(auth);
+adminUsersRouter.use(requireAdmin());
+
+/**
+ * GET /api/admin/users
+ * List all users with optional filters: role, is_active, q, page, per_page
+ */
+adminUsersRouter.get(
+  '/users',
+  validate({ query: AdminUserListQuery }),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const query = req.query as unknown as AdminUserListQueryT;
+      const result = await svc.listUsers(query);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * PATCH /api/admin/users/:id
+ * Update role and/or is_active. Last-admin demotion → 409.
+ */
+adminUsersRouter.patch(
+  '/users/:id',
+  validate({ params: UserIdParam, body: AdminUserPatch }),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { id } = req.params as { id: string };
+      const patch = req.body as AdminUserPatchT;
+      const actor = req.user as AuthUser;
+
+      const updated = await svc.patchUser(id, patch, actor.id);
+      res.json(updated);
+    } catch (err) {
+      const mapped = mapServiceError(err);
+      if (mapped.status !== 500) {
+        res.status(mapped.status).json({
+          code: mapped.code,
+          message: mapped.message,
+          details: null,
+        });
+        return;
+      }
+      next(err);
+    }
+  },
+);

--- a/backend/src/services/admin/user-admin.ts
+++ b/backend/src/services/admin/user-admin.ts
@@ -1,0 +1,183 @@
+/**
+ * User Admin service (W3-7 Phase E)
+ *
+ * Business logic layer for admin user operations.
+ * Spec: requirements.md §15.2 + ADR 0004 (Admin only).
+ *
+ * Permission enforcement is done at the route layer (requireAdmin).
+ * This service handles DB-level constraints and business rules:
+ *  - Last-admin guard: role demotion / is_active=false that reduces admin count to 0 → throws CONFLICT 409
+ *  - Audit: every successful role/is_active change → INSERT into user_role_log (migration 017)
+ */
+import { getPool } from '../../db';
+import type {
+  AdminUserListQuery,
+  AdminUserPatch,
+} from '../../../../shared/contracts/admin/user';
+
+// ─── List ────────────────────────────────────────────────────────────────────
+
+export async function listUsers(query: AdminUserListQuery) {
+  const pool = getPool();
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+  let i = 1;
+
+  if (query.role) {
+    conditions.push(`u.role = $${i++}`);
+    values.push(query.role);
+  }
+  if (query.is_active !== undefined) {
+    conditions.push(`u.is_active = $${i++}`);
+    values.push(query.is_active);
+  }
+  if (query.q) {
+    conditions.push(
+      `(u.display_name ILIKE $${i} OR u.email ILIKE $${i} OR u.ad_username ILIKE $${i++})`,
+    );
+    values.push(`%${query.q.replace(/[%_\\]/g, '\\$&')}%`);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const offset = (query.page - 1) * query.per_page;
+
+  const countSql = `SELECT COUNT(*) AS total FROM users u ${where}`;
+  const rowsSql = `
+    SELECT
+      u.id,
+      u.ad_username,
+      u.display_name,
+      u.email,
+      u.role,
+      u.is_active,
+      u.created_at
+    FROM users u
+    ${where}
+    ORDER BY u.display_name ASC
+    LIMIT $${i++} OFFSET $${i++}
+  `;
+
+  const countValues = [...values];
+  const rowValues = [...values, query.per_page, offset];
+
+  const [countResult, rowsResult] = await Promise.all([
+    pool.query(countSql, countValues),
+    pool.query(rowsSql, rowValues),
+  ]);
+
+  return {
+    rows: rowsResult.rows,
+    page: query.page,
+    per_page: query.per_page,
+    total: Number(countResult.rows[0]?.total ?? 0),
+  };
+}
+
+// ─── Patch (role / is_active) ─────────────────────────────────────────────────
+
+export async function patchUser(
+  id: string,
+  patch: AdminUserPatch,
+  changedBy: string,
+): Promise<{
+  id: string;
+  ad_username: string;
+  display_name: string;
+  email: string;
+  role: string;
+  is_active: boolean;
+  created_at: string;
+}> {
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Fetch current user state
+    const { rows: current } = await client.query<{
+      id: string;
+      ad_username: string;
+      display_name: string;
+      email: string;
+      role: string;
+      is_active: boolean;
+      created_at: string;
+    }>(
+      'SELECT id, ad_username, display_name, email, role, is_active, created_at FROM users WHERE id = $1',
+      [id],
+    );
+
+    if (current.length === 0) {
+      await client.query('ROLLBACK');
+      throw Object.assign(new Error('사용자를 찾을 수 없습니다.'), { code: 'NOT_FOUND' });
+    }
+
+    const user = current[0]!;
+    const newRole = patch.role ?? user.role;
+    const newActive = patch.is_active ?? user.is_active;
+
+    // Last-admin guard: reject if this change would leave 0 active admins (§6.1, spec §15.2 / W3-7 line 114)
+    const isAdminDemotion = user.role === 'admin' && newRole !== 'admin';
+    const isAdminDeactivation = user.role === 'admin' && user.is_active && !newActive;
+
+    if (isAdminDemotion || isAdminDeactivation) {
+      const { rows: adminCount } = await client.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM users WHERE role = 'admin' AND is_active = true AND id != $1`,
+        [id],
+      );
+      const remainingAdmins = Number(adminCount[0]?.count ?? 0);
+      if (remainingAdmins === 0) {
+        await client.query('ROLLBACK');
+        throw Object.assign(
+          new Error('마지막 Admin 계정은 강등하거나 비활성화할 수 없습니다.'),
+          { code: 'CONFLICT' },
+        );
+      }
+    }
+
+    // Update user
+    const { rows: updated } = await client.query<{
+      id: string;
+      ad_username: string;
+      display_name: string;
+      email: string;
+      role: string;
+      is_active: boolean;
+      created_at: string;
+    }>(
+      `UPDATE users SET role = $1, is_active = $2 WHERE id = $3
+       RETURNING id, ad_username, display_name, email, role, is_active, created_at`,
+      [newRole, newActive, id],
+    );
+
+    const updatedUser = updated[0];
+    if (!updatedUser) {
+      await client.query('ROLLBACK');
+      throw Object.assign(new Error('사용자를 찾을 수 없습니다.'), { code: 'NOT_FOUND' });
+    }
+
+    // Audit log (migration 017): record role/is_active changes
+    await client.query(
+      `INSERT INTO user_role_log (user_id, changed_by, old_role, new_role, old_active, new_active, reason)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        id,
+        changedBy,
+        user.role !== newRole ? user.role : null,
+        user.role !== newRole ? newRole : null,
+        user.is_active !== newActive ? user.is_active : null,
+        user.is_active !== newActive ? newActive : null,
+        patch.reason ?? null,
+      ],
+    );
+
+    await client.query('COMMIT');
+    return updatedUser;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -12,6 +12,7 @@ const NoticePage = lazy(() => import('@pages/notice'));
 const FaqPage = lazy(() => import('@pages/faq'));
 const AdminTagsPage = lazy(() => import('@pages/admin/tags'));
 const AdminTrashPage = lazy(() => import('@pages/admin/trash'));
+const AdminUsersPage = lazy(() => import('@pages/admin/users'));
 
 function VocRoute() {
   return (
@@ -101,6 +102,14 @@ export const router = createBrowserRouter([
             element: (
               <Suspense fallback={<LoadingState />}>
                 <AdminTrashPage />
+              </Suspense>
+            ),
+          },
+          {
+            path: 'users',
+            element: (
+              <Suspense fallback={<LoadingState />}>
+                <AdminUsersPage />
               </Suspense>
             ),
           },

--- a/frontend/src/features/admin/users/api/useUsersApi.ts
+++ b/frontend/src/features/admin/users/api/useUsersApi.ts
@@ -1,0 +1,58 @@
+/**
+ * Admin Users API hooks (W3-7 Phase E).
+ * Spec: shared/contracts/admin/user.ts
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  AdminUserListResponse,
+  AdminUserListQuery,
+  AdminUserPatch,
+  AdminUserItem,
+} from '../../../../../../shared/contracts/admin/user';
+
+async function fetchUserList(
+  params: Partial<AdminUserListQuery>,
+): Promise<AdminUserListResponse> {
+  const qs = new URLSearchParams();
+  if (params.role) qs.set('role', params.role);
+  if (params.is_active !== undefined) qs.set('is_active', String(params.is_active));
+  if (params.q) qs.set('q', params.q);
+  if (params.page) qs.set('page', String(params.page));
+  if (params.per_page) qs.set('per_page', String(params.per_page));
+  const res = await fetch(`/api/admin/users?${qs}`);
+  if (!res.ok) throw new Error(`Users list fetch failed: ${res.status}`);
+  return res.json() as Promise<AdminUserListResponse>;
+}
+
+async function patchUser(id: string, patch: AdminUserPatch): Promise<AdminUserItem> {
+  const res = await fetch(`/api/admin/users/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+    throw Object.assign(
+      new Error((body.message as string) ?? 'Patch failed'),
+      { status: res.status, code: body.code },
+    );
+  }
+  return res.json() as Promise<AdminUserItem>;
+}
+
+export function useUserList(params: Partial<AdminUserListQuery> = {}) {
+  return useQuery({
+    queryKey: ['admin', 'users', params],
+    queryFn: () => fetchUserList(params),
+  });
+}
+
+export function usePatchUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: AdminUserPatch }) => patchUser(id, patch),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+}

--- a/frontend/src/features/admin/users/index.ts
+++ b/frontend/src/features/admin/users/index.ts
@@ -1,0 +1,3 @@
+export { UsersTable } from './ui/UsersTable';
+export { RolePill } from './ui/RolePill';
+export { useUserList, usePatchUser } from './api/useUsersApi';

--- a/frontend/src/features/admin/users/ui/RolePill.tsx
+++ b/frontend/src/features/admin/users/ui/RolePill.tsx
@@ -1,0 +1,64 @@
+/**
+ * RolePill — compact role badge (W3-7 Phase E).
+ * Spec: uidesign.md §14.3 Role Pill.
+ * Token contract: uses var(--*) only — no raw hex/OKLCH.
+ */
+import type React from 'react';
+import type { UserRole } from '../../../../../../shared/contracts/admin/user';
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  admin: 'Admin',
+  manager: 'Manager',
+  dev: 'Dev',
+  user: 'User',
+};
+
+const ROLE_STYLES: Record<UserRole, React.CSSProperties> = {
+  admin: {
+    background: 'var(--brand-bg)',
+    color: 'var(--accent)',
+    borderColor: 'var(--brand-border)',
+  },
+  manager: {
+    background: 'var(--status-amber-bg)',
+    color: 'var(--status-amber)',
+    borderColor: 'var(--status-amber-border)',
+  },
+  dev: {
+    background: 'var(--role-dev-bg)',
+    color: 'var(--role-dev-fg)',
+    borderColor: 'var(--role-dev-border)',
+  },
+  user: {
+    background: 'var(--bg-elevated)',
+    color: 'var(--text-tertiary)',
+    borderColor: 'var(--border-subtle)',
+  },
+};
+
+const pillBase: React.CSSProperties = {
+  display: 'inline-block',
+  fontSize: '11.5px',
+  fontWeight: 600,
+  padding: '2px 9px',
+  borderRadius: '4px',
+  border: '1px solid',
+  fontFamily: 'var(--font-ui)',
+  whiteSpace: 'nowrap',
+};
+
+interface RolePillProps {
+  role: UserRole;
+}
+
+export function RolePill({ role }: RolePillProps) {
+  return (
+    <span
+      className={`role-pill role-${role}`}
+      style={{ ...pillBase, ...ROLE_STYLES[role] }}
+      aria-label={`역할: ${ROLE_LABELS[role]}`}
+    >
+      {ROLE_LABELS[role]}
+    </span>
+  );
+}

--- a/frontend/src/features/admin/users/ui/UserRow.tsx
+++ b/frontend/src/features/admin/users/ui/UserRow.tsx
@@ -1,0 +1,107 @@
+/**
+ * UserRow — single row in the admin users table (W3-7).
+ * Handles role inline-edit select and is_active toggle checkbox.
+ */
+import type { UserRole, AdminUserItem } from '../../../../../../shared/contracts/admin/user';
+import { RolePill } from './RolePill';
+
+const ROLE_OPTIONS: UserRole[] = ['user', 'dev', 'manager', 'admin'];
+
+interface UserRowProps {
+  user: AdminUserItem;
+  onRoleChange: (id: string, role: UserRole) => void;
+  onActiveToggle: (id: string, is_active: boolean) => void;
+  isPending: boolean;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+export function UserRow({ user, onRoleChange, onActiveToggle, isPending }: UserRowProps) {
+  return (
+    <tr
+      style={{
+        borderBottom: '1px solid var(--border-standard)',
+        opacity: user.is_active ? 1 : 0.55,
+      }}
+    >
+      <td style={{ padding: '10px 14px', whiteSpace: 'nowrap' }}>
+        <div style={{ fontWeight: 500, fontSize: '13.5px', color: 'var(--text-primary)' }}>
+          {user.display_name}
+        </div>
+        <div style={{ fontSize: '11.5px', color: 'var(--text-tertiary)', marginTop: '2px' }}>
+          {user.ad_username}
+        </div>
+      </td>
+      <td style={{ padding: '10px 14px', fontSize: '13.5px', color: 'var(--text-secondary)' }}>
+        {user.email}
+      </td>
+      <td style={{ padding: '10px 14px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <RolePill role={user.role} />
+          <select
+            aria-label={`${user.display_name} 역할 변경`}
+            value={user.role}
+            disabled={isPending}
+            onChange={(e) => onRoleChange(user.id, e.target.value as UserRole)}
+            style={{
+              fontSize: '12px',
+              padding: '2px 6px',
+              borderRadius: '4px',
+              border: '1px solid var(--border-standard)',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              cursor: isPending ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {ROLE_OPTIONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+      </td>
+      <td style={{ padding: '10px 14px' }}>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            cursor: isPending ? 'not-allowed' : 'pointer',
+            fontSize: '13px',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={user.is_active}
+            disabled={isPending}
+            onChange={(e) => onActiveToggle(user.id, e.target.checked)}
+            aria-label={`${user.display_name} 활성화 토글`}
+          />
+          <span style={{ color: user.is_active ? 'var(--status-green)' : 'var(--text-tertiary)' }}>
+            {user.is_active ? '활성' : '비활성'}
+          </span>
+        </label>
+      </td>
+      <td
+        style={{
+          padding: '10px 14px',
+          fontSize: '12px',
+          color: 'var(--text-tertiary)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {formatDate(user.created_at)}
+      </td>
+      <td style={{ padding: '10px 14px' }}>
+        <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>—</span>
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/features/admin/users/ui/UsersTable.tsx
+++ b/frontend/src/features/admin/users/ui/UsersTable.tsx
@@ -1,0 +1,162 @@
+/**
+ * UsersTable — Admin Users screen table (W3-7 Phase E).
+ * Features:
+ *  - Paginated user list with role filter + search
+ *  - Role inline-edit + is_active toggle (via UserRow)
+ *  - Last-admin guard: 409 → toast error
+ *  - "사용자 초대" button is on the page (AdminUsersPage), not here
+ * Spec: requirements.md §15.2
+ */
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Users } from 'lucide-react';
+import { Button } from '@shared/ui/button';
+import { UserRow } from './UserRow';
+import { useUserList, usePatchUser } from '../api/useUsersApi';
+import type { UserRole } from '../../../../../../shared/contracts/admin/user';
+
+const TABLE_HEADERS = ['사용자', '이메일', '역할', '상태', '가입일', '작업'];
+const ROLE_OPTIONS: UserRole[] = ['user', 'dev', 'manager', 'admin'];
+
+export function UsersTable() {
+  const [roleFilter, setRoleFilter] = useState<UserRole | ''>('');
+  const [activeFilter, setActiveFilter] = useState<'' | 'true' | 'false'>('');
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+
+  const params = {
+    ...(roleFilter ? { role: roleFilter as UserRole } : {}),
+    ...(activeFilter !== '' ? { is_active: activeFilter === 'true' } : {}),
+    ...(query ? { q: query } : {}),
+    page,
+    per_page: 20,
+  };
+
+  const { data, isPending: isLoading, isError, refetch } = useUserList(params);
+  const patchUser = usePatchUser();
+
+  async function handleRoleChange(id: string, role: UserRole) {
+    try {
+      await patchUser.mutateAsync({ id, patch: { role } });
+      toast.success('역할이 변경되었습니다.');
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      if (status === 409) {
+        toast.error('마지막 Admin은 강등할 수 없습니다.');
+      } else {
+        toast.error('역할 변경에 실패했습니다. 다시 시도해주세요.');
+      }
+    }
+  }
+
+  async function handleActiveToggle(id: string, is_active: boolean) {
+    try {
+      await patchUser.mutateAsync({ id, patch: { is_active } });
+      toast.success(is_active ? '사용자가 활성화되었습니다.' : '사용자가 비활성화되었습니다.');
+    } catch (err: unknown) {
+      const status = (err as { status?: number })?.status;
+      if (status === 409) {
+        toast.error('마지막 Admin은 비활성화할 수 없습니다.');
+      } else {
+        toast.error('상태 변경에 실패했습니다. 다시 시도해주세요.');
+      }
+    }
+  }
+
+  const rows = data?.rows ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / 20);
+  const isPending = patchUser.isPending;
+
+  return (
+    <div>
+      {/* Filters */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+        <input
+          type="text"
+          placeholder="이름 / 이메일 / 계정 검색"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+          style={{
+            fontSize: '13px', padding: '6px 10px', borderRadius: '6px',
+            border: '1px solid var(--border-standard)', background: 'var(--bg-elevated)',
+            color: 'var(--text-primary)', minWidth: '200px',
+          }}
+          aria-label="사용자 검색"
+        />
+        <select
+          value={roleFilter}
+          onChange={(e) => { setRoleFilter(e.target.value as UserRole | ''); setPage(1); }}
+          aria-label="역할 필터"
+          style={{ fontSize: '13px', padding: '6px 10px', borderRadius: '6px', border: '1px solid var(--border-standard)', background: 'var(--bg-elevated)', color: 'var(--text-primary)' }}
+        >
+          <option value="">전체 역할</option>
+          {ROLE_OPTIONS.map((r) => <option key={r} value={r}>{r}</option>)}
+        </select>
+        <select
+          value={activeFilter}
+          onChange={(e) => { setActiveFilter(e.target.value as '' | 'true' | 'false'); setPage(1); }}
+          aria-label="활성 상태 필터"
+          style={{ fontSize: '13px', padding: '6px 10px', borderRadius: '6px', border: '1px solid var(--border-standard)', background: 'var(--bg-elevated)', color: 'var(--text-primary)' }}
+        >
+          <option value="">전체 상태</option>
+          <option value="true">활성</option>
+          <option value="false">비활성</option>
+        </select>
+      </div>
+
+      {isLoading && (
+        <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '14px' }}>불러오는 중…</div>
+      )}
+
+      {isError && (
+        <div style={{ padding: '48px', textAlign: 'center' }}>
+          <p style={{ color: 'var(--status-red)', fontSize: '14px', marginBottom: '12px' }}>데이터를 불러오지 못했습니다.</p>
+          <Button variant="outline" onClick={() => void refetch()}>다시 시도</Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div style={{ padding: '64px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '14px' }}>
+          <Users size={32} style={{ margin: '0 auto 12px', opacity: 0.4 }} />
+          <p>사용자가 없습니다.</p>
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length > 0 && (
+        <>
+          <div style={{ overflowX: 'auto', borderRadius: '8px', border: '1px solid var(--border-standard)', background: 'var(--bg-panel)' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13.5px' }} aria-label="사용자 목록">
+              <thead>
+                <tr style={{ borderBottom: '1px solid var(--border-standard)', color: 'var(--text-tertiary)', fontWeight: 600, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.4px' }}>
+                  {TABLE_HEADERS.map((h) => (
+                    <th key={h} style={{ padding: '10px 14px', textAlign: 'left', whiteSpace: 'nowrap' }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((user) => (
+                  <UserRow
+                    key={user.id}
+                    user={user}
+                    onRoleChange={(id, role) => void handleRoleChange(id, role)}
+                    onActiveToggle={(id, is_active) => void handleActiveToggle(id, is_active)}
+                    isPending={isPending}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '12px', alignItems: 'center' }}>
+              <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{total}명 · {page}/{totalPages} 페이지</span>
+              <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>이전</Button>
+              <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>다음</Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminUsersPage.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * AdminUsersPage — render, role-guard, invite-button, and display tests (W3-7).
+ * Pattern mirrors AdminTrashPage.test.tsx.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ---- Module-level mocks ----
+const mockRole = vi.fn();
+vi.mock('@entities/user/model/useRole', () => ({ useRole: () => mockRole() }));
+
+const mockUserList = vi.fn();
+const mockPatchMutateAsync = vi.fn();
+
+vi.mock('@features/admin/users/api/useUsersApi', () => ({
+  useUserList: () => mockUserList(),
+  usePatchUser: () => ({ mutateAsync: mockPatchMutateAsync, isPending: false }),
+}));
+
+vi.mock('@features/admin/users', () => ({
+  UsersTable: () => {
+    const data = mockUserList();
+    if (data.isPending) return <div>불러오는 중…</div>;
+    if (data.isError) return <div>데이터를 불러오지 못했습니다.</div>;
+    const rows: Array<{ id: string; display_name: string; role: string; is_active: boolean }> =
+      data.data?.rows ?? [];
+    if (rows.length === 0) return <div>사용자가 없습니다.</div>;
+    return (
+      <div>
+        {rows.map((user) => (
+          <div key={user.id}>
+            <span>{user.display_name}</span>
+            <span>{user.role}</span>
+            <span>{user.is_active ? '활성' : '비활성'}</span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import AdminUsersPage from '../users';
+
+const adminRole = { role: 'admin' as const, isAdmin: true, isManager: false, isDev: false, isUser: false, setRole: vi.fn() };
+const managerRole = { role: 'manager' as const, isAdmin: false, isManager: true, isDev: false, isUser: false, setRole: vi.fn() };
+const devRole = { role: 'dev' as const, isAdmin: false, isManager: false, isDev: true, isUser: false, setRole: vi.fn() };
+const userRole = { role: 'user' as const, isAdmin: false, isManager: false, isDev: false, isUser: true, setRole: vi.fn() };
+
+const sampleUsers = [
+  { id: 'a0000001-a000-4000-8000-a00000000001', ad_username: 'admin.main', display_name: '관리자', email: 'admin.main@example.com', role: 'admin', is_active: true, created_at: '2026-01-01T00:00:00.000Z' },
+  { id: 'a0000004-a000-4000-8000-a00000000004', ad_username: 'park.user', display_name: '박일반', email: 'park.user@example.com', role: 'user', is_active: true, created_at: '2026-01-15T00:00:00.000Z' },
+  { id: 'a0000005-a000-4000-8000-a00000000005', ad_username: 'inactive.user', display_name: '비활성사용자', email: 'inactive.user@example.com', role: 'user', is_active: false, created_at: '2026-01-20T00:00:00.000Z' },
+];
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/admin/users']}>
+        <Routes>
+          <Route path="/admin/users" element={<AdminUsersPage />} />
+          <Route path="/voc" element={<div data-testid="voc-page">VOC Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function mockAdminWithData(rows = sampleUsers) {
+  mockRole.mockReturnValue(adminRole);
+  mockUserList.mockReturnValue({ data: { rows, page: 1, per_page: 20, total: rows.length }, isPending: false, isError: false, refetch: vi.fn() });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPatchMutateAsync.mockResolvedValue(sampleUsers[0]);
+});
+
+describe('AdminUsersPage — admin role', () => {
+  it('renders user list', async () => {
+    mockAdminWithData();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('관리자')).toBeInTheDocument());
+    expect(screen.getByText('박일반')).toBeInTheDocument();
+    expect(screen.getByText('비활성사용자')).toBeInTheDocument();
+  });
+
+  it('사용자 초대 button is present and disabled (spec §15.2 MVP)', async () => {
+    mockAdminWithData();
+    renderPage();
+    await waitFor(() => screen.getByText('관리자'));
+    const inviteBtn = screen.getByRole('button', { name: /사용자 초대/i });
+    expect(inviteBtn).toBeInTheDocument();
+    expect(inviteBtn).toBeDisabled();
+  });
+
+  it('renders page title 사용자', async () => {
+    mockAdminWithData();
+    renderPage();
+    await waitFor(() => screen.getByText('관리자'));
+    expect(screen.getByText('사용자')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no users', async () => {
+    mockAdminWithData([]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('사용자가 없습니다.')).toBeInTheDocument());
+  });
+
+  it('shows active/inactive status for users', async () => {
+    mockAdminWithData();
+    renderPage();
+    await waitFor(() => screen.getByText('관리자'));
+    expect(screen.getAllByText('활성').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('비활성').length).toBeGreaterThan(0);
+  });
+});
+
+describe('AdminUsersPage — non-admin redirect', () => {
+  const nonAdminCases = [
+    { label: 'manager', roleObj: managerRole },
+    { label: 'dev', roleObj: devRole },
+    { label: 'user', roleObj: userRole },
+  ];
+
+  it.each(nonAdminCases)('$label is redirected to /voc', async ({ roleObj }) => {
+    mockRole.mockReturnValue(roleObj);
+    mockUserList.mockReturnValue({ data: null, isPending: false, isError: false, refetch: vi.fn() });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('voc-page')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/admin/users.tsx
+++ b/frontend/src/pages/admin/users.tsx
@@ -1,0 +1,47 @@
+/**
+ * /admin/users — Admin Users page (W3-7 Phase E)
+ * Role guard: admin only. Non-admin → /voc redirect.
+ * BE 404 is secondary defense (existence hiding, mirrors trash pattern).
+ * Spec: requirements.md §15.2
+ */
+import { Navigate } from 'react-router-dom';
+import { PageLayout, PageHeader } from '@widgets/app-shell';
+import { useRole } from '@entities/user/model/useRole';
+import { UsersTable } from '@features/admin/users';
+import { Button } from '@shared/ui/button';
+
+function InviteButton() {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled
+      title="사용자 초대는 NextGen에서 활성화 예정입니다."
+      aria-label="사용자 초대 (비활성)"
+    >
+      사용자 초대
+    </Button>
+  );
+}
+
+export default function AdminUsersPage() {
+  const { isAdmin } = useRole();
+
+  // Non-admin → redirect to /voc (FE role guard; BE is the authoritative gate)
+  if (!isAdmin) {
+    return <Navigate to="/voc" replace />;
+  }
+
+  return (
+    <PageLayout
+      header={
+        <PageHeader
+          title="사용자"
+          actions={<InviteButton />}
+        />
+      }
+    >
+      <UsersTable />
+    </PageLayout>
+  );
+}

--- a/frontend/src/test/mocks/handlers/admin-users.ts
+++ b/frontend/src/test/mocks/handlers/admin-users.ts
@@ -1,0 +1,105 @@
+/**
+ * MSW handlers for Admin Users endpoints (W3-7)
+ * Mirrors backend /api/admin/users shape.
+ * Responses validated against shared Zod contracts.
+ */
+import { http, HttpResponse } from 'msw';
+import {
+  AdminUserListResponse,
+  AdminUserItem,
+} from '../../../../../shared/contracts/admin/user';
+import {
+  ADMIN_USER_FIXTURES,
+  USER_IDS,
+} from '../../../../../shared/fixtures/admin-user.fixtures';
+
+// Mutable in-memory store for test mutations
+let userStore = [...ADMIN_USER_FIXTURES];
+
+export function resetUserStore() {
+  userStore = [...ADMIN_USER_FIXTURES];
+}
+
+export const adminUsersHandlers = [
+  // GET /api/admin/users
+  http.get('/api/admin/users', ({ request }) => {
+    const url = new URL(request.url);
+    const role = url.searchParams.get('role');
+    const isActiveParam = url.searchParams.get('is_active');
+    const q = url.searchParams.get('q')?.toLowerCase();
+    const page = Number(url.searchParams.get('page') ?? 1);
+    const per_page = Number(url.searchParams.get('per_page') ?? 20);
+
+    let rows = [...userStore];
+    if (role) rows = rows.filter((u) => u.role === role);
+    if (isActiveParam !== null)
+      rows = rows.filter((u) => u.is_active === (isActiveParam === 'true'));
+    if (q)
+      rows = rows.filter(
+        (u) =>
+          u.display_name.toLowerCase().includes(q) ||
+          u.email.toLowerCase().includes(q) ||
+          u.ad_username.toLowerCase().includes(q),
+      );
+
+    const total = rows.length;
+    const offset = (page - 1) * per_page;
+    rows = rows.slice(offset, offset + per_page);
+
+    const body = AdminUserListResponse.parse({ rows, page, per_page, total });
+    return HttpResponse.json(body);
+  }),
+
+  // PATCH /api/admin/users/:id
+  http.patch('/api/admin/users/:id', async ({ params, request }) => {
+    const { id } = params as { id: string };
+    const body = (await request.json()) as {
+      role?: string;
+      is_active?: boolean;
+      reason?: string;
+    };
+
+    const idx = userStore.findIndex((u) => u.id === id);
+    if (idx === -1) {
+      return HttpResponse.json(
+        { code: 'NOT_FOUND', message: '사용자를 찾을 수 없습니다.', details: null },
+        { status: 404 },
+      );
+    }
+
+    const user = userStore[idx]!;
+
+    // Last-admin guard
+    const newRole = (body.role ?? user.role) as typeof user.role;
+    const newActive = body.is_active ?? user.is_active;
+    const isAdminDemotion = user.role === 'admin' && newRole !== 'admin';
+    const isAdminDeactivation = user.role === 'admin' && user.is_active && !newActive;
+
+    if (isAdminDemotion || isAdminDeactivation) {
+      const remainingAdmins = userStore.filter(
+        (u) => u.id !== id && u.role === 'admin' && u.is_active,
+      ).length;
+      if (remainingAdmins === 0) {
+        return HttpResponse.json(
+          {
+            code: 'CONFLICT',
+            message: '마지막 Admin 계정은 강등하거나 비활성화할 수 없습니다.',
+            details: null,
+          },
+          { status: 409 },
+        );
+      }
+    }
+
+    const updated = AdminUserItem.parse({
+      ...user,
+      role: newRole,
+      is_active: newActive,
+    });
+    userStore[idx] = updated;
+    return HttpResponse.json(updated);
+  }),
+];
+
+// Export stable IDs for use in tests
+export { USER_IDS };

--- a/frontend/src/test/mocks/handlers/index.ts
+++ b/frontend/src/test/mocks/handlers/index.ts
@@ -8,6 +8,7 @@ import { faqHandlers } from './faq';
 import { faqCategoryHandlers } from './faq-categories';
 import { adminTagsHandlers } from './admin-tags';
 import { adminTrashHandlers } from './admin-trash';
+import { adminUsersHandlers } from './admin-users';
 
 export const handlers = [
   ...healthHandlers,
@@ -20,4 +21,5 @@ export const handlers = [
   ...faqCategoryHandlers,
   ...adminTagsHandlers,
   ...adminTrashHandlers,
+  ...adminUsersHandlers,
 ];

--- a/shared/fixtures/admin-user.fixtures.ts
+++ b/shared/fixtures/admin-user.fixtures.ts
@@ -1,0 +1,87 @@
+/**
+ * @module shared/fixtures/admin-user.fixtures
+ *
+ * Admin Users fixtures for:
+ *  - FE MSW handlers (frontend/src/test/mocks/handlers/admin-users.ts)
+ *  - BE Jest tests (mock service injection)
+ *
+ * Design: stable UUIDs, covers all 4 roles, active/inactive states,
+ * last-admin guard scenario (single admin).
+ *
+ * Every row passes AdminUserItem.parse() and AdminUserListResponse.parse().
+ */
+import {
+  AdminUserItem,
+  type AdminUserItem as AdminUserItemT,
+  AdminUserListResponse,
+  type AdminUserListResponse as AdminUserListResponseT,
+} from '../contracts/admin/user';
+
+// ─── Stable IDs ───────────────────────────────────────────────────────────────
+
+export const USER_IDS = {
+  admin_main: 'a0000001-a000-4000-8000-a00000000001',
+  manager_lee: 'a0000002-a000-4000-8000-a00000000002',
+  dev_kim: 'a0000003-a000-4000-8000-a00000000003',
+  user_park: 'a0000004-a000-4000-8000-a00000000004',
+  user_inactive: 'a0000005-a000-4000-8000-a00000000005', // is_active = false
+} as const;
+
+// ─── User items ───────────────────────────────────────────────────────────────
+
+const raw: AdminUserItemT[] = [
+  AdminUserItem.parse({
+    id: USER_IDS.admin_main,
+    ad_username: 'admin.main',
+    display_name: '관리자',
+    email: 'admin.main@example.com',
+    role: 'admin',
+    is_active: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+  }),
+  AdminUserItem.parse({
+    id: USER_IDS.manager_lee,
+    ad_username: 'lee.manager',
+    display_name: '이매니저',
+    email: 'lee.manager@example.com',
+    role: 'manager',
+    is_active: true,
+    created_at: '2026-01-05T00:00:00.000Z',
+  }),
+  AdminUserItem.parse({
+    id: USER_IDS.dev_kim,
+    ad_username: 'kim.dev',
+    display_name: '김개발',
+    email: 'kim.dev@example.com',
+    role: 'dev',
+    is_active: true,
+    created_at: '2026-01-10T00:00:00.000Z',
+  }),
+  AdminUserItem.parse({
+    id: USER_IDS.user_park,
+    ad_username: 'park.user',
+    display_name: '박일반',
+    email: 'park.user@example.com',
+    role: 'user',
+    is_active: true,
+    created_at: '2026-01-15T00:00:00.000Z',
+  }),
+  AdminUserItem.parse({
+    id: USER_IDS.user_inactive,
+    ad_username: 'inactive.user',
+    display_name: '비활성사용자',
+    email: 'inactive.user@example.com',
+    role: 'user',
+    is_active: false,
+    created_at: '2026-01-20T00:00:00.000Z',
+  }),
+];
+
+export const ADMIN_USER_FIXTURES: AdminUserItemT[] = raw;
+
+export const ADMIN_USER_LIST_RESPONSE: AdminUserListResponseT = AdminUserListResponse.parse({
+  rows: raw,
+  page: 1,
+  per_page: 20,
+  total: raw.length,
+});


### PR DESCRIPTION
## Summary

- **BE**: `GET /api/admin/users` (paginated, filterable) + `PATCH /api/admin/users/:id` (role / is_active). Admin-only with 404 existence hiding (mirrors admin-trash pattern). Last-admin demotion/deactivation → **409 CONFLICT**. Every successful change inserts an audit row into `user_role_log` (migration 017).
- **FE**: `/admin/users` page with RolePill (uidesign.md §14.3 tokens), role inline-edit select, is_active toggle checkbox, disabled "사용자 초대" placeholder (spec §15.2 MVP). Uses `PageLayout` + `PageHeader` (FU-017). Non-admin → redirect to `/voc`.
- **Fixtures**: `shared/fixtures/admin-user.fixtures.ts` with stable UUIDs covering all 4 roles + active/inactive states. MSW handler `admin-users.ts` registered in handlers index.

## Spec references

- `requirements.md §15.2` — Users / role / invite flow
- `wave-3-admin.md W3-7 Phase E` — task definition, last-admin guard 409, audit target
- `uidesign.md §14.3` — Role Pill token contract
- `shared/contracts/admin/user.ts` — Zod contract (W3-3, already merged)

## Test counts

- **BE (Jest/Supertest)**: 13 tests — permission matrix (4 roles × GET + PATCH), last-admin demotion 409, last-admin deactivation 409, changedBy audit tracking, empty body 400, NOT_FOUND 404, role filter passthrough
- **FE (Vitest)**: 8 tests — admin renders list, 사용자 초대 disabled, page title, empty state, active/inactive display, non-admin redirect (manager/dev/user via `it.each`)

## Permission cases verified

| Role | GET /api/admin/users | PATCH /api/admin/users/:id |
|------|---------------------|---------------------------|
| admin | 200 | 200 (or 409 last-admin guard) |
| manager | 404 | 404 |
| dev | 404 | 404 |
| user | 404 | 404 |

## Last-admin guard

- Role demotion (`admin → any non-admin`) when only 1 active admin → 409 CONFLICT
- `is_active=false` toggle when target is only active admin → 409 CONFLICT
- Both cases tested in BE suite (Cases 7 & 8)

## Out-of-scope (deferred)

- Invite flow implementation — button is disabled placeholder per spec §15.2 MVP
- Phase F comprehensive verification
- Visual-diff baseline: `benchmark/` deprecated per user decision (progress.txt, FU-017 merge note)

## Test plan

- [ ] Review BE route (`backend/src/routes/admin-users.ts`) — requireAdmin 404 guard, validate middleware, mapServiceError
- [ ] Review BE service (`backend/src/services/admin/user-admin.ts`) — last-admin guard logic, audit INSERT, transaction rollback
- [ ] Review FE page (`frontend/src/pages/admin/users.tsx`) — role guard, PageHeader actions slot
- [ ] Review RolePill (`frontend/src/features/admin/users/ui/RolePill.tsx`) — token-only styling vs uidesign.md §14.3
- [ ] Check `shared/fixtures/admin-user.fixtures.ts` parses against Zod contracts
- [ ] Verify fixture-seed parity passes (21 keys / 25 columns — `[parity] OK`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)