### PR TITLE
fix(hookify): block --force-with-lease in force-push rule

### DIFF
--- a/.claude/hookify.block-force-push.local.md
+++ b/.claude/hookify.block-force-push.local.md
@@ -2,7 +2,7 @@
 name: block-force-push
 enabled: true
 event: bash
-pattern: git\s+push\s+.*(--force|-f)(\s|$)
+pattern: git\s+push\s+.*(--force(-with-lease|-if-includes)?|-f)(\s|$|=)
 action: block
 ---
 
@@ -10,6 +10,6 @@ action: block
 
 Per CLAUDE.md git workflow rules:
 
-- Force push to main is strictly prohibited
+- Force push is strictly prohibited (including `--force-with-lease`, `--force-if-includes`, `-f`)
 - If you need to update a PR branch: `gh pr merge <n> --merge --delete-branch`, then create a new branch
 - Never rewrite published history


### PR DESCRIPTION
## Summary
- Extend `block-force-push` regex to also match `--force-with-lease` / `--force-if-includes` (previous pattern required whitespace/end after `--force`, so `-with-lease` slipped through)
- Update rule body to enumerate the variants now covered

## Why
Session-audit (21bfb4d6) flagged R13 (`under_remediation`) regression: two `git push --force-with-lease` calls on feature branches were not blocked, despite hookify being in place. Root cause is the regex gap.

## Test plan
- [ ] After merge, attempt `git push --force-with-lease` on a throwaway branch — should be blocked
- [ ] Normal `git push` (no force flag) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)