### PR TITLE
docs(wave-2): dashboard plan + spec sync (RGL 커스터마이즈 MVP 승격)

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,20 +1,25 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점 (2026-05-10 P2 후속 batch 머지 완료 — Wave 2 또는 운영/배포 phase)
+## 다음 세션 시작점 (2026-05-10 Wave 2 Phase A 4 PR 오픈 — 머지 대기 → Phase D 진입)
 
-→ **P2 후속 3건 머지 완료** (2026-05-10):
-   - **FU-023** (PR #287): `createTag` slug 파생을 `<name>-<kind>` 로 변경 — FU-014 (name, kind) UNIQUE 와 정합. `('공통','general')` / `('공통','menu')` 둘 다 distinct slug. admin-tags.sql.test.ts `it.todo` → 실 테스트.
-   - **FU-024** (PR #289): `@testcontainers/postgresql` 도입 + `__tests__/helpers/testPostgres.ts` (pgvector pg16 컨테이너 + 21 마이그 Up 적용). `admin-sql-tc.test.ts` 5 cell — pg-mem 한계 (ILIKE ESCAPE / RETURNING correlated subquery) 우회. 4 skip 모두 제거.
-   - **FU-025** (PR #288): Notice `visible_from/to` KST 자정 정규화 — `NoticeFormDialog.tsx` 에 `toKstMidnightInstant(dateStr)` helper 추출, `+09:00` 직렬화. 회귀 테스트 5 case.
+→ **Wave 2 Phase A 4 PR 오픈** (2026-05-10, 머지 대기):
+   - **PR #291** (`docs/wave-2-dashboard-plan`): dashboard.md spec sync (NextGen → MVP 승격) + 신규 §"커스터마이즈 v2 — 레이아웃 엔진" + `wave-2-dashboard.md` plan (180+ 줄, Wave 3 구조 미러). codex:rescue 적대적 리뷰 (2026-05-10) 반영 — 위젯 11종 / PUT verb / zod bounds / draft buffer / Phase 순서 D 우선.
+   - **PR #292** (`chore/wave-2-rgl-install`): `react-grid-layout@^1.5.3` + `@types/react-grid-layout@^1.3.6` + Responsive smoke test 1 건. FE 575 → 576.
+   - **PR #293** (`migration/022-locked-widgets`): `dashboard_settings.locked_widgets jsonb NOT NULL DEFAULT '[]'` + Down + pg-mem 회귀 3 건. codex 가 011/012 SQL 스캔 → 컬럼 부재 확정 후 신설. BE 462 → 465.
+   - **PR #294** (`feat/wave-2-contract`): `shared/contracts/dashboard/{io.ts,index.ts}` zod v2 (WidgetId 11종 / Layout bounds `x+w<=12` / SizesV2 breakpoint-keyed / DashboardSettingsPutBody) + `shared/openapi.yaml` PUT 명세 explicit + `shared/fixtures/dashboard.fixtures.ts` stub (DEFAULT_DASHBOARD_SETTINGS). BE 465 → 489 (contract 27 회귀 추가).
 
-→ **메트릭**: BE 462/462 그린 (skip 4 → 0). FE 575/575 그린. typecheck 0.
+→ **결정 잠금** (`wave-2-dashboard.md §3`): W2-D1 react-grid-layout · W2-D2 widget_sizes v2 (breakpoint-keyed) · W2-D3 2-tier lock (Admin `locked_widgets` || personal `widget_visibility[id].locked`, 마이그 022 의존) · W2-D4 `defaultLayouts.ts` · W2-D5 Phase 순서 A → D → B/C 병렬 → E → F · W2-D7 TDD bounds + verb parity + draft cancel · W2-D9 codex:rescue 적대적 리뷰.
 
-→ **다음 세션 작업**: 활성 Open follow-up 다 닫혔음 (P3 만 잔존: FU-009/012/019/020). 진입 후보:
-   - **Wave 2 (Dashboard)** — `dashboard.md` plan 작성부터. KPI 8종 + 분포 4탭 + 우선순위×상태 매트릭스 + 히트맵 + 트렌드 + 처리속도 등 §11.7 엔드포인트 구현.
-   - **운영/배포 phase** — `connect-pg-simple` 세션 스토어 / OIDC 실구현 / production Dockerfile / 실 MSSQL 연동 / Playwright E2E 등.
-   - **Wave 2 권장** (운영/배포는 외부 의존 큼; 기능 완성도 우선).
+→ **OQ-3 변경** (auto-save → draft buffer + 명시 저장): drag/resize end → local draft 만 갱신. "저장" 클릭 → `PUT /api/dashboard/settings`. "취소" → draft 폐기 + 서버 hydrate 재로드. spec dashboard.md §저장/복원 정합.
 
-→ **마이그 번호** — 다음 마이그 번호 = **022**.
+→ **메트릭**: BE 489/489, FE 576/576. typecheck 0. lint 0.
+
+→ **다음 세션 작업**: 4 PR 머지 후 **Phase D (W2-5)** 진입. 별 브랜치 `feat/wave-2-phase-d-rgl-shell`.
+   - 11 위젯 placeholder + Responsive + WidthProvider + 편집 모드 토글 + `defaultLayouts.ts` + draft buffer + lock 머지 + xs read-only.
+   - TDD: widget_sizes v2 zod bounds (이미 PR-γ 에 27 회귀) + lock 머지 / xs read-only / draft cancel 회귀 신규.
+   - visual-diff baseline 1 건 (편집 모드 grab cursor + 11 placeholder).
+
+→ **마이그 번호** — 다음 마이그 번호 = **023** (022 본 세션 점유).
 
 ---
 

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -1,8 +1,8 @@
 # vocpage — 다음 세션 태스크 계획
 
-> 최종 업데이트: 2026-05-10 (P2 후속 3건 머지 완료 — Wave 2 또는 운영/배포 phase)
-> 현재 위치: **P2 후속 close (PR #287/#288/#289 머지) · 다음 = Wave 2 (Dashboard) 권장**
-> 진행 포인터: `claude-progress.txt` 첫 30줄 → 본 문서 → 활성 plan
+> 최종 업데이트: 2026-05-10 (Wave 2 Phase A 4 PR 오픈 — 머지 대기)
+> 현재 위치: **Wave 2 Phase A 오픈 (PR #291/#292/#293/#294) · 다음 = 사용자 머지 → Phase D 진입**
+> 진행 포인터: `claude-progress.txt` 첫 30줄 → 본 문서 → 활성 plan (`wave-2-dashboard.md`)
 > **2026-05-09 정책**: 구현 정본 = `requirements.md` + `uidesign.md` 만. prototype 참조 종료.
 
 ---
@@ -21,14 +21,15 @@
 | **P2 BE batch** | (별 plan 없음 — bucket FU-007/010/015/018)                                                                                                                              | ✅ **4건 전부 머지** (2026-05-10). FU-018 (PR #279, 권한 매트릭스 단일 파일 115 case) · FU-015 (PR #280, admin DB-backed 통합 13 pass + restore 트랜잭션 end-to-end) · FU-010 (PR #281, 마이그 021 user_role_log CHECK + NOT VALID backfill safety) · FU-007 (PR #282, doc-only timestamptz 정책 + inclusive-end + mismatch 명시). 신규 spawn: FU-021/022 (P1) · FU-023/024/025 (P2). |
 | **P1 후속**     | (별 plan 없음 — bucket FU-021/022)                                                                                                                                       | ✅ **2건 머지** (2026-05-10). FU-021 (PR #284, §8.3 spec 해석 확정 — read access 4 role ALLOW · matrix +10 case · service 코드 변경 0) · FU-022 (PR #285, adminTrash/adminUsers router-level guard → per-route guard · 회귀 9 case · API contract 변경 0). BE 456/461 그린. |
 | **P2 후속**     | (별 plan 없음 — bucket FU-023/024/025)                                                                                                                                   | ✅ **3건 머지** (2026-05-10). FU-023 (PR #287, createTag slug `<name>-<kind>` · admin-tags.sql.test.ts todo → 실 테스트) · FU-024 (PR #289, @testcontainers/postgresql 도입 + admin-sql-tc.test.ts 5 cell · skip 4 → 0) · FU-025 (PR #288, NoticeFormDialog KST 자정 직렬화 · 회귀 5 case). BE 462/462 그린, FE 575/575 그린. |
+| **2 (Dashboard)** | [`wave-2-dashboard.md`](./wave-2-dashboard.md) (Plan 신규) | ⏳ **Phase A 4 PR 오픈** (2026-05-10). PR #291 (docs spec sync + plan, RGL MVP 승격) · PR #293 (마이그 022 `locked_widgets` JSONB) · PR #294 (contract zod v2 + openapi PUT + 11 위젯 fixtures) · PR #292 (react-grid-layout install + smoke). codex:rescue 적대적 리뷰 (2026-05-10) 반영분 포함 (위젯 11종 · PUT verb · zod bounds · draft buffer · Phase D 우선). BE 489/489, FE 576/576. **사용자 머지 대기** → Phase D (W2-5) 진입. |
 
 ### Hard-blocks
 
-- 없음 (`/voc 완성` PR #242, Wave 4 PR #245 모두 머지 완료).
+- **Wave 2 Phase D 진입 차단**: PR #291/#293/#294/#292 4건 모두 머지 후 진입.
 
 ### 진행 순서
 
-~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → **Wave 2 (Dashboard)** → 운영/배포 phase.
+~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → **Wave 2 Phase A 오픈 (PR #291/#292/#293/#294 — 머지 대기)** → Wave 2 Phase D (RGL 쉘 + 11 placeholder + draft buffer + lock 머지) → Phase B/C 병렬 (위젯 콘텐츠) → Phase E (설정 패널) → Phase F (종합 검증) → 운영/배포 phase.
 
 ---
 

--- a/docs/specs/plans/wave-2-dashboard.md
+++ b/docs/specs/plans/wave-2-dashboard.md
@@ -23,13 +23,13 @@
 
 | 영역                | 산출                                                                                                | 정본 §                                  |
 | ------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| **위젯 8종**        | KPI / 분포(4탭) / 우선순위×상태 매트릭스 / 히트맵 / 주간 트렌드 / 태그 바 / 시스템 카드 / 담당자 표 | `dashboard.md §위젯 상세 명세` (1~8)    |
+| **위젯 11종**       | KPI / 분포(4탭) / 우선순위×상태 매트릭스 / 히트맵 / 주간 트렌드 / 태그 바 / 현황 카드 / 담당자 표 / 장기 미처리 / 처리속도(SLA) / 에이징 | `dashboard.md §위젯 상세 명세` (1~11)   |
 | **글로벌 컨트롤**   | GlobalTabs (전체/시스템/메뉴/담당자) + 날짜 범위 + 필터 컨텍스트 배너                               | `dashboard.md §글로벌 탭/필터 컨텍스트` |
 | **레이아웃 엔진**   | react-grid-layout 도입 + 12-col 그리드 + lg/md/sm 브레이크포인트 + 편집 모드 토글                   | `dashboard.md §커스터마이즈 v2`         |
 | **잠금 시스템**     | Admin `locked_widgets` JSONB + 개인 `widget_visibility[id].locked` 머지                             | `dashboard.md §커스터마이즈 v2 §잠금`   |
 | **설정 패널**       | 헤더 "설정" 버튼 → 우측 슬라이드인 패널 (위젯 가시성 / 기본 날짜 / 히트맵 X축 / 잠금 / GlobalTabs)   | `dashboard.md §편집 가능 항목 (MVP)`    |
 | **권한 / 라우팅**   | Manager/Admin/Dev 진입, User 403, sidebar group 노출 분기                                           | `dashboard.md §대상 사용자` + ADR 0004  |
-| **BE 엔드포인트**   | KPI / 분포 / 매트릭스 / 히트맵 / 트렌드 / 태그 / 시스템 / 담당자 / settings GET·PATCH               | `requirements.md §11.7` (확정 시)       |
+| **BE 엔드포인트**   | 위젯별 GET 11종 + `GET /api/dashboard/settings` + **`PUT /api/dashboard/settings`** (PATCH 아님 — `dashboard.md §793` / `requirements.md §347`)  | `requirements.md §11.7` + `dashboard.md §API` |
 | **시각 baseline**   | dashboard 5종 PNG (전체/시스템/메뉴/담당자필터/편집모드)                                            | `CLAUDE.md §benchmark`                  |
 
 ### 2.2 Out-of-scope (이 Wave 에서 다루지 않음)
@@ -53,13 +53,13 @@
 | ----- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | W2-D1 | 레이아웃 라이브러리        | **`react-grid-layout` ^1.4** (`Responsive` + `WidthProvider`). 거부: dnd-kit (그리드 수학 자체 구현 부담), gridstack (레거시).                                                                | dashboard.md §커스터마이즈 v2 §라이브러리           |
 | W2-D2 | `widget_sizes` 직렬화      | **v2 (breakpoint-keyed)**. v1 (flat) 데이터 부재 → in-app 마이그 불필요. zod 가 v2 형식만 허용.                                                                                                | dashboard.md §widget_sizes v2 직렬화                |
-| W2-D3 | 잠금 의미                  | **2-tier**: Admin `locked_widgets` (전체 강제 static) + 개인 `widget_visibility[id].locked` (자기 화면). 머지 = OR. 개인 unlock 으로 Admin lock 해제 불가.                                    | dashboard.md §잠금 머지 규칙                        |
+| W2-D3 | 잠금 의미                  | **2-tier**: Admin `locked_widgets` (전체 강제 static) + 개인 `widget_visibility[id].locked` (자기 화면). 머지 = OR. 개인 unlock 으로 Admin lock 해제 불가. **선행 조건: 마이그 022 (`locked_widgets` JSONB 컬럼 신설) 머지 — codex 검증 결과 011/012 에 부재.**  | dashboard.md §잠금 머지 규칙 + codex 리뷰 (2026-05-10) |
 | W2-D4 | 기본 레이아웃              | `frontend/src/features/dashboard/defaultLayouts.ts` (lg/md/sm 명시, xs auto-stack).                                                                                                           | dashboard.md §저장/복원                             |
-| W2-D5 | Phase 분할                 | A 마이그/contract → B KPI+분포+매트릭스 → C 히트맵+트렌드+나머지 위젯 → D RGL 엔진+편집모드 → E 설정 패널 → F 종합검증.                                                                       | 본 plan §6                                          |
+| W2-D5 | Phase 분할 (codex 권고 반영) | A 마이그(021/022)/contract/RGL install → **D RGL 쉘 + defaultLayouts + lock 머지 (placeholder 위젯)** → **B,C 위젯 콘텐츠 병렬** → E 설정 패널 → F 종합검증. RGL CSS 검증을 위젯 콘텐츠보다 먼저. | codex 리뷰 §5 phase ordering                        |
 | W2-D6 | PR 단위                    | Phase 당 1 PR (FE+BE+contract+fixture 동봉). spec sync PR 별도 (Phase A 시작 시 1 회).                                                                                                        | Wave 3 D4 precedent                                 |
-| W2-D7 | TDD 의무 surface           | (a) `shared/contracts/dashboard.ts` zod (v2 형식) — irreversible. (b) BE 권한 (Admin only `locked_widgets` mutate, User 진입 403). (c) `dashboard_settings` migration rollback 회귀.          | `CLAUDE.md §Engineering rules`                      |
+| W2-D7 | TDD 의무 surface (codex 보강) | (a) zod (v2 형식 + bounds: `x>=0`, `y>=0`, `w>=1 && x+w<=12`, `h>=1`) — irreversible. (b) BE 권한 (Admin only `locked_widgets` mutate, User 진입 403). (c) 마이그 022 rollback 회귀. (d) **API verb parity** (PUT 만 200, PATCH 405). (e) **draft buffer cancel 회귀** (drag → cancel → DB 미반영 검증). | `CLAUDE.md §Engineering rules` + codex §4 |
 | W2-D8 | 시각 검증                  | `benchmark/dashboard/*.png` 5종 신규 + `INDEX.md` row. Phase F 자손 SKIP 0.                                                                                                                   | `CLAUDE.md §Top-level directories`                  |
-| W2-D9 | 자동화 / 리뷰              | Phase 진행 중 autopilot 허용. **plan/PLAN.md 머지 전 `codex:rescue` 적대적 리뷰 자동 디스패치** (memory: "Never self-review. Auto-trigger at 1000 LOC"). 머지·완료 선언은 사용자 검수 후에만. | Wave 3 D8 precedent + memory `feedback_review_delegation.md` |
+| W2-D9 | 자동화 / 리뷰              | Phase 진행 중 autopilot 허용. **wave plan + Phase PLAN 머지 전 `codex:rescue` 적대적 리뷰** — 산출물은 PR description 에 인라인 첨부 (별 파일 X). 머지·완료 선언은 사용자 검수 후에만. | Wave 3 D8 precedent + memory `feedback_review_delegation.md` |
 
 ## 4. 원칙
 
@@ -87,35 +87,37 @@
 - **Wave 6+ 모바일 대시보드** — 본 Wave xs 브레이크포인트 read-only 결정이 패턴. 본 Wave 머지 전 모바일 편집 UI 결정 금지.
 - **위젯 export (NextGen)** — 본 Wave 의 위젯 ID 체계 확정 후 export key 매핑 가능.
 
-## 6. Phase 흐름
+## 6. Phase 흐름 (codex 리뷰 §5 권고 반영 — D 를 B/C 앞으로)
 
 ```
-Phase A: spec sync + contract + 라이브러리 도입 (3 PR · partial parallel)
+Phase A: spec sync + contract + 마이그 + 라이브러리 (4 PR)
   ├─ PR-α docs/wave-2-spec-sync (dashboard.md §커스터마이즈 v2 + uidesign.md 그리드 토큰 3종 + 본 plan)
-  ├─ PR-β feat/wave-2-contract (shared/contracts/dashboard.ts zod + openapi.yaml + fixtures stub)
-  ├─ PR-γ chore/wave-2-rgl-install (react-grid-layout ^1.4 + 타입 + import test)
+  ├─ PR-β migration/022-locked-widgets (locked_widgets JSONB DEFAULT '[]' 컬럼 신설 + rollback)
+  ├─ PR-γ feat/wave-2-contract (shared/contracts/dashboard.ts zod v2 + bounds + openapi.yaml PUT + 위젯 11종 fixtures stub)
+  ├─ PR-δ chore/wave-2-rgl-install (react-grid-layout ^1.4 + 타입 + smoke render test)
   └─ 사용자 승인 게이트 ──┐
                           ▼
-Phase B: KPI + 분포 + 매트릭스 (1 PR)
-  ├─ TDD: BE 권한 (User 403 / Manager+Admin+Dev 200) + 분포 dim 4종 zod 검증
-  ├─ FE: 3 위젯 컴포넌트 + 글로벌 필터 hook + GlobalTabs 컨테이너
-  ├─ visual-diff baseline 1 건 (전체 탭)
+Phase D: RGL 쉘 + 편집 모드 (1 PR — 위젯은 placeholder 11개)
+  ├─ TDD: widget_sizes v2 zod bounds / lock 머지 규칙 / xs read-only / draft buffer cancel
+  ├─ FE: Responsive + WidthProvider + 편집 토글 + grab/resize 핸들 + defaultLayouts.ts (11 위젯) + draft buffer
+  ├─ visual-diff baseline 1 건 (편집 모드 grab cursor + 11 placeholder)
   └─ 사용자 검수 ──┐
                   ▼
-Phase C: 히트맵 + 트렌드 + 태그바 + 시스템카드 + 담당자표 (1 PR)
-  ├─ TDD: 히트맵 X축 3종 zod / 시스템 행 클릭 → 시스템 탭 전환 / 담당자 행 하이라이트
-  ├─ FE: 5 위젯 + 브레드크럼 + 드릴다운 동선
+[Phase B + Phase C 병렬 — 위젯 콘텐츠 독립]
+Phase B: 위젯 1~3 (KPI + 분포 + 매트릭스) (1 PR)
+  ├─ TDD: BE 권한 + 분포 dim 4종 zod
+  ├─ FE: 3 위젯 — Phase D 의 placeholder 슬롯 채우기
+  ├─ visual-diff baseline 1 건 (전체 탭)
+  └─ 사용자 검수 ──┐
+                  ▼ (or 병렬 머지)
+Phase C: 위젯 4~11 (히트맵 + 트렌드 + 태그바 + 현황카드 + 담당자표 + 장기미처리 + 처리속도 + 에이징) (1 PR)
+  ├─ TDD: 히트맵 X축 3종 zod / 시스템 행 클릭 → 탭 전환 / SLA % 산식 회귀 / 에이징 버킷 경계
+  ├─ FE: 8 위젯 — Phase D placeholder 채우기
   ├─ visual-diff baseline 2 건 (시스템 탭 / 메뉴 탭)
   └─ 사용자 검수 ──┐
                   ▼
-Phase D: RGL 엔진 + 편집 모드 (1 PR)
-  ├─ TDD: widget_sizes v2 zod / lock 머지 규칙 / xs read-only / 디바운스 500ms
-  ├─ FE: Responsive + WidthProvider + 편집 토글 + grab/resize 핸들 + defaultLayouts.ts
-  ├─ visual-diff baseline 1 건 (편집 모드 grab cursor)
-  └─ 사용자 검수 ──┐
-                  ▼
 Phase E: 설정 패널 + 잠금 UI (1 PR)
-  ├─ TDD: BE Admin only `locked_widgets` mutate / FE Admin 토글 / 개인 잠금 UI / "기본값으로 초기화"
+  ├─ TDD: BE Admin only `locked_widgets` mutate / FE Admin 토글 / 개인 잠금 UI / "기본값으로 초기화" / cancel = draft 폐기
   ├─ FE: 우측 슬라이드인 패널 + 위젯 가시성 체크박스 + 기본 날짜·X축 셀렉터 + GlobalTabs 순서 (Admin)
   ├─ visual-diff baseline 1 건 (담당자 필터 컨텍스트 배너)
   └─ 사용자 검수 ──┐
@@ -125,7 +127,8 @@ Phase F: 종합 검증
   ├─ 권한 매트릭스 BE 통합 테스트 그린 (User 403, Dev read 가능, Admin only mutate)
   ├─ FE/BE typecheck + lint + test 모두 그린
   ├─ 토큰 lint (raw hex/OKLCH 0 hits, 그리드 토큰 3종 lint:tokens 통과)
-  ├─ 성능: dev 서버 LCP 측정 ≤ 3s (`scripts/visual-diff.ts` 와 별도)
+  ├─ 성능: dev 서버 LCP 측정 ≤ 3s
+  ├─ fixture parity (`scripts/check-fixture-seed-parity.ts` — 11 위젯 dim/xAxis/menu/assignee 조합 커버)
   ├─ claude-progress.txt + next-session-tasks.md 갱신
   └─ 사용자 최종 승인 → Wave 2 완료
 ```
@@ -133,36 +136,38 @@ Phase F: 종합 검증
 ### 6.1 Phase 게이트 룰
 
 - 직전 Phase 마지막 PR 머지 + 사용자 검수 통과 시 다음 Phase 진입.
-- Phase B/C 는 위젯 콘텐츠라 서로 독립 → 사용자 승인 시 병렬 슬롯 가능. Phase A 머지 전 진입 금지.
-- Phase D (RGL) 는 Phase B/C 의 위젯 ID 체계 확정 후 진입 (lock 머지 규칙이 위젯 ID 의존).
+- **Phase D 가 B/C 앞**: codex 권고 — RGL CSS·lock·draft buffer 검증을 위젯 콘텐츠 전에. 위젯 ID 와 defaultLayouts 는 Phase A 의 contract 에서 고정.
+- Phase B / C 는 서로 독립 → 사용자 승인 시 병렬 슬롯 가능. Phase D 머지 전 진입 금지.
 
 ### 6.2 Task ID 부여
 
 | ID    | Phase | 작업 (한 줄)                                                                                                            | trigger / 비고                                  |
 | ----- | ----- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | W2-1  | A     | docs/wave-2-spec-sync (`dashboard.md §커스터마이즈 v2` + `uidesign.md` 그리드 토큰 3종 + 본 plan)                       | spec sync (irreversible — 사용자 승인 후 머지) |
-| W2-2  | A     | feat/wave-2-contract (`shared/contracts/dashboard.ts` zod + `openapi.yaml` + dashboard fixtures stub)                   | contract 정본 확정                              |
-| W2-3  | A     | chore/wave-2-rgl-install (`react-grid-layout` ^1.4 + 타입 + smoke render test)                                          | 라이브러리 도입 별 PR                           |
-| W2-4  | B     | KPI + 분포 + 매트릭스 FE+BE+fixture+권한 (1 PR)                                                                          | dashboard.md §위젯 1~3                          |
-| W2-5  | C     | 히트맵 + 트렌드 + 태그바 + 시스템카드 + 담당자표 FE+BE+fixture (1 PR)                                                    | dashboard.md §위젯 4~8                          |
-| W2-6  | D     | RGL Responsive 통합 + 편집 모드 + defaultLayouts + lock 머지 (1 PR)                                                      | dashboard.md §커스터마이즈 v2                   |
-| W2-7  | E     | 설정 패널 + Admin only `locked_widgets` mutate + 개인 잠금 (1 PR)                                                        | dashboard.md §편집 진입점                       |
-| W2-8  | F     | 종합 검증 + progress 갱신                                                                                                | gate close                                      |
+| W2-2  | A     | migration/022-locked-widgets (`dashboard_settings.locked_widgets JSONB DEFAULT '[]'` + rollback)                        | codex §3 OQ-5 리얼리티 체크 (011/012 부재 확인) |
+| W2-3  | A     | feat/wave-2-contract (`shared/contracts/dashboard.ts` zod v2 + bounds + `openapi.yaml` PUT + 11 위젯 fixtures stub)     | contract 정본 확정 + codex §1 verb mismatch     |
+| W2-4  | A     | chore/wave-2-rgl-install (`react-grid-layout` ^1.4 + 타입 + smoke render test)                                          | 라이브러리 도입 별 PR                           |
+| W2-5  | D     | RGL 쉘 + Responsive + 편집 모드 + defaultLayouts (11 위젯 placeholder) + lock 머지 + draft buffer (1 PR)                  | dashboard.md §커스터마이즈 v2                   |
+| W2-6  | B     | 위젯 1~3 (KPI + 분포 + 매트릭스) FE+BE+fixture+권한 (1 PR)                                                                | dashboard.md §위젯 1~3                          |
+| W2-7  | C     | 위젯 4~11 (히트맵 + 트렌드 + 태그바 + 현황카드 + 담당자표 + 장기미처리 + 처리속도 + 에이징) FE+BE+fixture (1 PR)         | dashboard.md §위젯 4~11                         |
+| W2-8  | E     | 설정 패널 + Admin only `locked_widgets` mutate + 개인 잠금 + cancel→draft 폐기 (1 PR)                                    | dashboard.md §편집 진입점                       |
+| W2-9  | F     | 종합 검증 + progress 갱신                                                                                                | gate close                                      |
 
 > **R5 준수**: 묶음 PR 금지. W2-1/W2-2/W2-3 모두 별 PR.
 > **R3 준수**: Phase A~F 는 grouping 메타데이터일 뿐 ID 에 부착 금지.
 
-## 7. Open Questions (사용자 결정 대기)
+## 7. Open Questions — 결정 (2026-05-10 사용자 위임)
 
-| OQ    | 항목                                                  | 옵션                                                                                                                                                                          | 권장 |
-| ----- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| OQ-1  | xs(<768) 편집 UI                                      | A: read-only 만 (RGL 자동 stack) / B: 모바일 전용 모달 편집 UI 신설                                                                                                            | **A** — YAGNI, NextGen 으로 미루기 |
-| OQ-2  | 편집 모드 vs 항상-드래그                              | A: 헤더 "편집" 토글 진입 시에만 드래그 가능 / B: 항상 드래그 가능 (RGL 기본)                                                                                                  | **A** — 의도치 않은 드래그 방지 + 시각적 명료성 |
-| OQ-3  | 자동 저장 vs 명시적 "저장" 버튼                       | A: 디바운스 500ms 자동 저장 / B: "저장" 버튼 클릭 시에만                                                                                                                       | **A** — 사용자 작업 손실 위험 낮춤. "취소" 는 직전 hydrate 로 복원 |
-| OQ-4  | 위젯 추가/제거 (위젯 가시성 0 → 1)                    | A: 설정 패널에서만 / B: 편집 모드에서 빈 슬롯 + 위젯 카탈로그                                                                                                                  | **A** — 정본 §편집 가능 항목 표 정합 |
-| OQ-5  | `dashboard_settings` 마이그 추가 여부                 | A: 추가 없음 (마이그 011/012 의 `widget_sizes JSONB` 재사용) / B: `locked_widgets` 컬럼 신규 마이그                                                                            | **B** — 마이그 022 신규 (locked_widgets JSONB DEFAULT '[]'). 011 에 컬럼 자체가 없음 — 본 plan §dashboard_settings 스키마 확인 필요 (`docs/specs/requires/dashboard.md` 의 스키마는 spec 갱신, 실 DB 는 별 마이그). |
+> 사용자가 "알아서 다 진행" 위임 (2026-05-10 세션). OQ-1~4 본 plan §3 와 정합하게 잠금. OQ-5 는 마이그 011/012 실 SQL 스캔 후 확정 (codex:rescue 리뷰 회신).
 
-> 5 건 모두 사용자 결정 필요. **OQ-5 가 가장 risk** — 마이그 추가 여부는 `backend/migrations/011_*.sql` / `012_*.sql` 실제 컬럼 스캔 후 확정. Phase A 진입 전 사용자 결정 필수.
+| OQ    | 항목                                                  | 결정                                                                                          | 근거                                                                       |
+| ----- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| OQ-1  | xs(<768) 편집 UI                                      | **A — read-only 만** (RGL 자동 1-col stack)                                                   | YAGNI · NextGen 로 분리 (`dashboard.md §접근성`)                           |
+| OQ-2  | 편집 모드 vs 항상-드래그                              | **A — 헤더 "편집" 토글 진입 시에만 드래그**                                                   | 의도치 않은 드래그 방지 · 시각적 명료성 (`dashboard.md §편집 모드 토글`)   |
+| OQ-3  | 자동 저장 vs 명시 저장 (codex §2 모순 지적)           | **B — draft buffer + 명시 "저장" 버튼**. drag/resize end → local draft 만 갱신. "저장" 클릭 → PUT. "취소" → draft 폐기 + 서버 hydrate 재로드. | codex 리뷰 §2 cancel 의미론 (auto-save + cancel 모순 회피) |
+| OQ-4  | 위젯 추가/제거 동선                                   | **A — 설정 패널에서만** (편집 모드 빈 슬롯 카탈로그 X)                                        | 정본 §편집 가능 항목 표 정합                                               |
+| OQ-5  | `dashboard_settings` 마이그 추가 (codex §3 검증)      | **B — 마이그 022 신설**. codex 가 011/012 SQL 스캔 → `locked_widgets` 부재 확인. 컬럼 명세: `locked_widgets JSONB NOT NULL DEFAULT '[]'`. | codex 리뷰 §3 (`011_pre_impl_alignment.sql:40-59`, `012_voc_origin_metadata.sql`) |
+| OQ-6  | spec 자체 모순: `default_date_range` 기본값 (codex §1) | **사용자 결정 필요** — `dashboard.md:13` ("최근 1개월") vs `dashboard.md:693` 스키마 (`'3m'`) vs 마이그 011 (`'1m'`). 권장: `'1m'` 통일 (preamble + 011 정합). | codex 리뷰 §1 (spec 자체 충돌, 본 Wave plan 외 영역) |
 
 ---
 

--- a/docs/specs/plans/wave-2-dashboard.md
+++ b/docs/specs/plans/wave-2-dashboard.md
@@ -1,0 +1,173 @@
+# Wave 2 — Dashboard Plan
+
+> 목적: `requires/dashboard.md` 정본의 Manager/Admin/Dev 대시보드 vertical slice (KPI 8종 + 분포 4탭 + 매트릭스 + 히트맵 + 트렌드 + 처리속도 + **react-grid-layout 커스터마이즈**) 를 Wave 단위로 구현·검증한다.
+> Follow-up bucket: `followup-bucket.md`. ID 규칙은 root `CLAUDE.md` 참조.
+> 정본 product spec: `requires/dashboard.md` (특히 §위젯 상세 명세, §커스터마이징, §커스터마이즈 v2 — 레이아웃 엔진).
+
+## 0. 진입 게이트
+
+- **Hard-block**: 없음. Wave 5 Phase B PR-2 머지 후 즉시 진입 가능 (`claude-progress.txt` 2026-05-10 기준 활성 follow-up 클로즈 완료).
+- **사용자 승인**: 본 plan 의 §3 결정·§7 OQ 게이트가 모두 사용자 승인된 후 Phase A 진입.
+- **선행 spec sync**: `requires/dashboard.md §커스터마이즈 v2` (2026-05-10 추가) — 본 plan 과 같은 PR 에서 머지.
+
+## 1. 배경
+
+- Wave 0~1.7 / Wave 3 / Wave 4 / Wave 5 머지 완료. 활성 Open follow-up = 0 (P3 잔존만: FU-009/012/019/020).
+- `dashboard.md` 정본은 D14(2026-04-26) 시점 작성 — 위젯 콘텐츠 8종은 이미 fully specified, 커스터마이즈 v1 (숨김/기본값) 만 명시 후 NextGen 으로 분리.
+- 2026-05-10 사용자 결정: **드래그/리사이즈/잠금/반응형을 Wave 2 MVP 로 승격**. NextGen 분리 해제.
+- `dashboard_settings` 테이블 (마이그 011) 은 이미 머지 — `widget_sizes JSONB` 컬럼 재사용. v2 형식(브레이크포인트 키) 으로 직렬화 변경만 contract level 에서 강제.
+
+## 2. 범위
+
+### 2.1 In-scope
+
+| 영역                | 산출                                                                                                | 정본 §                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **위젯 8종**        | KPI / 분포(4탭) / 우선순위×상태 매트릭스 / 히트맵 / 주간 트렌드 / 태그 바 / 시스템 카드 / 담당자 표 | `dashboard.md §위젯 상세 명세` (1~8)    |
+| **글로벌 컨트롤**   | GlobalTabs (전체/시스템/메뉴/담당자) + 날짜 범위 + 필터 컨텍스트 배너                               | `dashboard.md §글로벌 탭/필터 컨텍스트` |
+| **레이아웃 엔진**   | react-grid-layout 도입 + 12-col 그리드 + lg/md/sm 브레이크포인트 + 편집 모드 토글                   | `dashboard.md §커스터마이즈 v2`         |
+| **잠금 시스템**     | Admin `locked_widgets` JSONB + 개인 `widget_visibility[id].locked` 머지                             | `dashboard.md §커스터마이즈 v2 §잠금`   |
+| **설정 패널**       | 헤더 "설정" 버튼 → 우측 슬라이드인 패널 (위젯 가시성 / 기본 날짜 / 히트맵 X축 / 잠금 / GlobalTabs)   | `dashboard.md §편집 가능 항목 (MVP)`    |
+| **권한 / 라우팅**   | Manager/Admin/Dev 진입, User 403, sidebar group 노출 분기                                           | `dashboard.md §대상 사용자` + ADR 0004  |
+| **BE 엔드포인트**   | KPI / 분포 / 매트릭스 / 히트맵 / 트렌드 / 태그 / 시스템 / 담당자 / settings GET·PATCH               | `requirements.md §11.7` (확정 시)       |
+| **시각 baseline**   | dashboard 5종 PNG (전체/시스템/메뉴/담당자필터/편집모드)                                            | `CLAUDE.md §benchmark`                  |
+
+### 2.2 Out-of-scope (이 Wave 에서 다루지 않음)
+
+- **위젯 콘텐츠 신규 추가** — `dashboard.md` 미명시 위젯은 별 wave.
+- **위젯 export (CSV/PDF)** — NextGen.
+- **모바일 (xs) 편집 UI** — RGL 자동 1-col stack 으로 read-only 만. 편집 진입 자체 차단.
+- **키보드 드래그 reorder** — RGL 한계. NextGen.
+- **위젯 간 드릴다운 cross-link** (이미 §위젯 상세 명세에 명시된 클릭 동선만 구현, 그 외 신규 동선 X).
+- **실 MSSQL 연동** — 본 Wave 는 PostgreSQL 자체 데이터로 vertical slice. 실 운영 swap 은 별 트랙 (`external-masters.md` 동일 패턴).
+
+### 2.3 Touch budget
+
+- **변경 (대규모)**: `frontend/src/features/dashboard/**` (신규 대량), `frontend/src/pages/dashboard/**` (신규), `frontend/src/app/router.tsx` (라우트 추가), `backend/src/routes/dashboard/**` (신규), `backend/src/services/dashboard/**` (신규), `shared/contracts/dashboard.ts` (zod 신규), `shared/fixtures/dashboard-*.json` (신규), `frontend/package.json` (`react-grid-layout` ^1.4 추가), `requires/uidesign.md` (그리드 토큰 3종 추가 — Phase A 별 PR), `requires/dashboard.md` (본 PR 에 sync 동봉).
+- **비변경**: Wave 3 admin 도메인, Wave 4 notice/faq, Wave 5 notifications, VOC 도메인 본문, 토큰 정의부 (그리드 토큰 외).
+- **신규 의존성**: `react-grid-layout@^1.4` (MIT, 80kb gz), `@types/react-grid-layout` (dev).
+
+## 3. 결정 (잠금 — 사용자 최종 승인 시점에 잠긴다)
+
+| ID    | 항목                       | 결정                                                                                                                                                                                          | 근거                                                |
+| ----- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| W2-D1 | 레이아웃 라이브러리        | **`react-grid-layout` ^1.4** (`Responsive` + `WidthProvider`). 거부: dnd-kit (그리드 수학 자체 구현 부담), gridstack (레거시).                                                                | dashboard.md §커스터마이즈 v2 §라이브러리           |
+| W2-D2 | `widget_sizes` 직렬화      | **v2 (breakpoint-keyed)**. v1 (flat) 데이터 부재 → in-app 마이그 불필요. zod 가 v2 형식만 허용.                                                                                                | dashboard.md §widget_sizes v2 직렬화                |
+| W2-D3 | 잠금 의미                  | **2-tier**: Admin `locked_widgets` (전체 강제 static) + 개인 `widget_visibility[id].locked` (자기 화면). 머지 = OR. 개인 unlock 으로 Admin lock 해제 불가.                                    | dashboard.md §잠금 머지 규칙                        |
+| W2-D4 | 기본 레이아웃              | `frontend/src/features/dashboard/defaultLayouts.ts` (lg/md/sm 명시, xs auto-stack).                                                                                                           | dashboard.md §저장/복원                             |
+| W2-D5 | Phase 분할                 | A 마이그/contract → B KPI+분포+매트릭스 → C 히트맵+트렌드+나머지 위젯 → D RGL 엔진+편집모드 → E 설정 패널 → F 종합검증.                                                                       | 본 plan §6                                          |
+| W2-D6 | PR 단위                    | Phase 당 1 PR (FE+BE+contract+fixture 동봉). spec sync PR 별도 (Phase A 시작 시 1 회).                                                                                                        | Wave 3 D4 precedent                                 |
+| W2-D7 | TDD 의무 surface           | (a) `shared/contracts/dashboard.ts` zod (v2 형식) — irreversible. (b) BE 권한 (Admin only `locked_widgets` mutate, User 진입 403). (c) `dashboard_settings` migration rollback 회귀.          | `CLAUDE.md §Engineering rules`                      |
+| W2-D8 | 시각 검증                  | `benchmark/dashboard/*.png` 5종 신규 + `INDEX.md` row. Phase F 자손 SKIP 0.                                                                                                                   | `CLAUDE.md §Top-level directories`                  |
+| W2-D9 | 자동화 / 리뷰              | Phase 진행 중 autopilot 허용. **plan/PLAN.md 머지 전 `codex:rescue` 적대적 리뷰 자동 디스패치** (memory: "Never self-review. Auto-trigger at 1000 LOC"). 머지·완료 선언은 사용자 검수 후에만. | Wave 3 D8 precedent + memory `feedback_review_delegation.md` |
+
+## 4. 원칙
+
+1. **Spec 정본 우선** — `dashboard.md` (특히 §위젯 상세 명세) 가 충돌하면 사용자에게 보고. 임의 동기화 금지. 본 PR 에 spec sync 동봉되는 부분은 §"커스터마이즈 v2" 만.
+2. **Contract 우선** — Phase A 에서 `shared/contracts/dashboard.ts` zod 확정 + `openapi.yaml` 갱신 후 Phase B 진입. zod schema 와 fixture 가 단일 출처.
+3. **권한 이중 방어** — FE role guard (sidebar group + route boundary) + BE 403. User 진입 시 403 → 홈 리다이렉트.
+4. **위젯 모듈화** — 8 위젯 각각 `frontend/src/features/dashboard/widgets/<id>/` 디렉토리. 위젯 간 의존 금지 (필터 컨텍스트만 공유). 디스패치는 위젯 ID → 컴포넌트 맵.
+5. **토큰 위반 0** — RGL CSS 의 `react-grid-item.dragging` / `resizing` / `static` 상태 색상은 모두 `uidesign.md` 토큰. raw hex/OKLCH 도입 금지. 그리드 gap/padding/handle 색은 신규 토큰 3종 (Phase A 별 PR).
+6. **YAGNI** — 모바일 편집 UI / 키보드 reorder / 위젯 export 는 placeholder 도 만들지 않음. 코드 0줄.
+7. **성능 게이트** — 페이지 최초 로드 LCP ≤ 3 초 (DB 3,000건 이하 가정, `dashboard.md §통과 게이트`). RGL `transformScale` 비활성, CSS 토큰 변환은 root 레벨에서 1 회.
+
+## 5. 의존성 / 차단
+
+### 5.1 진입 차단 (선행 필수)
+
+- 없음. Wave 5 Phase B PR-2 머지 완료 (2026-05-10).
+
+### 5.2 외부 차단 (해소 불가)
+
+- 실 MSSQL 외부 마스터 — Phase B/C 의 시스템·메뉴 dim 셀렉터는 PostgreSQL 자체 `external_systems` / `external_menus` 캐시 사용. 실 운영 swap 은 별 트랙.
+- OIDC 인증 — `AUTH_MODE=mock` 전제. role guard 만 검증. 실연동은 별 트랙.
+
+### 5.3 후속 차단 (본 Wave 가 차단)
+
+- **Wave 6+ 모바일 대시보드** — 본 Wave xs 브레이크포인트 read-only 결정이 패턴. 본 Wave 머지 전 모바일 편집 UI 결정 금지.
+- **위젯 export (NextGen)** — 본 Wave 의 위젯 ID 체계 확정 후 export key 매핑 가능.
+
+## 6. Phase 흐름
+
+```
+Phase A: spec sync + contract + 라이브러리 도입 (3 PR · partial parallel)
+  ├─ PR-α docs/wave-2-spec-sync (dashboard.md §커스터마이즈 v2 + uidesign.md 그리드 토큰 3종 + 본 plan)
+  ├─ PR-β feat/wave-2-contract (shared/contracts/dashboard.ts zod + openapi.yaml + fixtures stub)
+  ├─ PR-γ chore/wave-2-rgl-install (react-grid-layout ^1.4 + 타입 + import test)
+  └─ 사용자 승인 게이트 ──┐
+                          ▼
+Phase B: KPI + 분포 + 매트릭스 (1 PR)
+  ├─ TDD: BE 권한 (User 403 / Manager+Admin+Dev 200) + 분포 dim 4종 zod 검증
+  ├─ FE: 3 위젯 컴포넌트 + 글로벌 필터 hook + GlobalTabs 컨테이너
+  ├─ visual-diff baseline 1 건 (전체 탭)
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase C: 히트맵 + 트렌드 + 태그바 + 시스템카드 + 담당자표 (1 PR)
+  ├─ TDD: 히트맵 X축 3종 zod / 시스템 행 클릭 → 시스템 탭 전환 / 담당자 행 하이라이트
+  ├─ FE: 5 위젯 + 브레드크럼 + 드릴다운 동선
+  ├─ visual-diff baseline 2 건 (시스템 탭 / 메뉴 탭)
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase D: RGL 엔진 + 편집 모드 (1 PR)
+  ├─ TDD: widget_sizes v2 zod / lock 머지 규칙 / xs read-only / 디바운스 500ms
+  ├─ FE: Responsive + WidthProvider + 편집 토글 + grab/resize 핸들 + defaultLayouts.ts
+  ├─ visual-diff baseline 1 건 (편집 모드 grab cursor)
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase E: 설정 패널 + 잠금 UI (1 PR)
+  ├─ TDD: BE Admin only `locked_widgets` mutate / FE Admin 토글 / 개인 잠금 UI / "기본값으로 초기화"
+  ├─ FE: 우측 슬라이드인 패널 + 위젯 가시성 체크박스 + 기본 날짜·X축 셀렉터 + GlobalTabs 순서 (Admin)
+  ├─ visual-diff baseline 1 건 (담당자 필터 컨텍스트 배너)
+  └─ 사용자 검수 ──┐
+                  ▼
+Phase F: 종합 검증
+  ├─ 5 시각 baseline 자손 SKIP 0
+  ├─ 권한 매트릭스 BE 통합 테스트 그린 (User 403, Dev read 가능, Admin only mutate)
+  ├─ FE/BE typecheck + lint + test 모두 그린
+  ├─ 토큰 lint (raw hex/OKLCH 0 hits, 그리드 토큰 3종 lint:tokens 통과)
+  ├─ 성능: dev 서버 LCP 측정 ≤ 3s (`scripts/visual-diff.ts` 와 별도)
+  ├─ claude-progress.txt + next-session-tasks.md 갱신
+  └─ 사용자 최종 승인 → Wave 2 완료
+```
+
+### 6.1 Phase 게이트 룰
+
+- 직전 Phase 마지막 PR 머지 + 사용자 검수 통과 시 다음 Phase 진입.
+- Phase B/C 는 위젯 콘텐츠라 서로 독립 → 사용자 승인 시 병렬 슬롯 가능. Phase A 머지 전 진입 금지.
+- Phase D (RGL) 는 Phase B/C 의 위젯 ID 체계 확정 후 진입 (lock 머지 규칙이 위젯 ID 의존).
+
+### 6.2 Task ID 부여
+
+| ID    | Phase | 작업 (한 줄)                                                                                                            | trigger / 비고                                  |
+| ----- | ----- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| W2-1  | A     | docs/wave-2-spec-sync (`dashboard.md §커스터마이즈 v2` + `uidesign.md` 그리드 토큰 3종 + 본 plan)                       | spec sync (irreversible — 사용자 승인 후 머지) |
+| W2-2  | A     | feat/wave-2-contract (`shared/contracts/dashboard.ts` zod + `openapi.yaml` + dashboard fixtures stub)                   | contract 정본 확정                              |
+| W2-3  | A     | chore/wave-2-rgl-install (`react-grid-layout` ^1.4 + 타입 + smoke render test)                                          | 라이브러리 도입 별 PR                           |
+| W2-4  | B     | KPI + 분포 + 매트릭스 FE+BE+fixture+권한 (1 PR)                                                                          | dashboard.md §위젯 1~3                          |
+| W2-5  | C     | 히트맵 + 트렌드 + 태그바 + 시스템카드 + 담당자표 FE+BE+fixture (1 PR)                                                    | dashboard.md §위젯 4~8                          |
+| W2-6  | D     | RGL Responsive 통합 + 편집 모드 + defaultLayouts + lock 머지 (1 PR)                                                      | dashboard.md §커스터마이즈 v2                   |
+| W2-7  | E     | 설정 패널 + Admin only `locked_widgets` mutate + 개인 잠금 (1 PR)                                                        | dashboard.md §편집 진입점                       |
+| W2-8  | F     | 종합 검증 + progress 갱신                                                                                                | gate close                                      |
+
+> **R5 준수**: 묶음 PR 금지. W2-1/W2-2/W2-3 모두 별 PR.
+> **R3 준수**: Phase A~F 는 grouping 메타데이터일 뿐 ID 에 부착 금지.
+
+## 7. Open Questions (사용자 결정 대기)
+
+| OQ    | 항목                                                  | 옵션                                                                                                                                                                          | 권장 |
+| ----- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| OQ-1  | xs(<768) 편집 UI                                      | A: read-only 만 (RGL 자동 stack) / B: 모바일 전용 모달 편집 UI 신설                                                                                                            | **A** — YAGNI, NextGen 으로 미루기 |
+| OQ-2  | 편집 모드 vs 항상-드래그                              | A: 헤더 "편집" 토글 진입 시에만 드래그 가능 / B: 항상 드래그 가능 (RGL 기본)                                                                                                  | **A** — 의도치 않은 드래그 방지 + 시각적 명료성 |
+| OQ-3  | 자동 저장 vs 명시적 "저장" 버튼                       | A: 디바운스 500ms 자동 저장 / B: "저장" 버튼 클릭 시에만                                                                                                                       | **A** — 사용자 작업 손실 위험 낮춤. "취소" 는 직전 hydrate 로 복원 |
+| OQ-4  | 위젯 추가/제거 (위젯 가시성 0 → 1)                    | A: 설정 패널에서만 / B: 편집 모드에서 빈 슬롯 + 위젯 카탈로그                                                                                                                  | **A** — 정본 §편집 가능 항목 표 정합 |
+| OQ-5  | `dashboard_settings` 마이그 추가 여부                 | A: 추가 없음 (마이그 011/012 의 `widget_sizes JSONB` 재사용) / B: `locked_widgets` 컬럼 신규 마이그                                                                            | **B** — 마이그 022 신규 (locked_widgets JSONB DEFAULT '[]'). 011 에 컬럼 자체가 없음 — 본 plan §dashboard_settings 스키마 확인 필요 (`docs/specs/requires/dashboard.md` 의 스키마는 spec 갱신, 실 DB 는 별 마이그). |
+
+> 5 건 모두 사용자 결정 필요. **OQ-5 가 가장 risk** — 마이그 추가 여부는 `backend/migrations/011_*.sql` / `012_*.sql` 실제 컬럼 스캔 후 확정. Phase A 진입 전 사용자 결정 필수.
+
+---
+
+## 8. 리뷰 흐름
+
+- 본 plan 은 `codex:rescue` 에이전트 적대적 리뷰 통과 후 사용자 승인.
+- 리뷰 산출물: `.claude/specs/wave-2-codex-review.md` (생성 시) — missing edge case / 모순 / 의존성 그래프 누락 사항.
+- 리뷰 후 본 plan §3 결정·§7 OQ 가 추가/수정될 수 있음.

--- a/docs/specs/plans/wave-2-phase-d-prompt.md
+++ b/docs/specs/plans/wave-2-phase-d-prompt.md
@@ -1,0 +1,113 @@
+# Wave 2 Phase D 진입 프롬프트 (다음 세션용)
+
+> 본 파일은 다음 세션 시작 시 사용자가 프롬프트로 붙여넣는 단일 메시지.
+> 사용 방법: 아래 ``` 코드 블록 안의 본문을 복사해서 새 Claude 세션에 그대로 붙여넣기.
+
+---
+
+```
+Wave 2 Phase D 진입 — RGL 쉘 + 편집 모드 + 11 위젯 placeholder + draft buffer + lock 머지.
+
+## Context
+
+직전 세션 (2026-05-10) 에서 Wave 2 Phase A 의 4 PR 을 오픈했고, 본 세션 시작 전에 사용자가 모두 머지한 상태:
+- #291 docs(wave-2): plan + spec sync (RGL 커스터마이즈 MVP 승격)
+- #292 chore(wave-2): react-grid-layout install + smoke test
+- #293 feat(wave-2): migration 022 dashboard_settings.locked_widgets
+- #294 feat(wave-2): contract zod v2 + openapi PUT + fixtures stub
+
+머지가 안 됐다면 진입 거부하고 사용자에게 머지 요청. 머지됐으면 진입.
+
+## 작업 정본
+
+- Plan: `docs/specs/plans/wave-2-dashboard.md` §3 결정 W2-D1~D9 / §6.2 W2-5 / §7 OQ.
+- Spec: `docs/specs/requires/dashboard.md` §커스터마이즈 v2 (전체) — 라이브러리 / 그리드 계약 / 브레이크포인트 / widget_sizes v2 직렬화 / 잠금 머지 / 저장-복원 (draft buffer) / RGL CSS / 시각 토큰 / 접근성.
+- Contract: `shared/contracts/dashboard/io.ts` (zod 정본 — WidgetId 11종 / WidgetLayout bounds / WidgetSizesV2 / DashboardSettings / DashboardSettingsPutBody).
+- Fixture: `shared/fixtures/dashboard.fixtures.ts` (`DEFAULT_DASHBOARD_SETTINGS`, `DEFAULT_WIDGET_SIZES_LG`, `WIDGET_IDS`).
+- Migration: `backend/migrations/022_dashboard_locked_widgets.sql` (적용됨).
+
+## 작업 범위 (W2-5 / Phase D — 1 PR)
+
+브랜치: `feat/wave-2-phase-d-rgl-shell` (main 에서 분기)
+
+### FE 신설
+
+- `frontend/src/features/dashboard/DashboardShell.tsx` — Responsive + WidthProvider 래핑. props = `{ widgets: WidgetSlot[], settings: DashboardSettings, isAdmin: boolean }`.
+- `frontend/src/features/dashboard/defaultLayouts.ts` — 11 위젯의 lg/md/sm 기본 좌표 export. `shared/fixtures` 의 `DEFAULT_WIDGET_SIZES_LG` 와 정합 (lg 동일 + md/sm 도출 룰 명시).
+- `frontend/src/features/dashboard/WidgetPlaceholder.tsx` — 11 위젯 모두 동일 placeholder (Skeleton + 위젯 ID 표시 + 헤더 잠금 🔒). 실 콘텐츠는 Phase B/C 에서 채움.
+- `frontend/src/features/dashboard/EditModeToggle.tsx` — "편집" / "저장" / "취소" 버튼 + isEditing state.
+- `frontend/src/features/dashboard/useDashboardDraft.ts` — draft buffer hook. 서버 hydrate → draft 로 복사, drag/resize end → draft 만 갱신, 저장 = `PUT /api/dashboard/settings`, 취소 = draft 폐기 후 hydrate 재로드.
+- `frontend/src/features/dashboard/lockMerge.ts` — `mergeLock(adminLocked, personalVisibility)` 헬퍼. 반환: `Record<WidgetId, boolean>` (true = static).
+- `frontend/src/api/dashboard.ts` — `useDashboardSettings()` (GET) + `useUpdateDashboardSettings()` (PUT). zod 응답 검증.
+- `frontend/src/pages/dashboard/DashboardPage.tsx` — Manager/Admin/Dev role guard + 라우트. User 진입 시 `/` 리다이렉트.
+- `frontend/src/app/router.tsx` — `/dashboard` 라우트 추가.
+- `frontend/src/styles/dashboard-rgl.css` — RGL CSS 규칙 (z-index dragging=1000 / overflow / scroll container / resize handle 토큰화). spec §RGL CSS 규칙 정합.
+- 신규 토큰 3종 (`uidesign.md` 동기 PR 또는 Phase D PR 동봉): `--dashboard-grid-gap` / `--dashboard-grid-padding` / `--dashboard-widget-resize-handle`.
+
+### BE 신설
+
+- `backend/src/routes/dashboard-settings.ts` — `GET /api/dashboard/settings` + `PUT /api/dashboard/settings`. role guard (User 403). zod body validation.
+- `backend/src/services/dashboard/settings.service.ts` — Admin 행 (`user_id IS NULL`) + 개인 행 머지 로직. `locked_widgets` mutate 는 Admin only (route guard + service assertion).
+- `backend/src/repository/dashboard.repo.ts` — `dashboard_settings` SELECT/UPDATE.
+
+### TDD (irreversible 우선 — `CLAUDE.md §3`)
+
+이미 PR-γ (#294) 에 contract bounds 27 회귀가 있음. 본 Phase D 추가:
+
+- `frontend/src/features/dashboard/__tests__/lockMerge.test.ts` — Admin lock + personal lock 머지 OR 검증. 개인 unlock 으로 Admin lock 해제 불가 회귀.
+- `frontend/src/features/dashboard/__tests__/useDashboardDraft.test.ts` — drag → draft 갱신 / 저장 → PUT 호출 / 취소 → hydrate 재로드 / 디바운스 X 검증.
+- `frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx` — xs 브레이크포인트에서 `isDraggable: false` 검증. 편집 모드 토글 시 grab cursor 검증.
+- `backend/src/__tests__/dashboard-settings.test.ts` — Manager/Admin/Dev 200 / User 403 / Admin 만 `locked_widgets` mutate 가능 / PUT 빈 body no-op / PUT zod 위반 400.
+
+### 시각
+
+- `benchmark/dashboard/01-edit-mode-grab.png` — 편집 모드 grab cursor + 11 placeholder 베이스라인 1 건.
+- `benchmark/INDEX.md` row 추가.
+
+## 작업 순서 (TDD 의무)
+
+1. **권한·draft buffer 회귀 작성** (실패 확인) — `dashboard-settings.test.ts` + `useDashboardDraft.test.ts` + `lockMerge.test.ts`.
+2. BE route + service 구현 → 회귀 그린.
+3. FE hook (`useDashboardDraft`, `useDashboardSettings`) + `lockMerge` 헬퍼 구현 → 회귀 그린.
+4. `DashboardShell` + `WidgetPlaceholder` + `EditModeToggle` 구현. 11 위젯 placeholder 렌더.
+5. RGL CSS (`dashboard-rgl.css` + `uidesign.md` 토큰 3종) — `lint:tokens` 0 hits 확인.
+6. `/dashboard` 라우트 추가 + role guard + page.
+7. visual-diff baseline 캡처.
+8. 회귀 전체 그린 (FE typecheck + test + lint + lint:tokens · BE typecheck + test).
+9. 사용자 검수 → push → PR open. (PR merge 는 사용자.)
+
+## 머지 가드 (사용자 확인 후에만 PR 생성)
+
+- FE typecheck 0 / FE lint 0 / FE lint:tokens 0
+- BE typecheck 0
+- 회귀 그린 (BE 전체 + FE 전체)
+- visual-diff baseline 자손 SKIP 0
+- `dashboard.md` 정본과의 차이 0 (편집 모드 토글 / draft buffer / lock 머지 / xs read-only / RGL CSS)
+
+## 리뷰
+
+본 Phase 의 PLAN.md 또는 PR description 을 codex:rescue 적대적 리뷰에 디스패치 (memory `feedback_review_delegation.md` — Auto-trigger at 1000 LOC). 회신 후 `wave-2-dashboard.md §3` 또는 본 PR 코멘트로 결정 갱신.
+
+## 비-범위 (Phase D 가 다루지 않음)
+
+- 위젯 콘텐츠 (KPI / 분포 / 매트릭스 / 히트맵 / 트렌드 / 태그 / 시스템 / 담당자 / 장기미처리 / SLA / 에이징) — Phase B/C 별 PR.
+- 설정 패널 (위젯 가시성 토글 / 기본 날짜 / X축 / GlobalTabs 순서) — Phase E.
+- 모바일 편집 UI / 키보드 reorder / 위젯 export — NextGen.
+
+## 자율 실행
+
+사용자가 "알아서 다 진행" 위임 (이전 세션 2026-05-10). 머지 단계만 사용자 — 그 외 결정 / 구현 / TDD / 리뷰 디스패치 / push / PR open 은 모두 자동.
+
+시작 전 첫 응답에 다음을 포함할 것:
+1. 4 PR 머지 상태 확인 (`gh pr view 291/292/293/294 --json state`)
+2. 머지 안 된 PR 있으면 사용자에게 머지 요청 후 종료. 모두 머지된 경우만 진입.
+3. Phase D 작업 순서 확인 (위 순서 1~9) 및 첫 단계 (TDD 회귀 작성) 진입.
+```
+
+---
+
+## 사용 메모
+
+- 위 코드 블록 본문이 다음 세션 진입 메시지. 그대로 붙여넣으면 됨.
+- 머지가 일부만 됐을 때를 대비해 첫 단계가 머지 상태 확인.
+- Phase D 가 끝나면 본 파일 폐기 + 새로 Phase E 프롬프트 작성.

--- a/docs/specs/requires/dashboard.md
+++ b/docs/specs/requires/dashboard.md
@@ -763,19 +763,27 @@ dashboard_settings (
 
 ```ts
 // shared/contracts/dashboard.ts
-type WidgetLayout = { x: number; y: number; w: number; h: number; static?: boolean };
-type WidgetSizesV2 = {
-  [widgetId: string]: {
-    lg: WidgetLayout;
-    md?: WidgetLayout;
-    sm?: WidgetLayout;
+const WidgetLayoutSchema = z.object({
+  x: z.number().int().min(0).max(11),
+  y: z.number().int().min(0),
+  w: z.number().int().min(1).max(12),
+  h: z.number().int().min(1),
+  static: z.boolean().optional(),
+}).refine(({ x, w }) => x + w <= 12, { message: 'x + w must be ≤ 12 (12-col grid)' });
+
+const WidgetSizesV2Schema = z.record(
+  z.object({
+    lg: WidgetLayoutSchema,
+    md: WidgetLayoutSchema.optional(),
+    sm: WidgetLayoutSchema.optional(),
     // xs 는 RGL 자동 처리 — 저장하지 않음
-  };
-};
+  }),
+);
 ```
 
 - `md`/`sm` 미지정 시 RGL 가 `lg` 에서 폴백.
 - `static: true` 인 위젯은 드래그·리사이즈 비활성. UI 헤더에 🔒 표시.
+- bounds 위반 (`x + w > 12`, 음수, 정수 아님) → 400. fixture / seed 생성 시 동일 zod 강제.
 
 ### 잠금 머지 규칙
 
@@ -788,11 +796,14 @@ const isStatic = adminLockedWidgets.includes(widgetId)
 - 개인 잠금은 자기 화면에만 적용. 개인이 unlock 해도 Admin 잠금은 해제 불가 (UI 토글 disabled + tooltip "Admin 강제 잠금").
 - 권한: `locked_widgets` mutate 는 **Admin only** (BE 403 + FE 토글 hidden). `widget_visibility[id].locked` 는 모든 role.
 
-### 저장/복원
+### 저장/복원 (draft buffer 모델)
 
-- **저장**: `PATCH /api/dashboard/settings` 페이로드에 `widget_sizes: WidgetSizesV2` 포함. 디바운스 500ms (드래그 종료 시 발사).
+- **HTTP verb**: `PUT /api/dashboard/settings` (PATCH 아님 — `requirements.md §11.7` 정합).
+- **draft buffer**: 편집 모드 진입 시 서버 hydrate 값을 `draft` 로 복사. drag/resize end → `draft` 만 로컬 갱신 (서버 호출 X).
+- **저장**: "저장" 버튼 클릭 → `PUT /api/dashboard/settings` body = `{ widget_sizes: WidgetSizesV2, ...other }`. 200 OK 시 편집 모드 종료 + `draft` → 적용.
+- **취소**: "취소" 버튼 클릭 → `draft` 폐기 + 서버 값으로 재 hydrate. DB 미변경.
 - **복원**: 페이지 mount 시 `GET /api/dashboard/settings` → `Responsive` 의 `layouts` prop 으로 hydrate.
-- **기본 레이아웃**: `frontend/src/features/dashboard/defaultLayouts.ts` 가 8 위젯의 lg/md/sm 기본 좌표 export. 사용자 저장값 없으면 fallback.
+- **기본 레이아웃**: `frontend/src/features/dashboard/defaultLayouts.ts` 가 11 위젯의 lg/md/sm 기본 좌표 export. 사용자 저장값 없으면 fallback.
 
 ### 편집 모드 토글
 
@@ -809,6 +820,15 @@ const isStatic = adminLockedWidgets.includes(widgetId)
 
 - `uidesign.md` 신규 토큰 필요: `--dashboard-grid-gap` (16px), `--dashboard-grid-padding` (24px), `--dashboard-widget-resize-handle` (위젯 우하단 핸들 색).
 - 신규 토큰은 Wave 2 Phase A 에서 spec PR 별도 머지.
+
+### RGL CSS 규칙
+
+- 위젯 컨테이너: `overflow: hidden`. 위젯 내부 스크롤은 위젯이 자체 처리 (히트맵 / 담당자표 등).
+- z-index: 일반 = 1, hover = 2, dragging = 1000, resizing = 999. 편집 모드 외 zIndex 변동 X.
+- resize handle: 위젯 우하단 절대 배치, 12×12px, `containerPadding` 안에 머무름. dragging 중에는 hidden.
+- scroll container: 페이지 root `overflow-y: auto`. 그리드 자체는 `overflow: visible` (RGL 가 자식 위치를 absolute 로 깔기 때문).
+- 모바일 (`xs` < 768): RGL `isDraggable: false` + `isResizable: false` 강제. 1-col auto-stack.
+- 편집 모드 진입 시 페이지 root `cursor: grab` 추가. dragging 중 `cursor: grabbing`.
 
 ### 접근성
 

--- a/docs/specs/requires/dashboard.md
+++ b/docs/specs/requires/dashboard.md
@@ -664,10 +664,9 @@ interface AssigneeTableState {
 
 ## 커스터마이징 (MVP)
 
-> 드래그앤드롭 재배치, 위젯 크기 조절, 항목별 잠금은 NextGen으로 이동.
-> 상세: `docs/specs/plans/dashboard-v2-layout-editor.md` (파일명은 초안 시점 유지 — 내용은 NextGen 기능)
+> 2026-05-10: 드래그/리사이즈/잠금/반응형이 NextGen → MVP 로 승격 (Wave 2 결정 W2-D1~D3). 상세 엔진 명세는 본 §"커스터마이즈 v2 — 레이아웃 엔진" 참조.
 
-MVP 범위: **위젯 숨기기/표시** + **기본 날짜 범위** + **히트맵 기본 X축** + **GlobalTabs 순서·숨김(Admin)**
+MVP 범위: **위젯 숨기기/표시** + **드래그 재배치** + **크기 조절** + **위젯 고정** + **반응형 브레이크포인트 레이아웃** + **기본 날짜 범위** + **히트맵 기본 X축** + **GlobalTabs 순서·숨김(Admin)**
 
 ### 설정 계층
 
@@ -684,6 +683,12 @@ dashboard_settings (
   widget_visibility      JSONB       NOT NULL DEFAULT '{}',
   -- 예: {"kpi": true, "heatmap": true, "aging": false}
   widget_sizes           JSONB       NOT NULL DEFAULT '{}',
+  -- v2 (2026-05-10~): breakpoint-keyed { [widgetId]: { lg: {x,y,w,h,static}, md:{...}, sm:{...} } }
+  -- 예: { "kpi": { "lg": {"x":0,"y":0,"w":12,"h":2,"static":false} } }
+  -- v1 (flat {w,h}) 데이터는 존재하지 않음 (Wave 2 미출시) → in-app 마이그 불필요.
+  locked_widgets         JSONB       NOT NULL DEFAULT '[]',
+  -- Admin 기본값 행에서만 의미 있음 (user_id IS NULL). 예: ["kpi","heatmap"] → 모든 사용자에게 RGL static 강제.
+  -- 개인 행에서는 빈 배열로 둠. 개인 잠금은 widget_visibility[id].locked 필드로 표현.
   locked_fields          JSONB       NOT NULL DEFAULT '[]',
   default_date_range     VARCHAR(8)  NOT NULL DEFAULT '3m',
   -- enum: '1m' | '3m' | '1y' | 'all' | 'custom' (정본: migration 011 + requirements.md §4)
@@ -704,14 +709,108 @@ dashboard_settings (
 
 ### 편집 가능 항목 (MVP)
 
-| 항목                 | 개인 | Admin 기본값 |
-| -------------------- | ---- | ------------ |
-| 위젯 숨기기/표시     | ✓    | ✓            |
-| 기본 날짜 범위       | ✓    | ✓            |
-| 히트맵 기본 X축      | ✓    | ✓            |
-| GlobalTabs 순서·숨김 | —    | ✓            |
+| 항목                       | 개인 | Admin 기본값 |
+| -------------------------- | ---- | ------------ |
+| 위젯 숨기기/표시           | ✓    | ✓            |
+| 위젯 위치 (drag)           | ✓    | ✓            |
+| 위젯 크기 (resize)         | ✓    | ✓            |
+| 위젯 고정 (lock)           | ✓    | ✓ (강제)     |
+| 브레이크포인트 (lg/md/sm)  | auto | —            |
+| 기본 날짜 범위             | ✓    | ✓            |
+| 히트맵 기본 X축            | ✓    | ✓            |
+| GlobalTabs 순서·숨김       | —    | ✓            |
 
 ### 세션 임시 설정 (sessionStorage)
 
 - 저장 없이 닫으면 초기화
 - 동일 항목 오버라이드 (세션 중 임시 변경 유지)
+
+---
+
+## 커스터마이즈 v2 — 레이아웃 엔진
+
+> 정본 결정 게이트: `docs/specs/plans/wave-2-dashboard.md §3` (W2-D1~D4).
+
+### 라이브러리
+
+- **`react-grid-layout`** (RGL) ^1.4 — `Responsive` + `WidthProvider` HOC.
+- 채택 근거: 드래그·리사이즈·반응형 브레이크포인트·`static` 잠금이 단일 라이브러리로 해결. 직렬화 형식이 JSONB 스키마와 1:1.
+- 거부: `dnd-kit` (그리드 수학 / 리사이즈 / 반응형 모두 자체 구현 부담), `gridstack.js` (jQuery 기반 레거시).
+
+### 그리드 계약
+
+| 항목 | 값 |
+| --- | --- |
+| 컬럼 수 | 12 (모든 브레이크포인트) |
+| `rowHeight` | 80px |
+| `margin` | `[16, 16]` |
+| `containerPadding` | `[24, 24]` |
+| `compactType` | `'vertical'` |
+| `preventCollision` | `false` |
+
+### 브레이크포인트
+
+| key | min-width | 비고 |
+| --- | --------- | ---- |
+| `lg` | ≥1200 | 데스크톱 기본 |
+| `md` | ≥996  | 태블릿 가로 |
+| `sm` | ≥768  | 태블릿 세로 |
+| `xs` | <768  | 단일 컬럼 auto-stack (RGL 기본) |
+
+`xs` 는 사용자가 편집하지 않음 — RGL 가 `lg` 레이아웃을 자동으로 1-col 풀폭으로 압축. 모바일은 read-only 모드 (드래그/리사이즈 비활성).
+
+### `widget_sizes` v2 직렬화
+
+```ts
+// shared/contracts/dashboard.ts
+type WidgetLayout = { x: number; y: number; w: number; h: number; static?: boolean };
+type WidgetSizesV2 = {
+  [widgetId: string]: {
+    lg: WidgetLayout;
+    md?: WidgetLayout;
+    sm?: WidgetLayout;
+    // xs 는 RGL 자동 처리 — 저장하지 않음
+  };
+};
+```
+
+- `md`/`sm` 미지정 시 RGL 가 `lg` 에서 폴백.
+- `static: true` 인 위젯은 드래그·리사이즈 비활성. UI 헤더에 🔒 표시.
+
+### 잠금 머지 규칙
+
+```ts
+const isStatic = adminLockedWidgets.includes(widgetId)
+              || personalWidgetVisibility[widgetId]?.locked === true;
+```
+
+- `dashboard_settings` 의 Admin 행(`user_id IS NULL`) `locked_widgets` 가 우선.
+- 개인 잠금은 자기 화면에만 적용. 개인이 unlock 해도 Admin 잠금은 해제 불가 (UI 토글 disabled + tooltip "Admin 강제 잠금").
+- 권한: `locked_widgets` mutate 는 **Admin only** (BE 403 + FE 토글 hidden). `widget_visibility[id].locked` 는 모든 role.
+
+### 저장/복원
+
+- **저장**: `PATCH /api/dashboard/settings` 페이로드에 `widget_sizes: WidgetSizesV2` 포함. 디바운스 500ms (드래그 종료 시 발사).
+- **복원**: 페이지 mount 시 `GET /api/dashboard/settings` → `Responsive` 의 `layouts` prop 으로 hydrate.
+- **기본 레이아웃**: `frontend/src/features/dashboard/defaultLayouts.ts` 가 8 위젯의 lg/md/sm 기본 좌표 export. 사용자 저장값 없으면 fallback.
+
+### 편집 모드 토글
+
+- 헤더 우측 "편집" 버튼 → `isEditing: true` 시에만 RGL `isDraggable`/`isResizable` 활성. 비편집 시 read-only.
+- 편집 모드 진입 시 모든 위젯 헤더에 grab 커서 + 우하단 리사이즈 핸들 노출.
+- "저장" / "취소" / "기본값으로 초기화" 버튼은 편집 모드에서만 표시.
+
+### 마이그레이션
+
+- 기존 `widget_sizes JSONB` 컬럼 (마이그 011/012) 재사용 — 추가 마이그 불필요.
+- v1 (flat `{w,h}`) 데이터 부재 (Wave 2 미출시) → in-app 마이그 코드 작성 안 함. zod 가 v2 형식만 허용.
+
+### 시각 토큰
+
+- `uidesign.md` 신규 토큰 필요: `--dashboard-grid-gap` (16px), `--dashboard-grid-padding` (24px), `--dashboard-widget-resize-handle` (위젯 우하단 핸들 색).
+- 신규 토큰은 Wave 2 Phase A 에서 spec PR 별도 머지.
+
+### 접근성
+
+- 키보드 reorder: 미지원 (RGL 한계). NextGen 으로 분리.
+- 스크린리더: 위젯 헤더 `aria-label` 에 위치 정보 포함 ("KPI 위젯, 1행 1열, 잠김").


### PR DESCRIPTION
## Summary

Wave 2 (Dashboard) plan 신규 작성 + dashboard.md spec sync 1 PR.

- **dashboard.md spec sync**: 드래그/리사이즈/잠금/반응형을 NextGen → MVP 승격. 신규 §\"커스터마이즈 v2 — 레이아웃 엔진\" (RGL ^1.4, 12-col 그리드, lg/md/sm 브레이크포인트, widget_sizes v2 직렬화, 2-tier 잠금 머지, draft buffer 저장 모델, RGL CSS 규칙).
- **wave-2-dashboard.md 신규**: §0~§8 구조 (Wave 3 plan 미러). 결정 W2-D1~D9, Phase A~F 분할, Task ID W2-1~W2-9, OQ 6 건.
- **결정 잠금**: W2-D1 react-grid-layout / W2-D2 v2 직렬화 / W2-D3 2-tier lock (마이그 022 의존) / W2-D5 Phase 순서 (codex 권고 D 우선) / W2-D9 codex:rescue 적대적 리뷰.

## codex:rescue 적대적 리뷰 결과 (2026-05-10)

### Hard contradictions (반영 완료)

1. **위젯 카운트 8 → 11**: 정본 §위젯 상세 명세 §1~§11 (장기미처리 / 처리속도 / 에이징 누락 발견 → 추가).
2. **HTTP verb PATCH → PUT**: \`requirements.md §11.7\` + \`dashboard.md §793\` 정합.
3. **default_date_range 모순**: spec preamble (\"최근 1개월\") vs 스키마 (\`'3m'\`) vs 마이그 011 (\`'1m'\`) 충돌. **OQ-6 신규**, 사용자 결정 의뢰. 본 PR 에서는 spec 변경 없음 (별 PR 권장).
4. **locked_widgets 부재**: codex 가 \`011_pre_impl_alignment.sql:40-59\` + \`012_voc_origin_metadata.sql\` 스캔 → 컬럼 부재 확정. **마이그 022 신설** (W2-2).

### Missing edges (반영 완료)

- RGL CSS: z-index (dragging=1000, resizing=999) / overflow / scroll container / resize handle 명시.
- 저장/복원: draft buffer 모델 (auto-save + cancel 모순 회피). \"저장\" 명시 클릭 시에만 PUT.
- widget_sizes zod bounds: \`x>=0, x+w<=12, w>=1, h>=1\` + 정수 강제.

### Phase 순서 변경 (codex §5 권고)

- 종전: A → B/C → D → E → F (위젯 콘텐츠 우선)
- 변경: A → **D (RGL 쉘 + placeholder 11 위젯) → B/C 병렬 (콘텐츠)** → E → F. RGL CSS·lock·draft buffer 검증을 위젯 콘텐츠 전에.

## 사용자 결정 대기 (Open Questions)

- **OQ-6** (신규): \`default_date_range\` 기본값 \`'1m'\` vs \`'3m'\` — spec 자체 모순. 권장 \`'1m'\` (preamble + 011 정합). **이 PR 에서 결정 X — 별 PR 또는 본 PR 코멘트로 결정**.
- **OQ-1~5**: §3 결정과 정합하게 잠금 (사용자 위임 2026-05-10).

## Phase A 후속 (이 PR 머지 후)

- W2-2 PR-β: 마이그 022 (\`locked_widgets JSONB\`)
- W2-3 PR-γ: \`shared/contracts/dashboard.ts\` zod v2 + bounds + openapi.yaml PUT + 11 위젯 fixtures stub
- W2-4 PR-δ: \`react-grid-layout\` ^1.4 install + 타입 + smoke test

## Test plan

- [ ] dashboard.md §커스터마이즈 v2 정합성 (위젯 11종 / PUT verb / draft buffer / zod bounds)
- [ ] wave-2-dashboard.md §3 결정 W2-D1~D9 잠금 상태
- [ ] wave-2-dashboard.md §6 Phase 흐름 D → B/C 순서
- [ ] wave-2-dashboard.md §7 OQ-6 (default_date_range) 결정 의뢰

🤖 Generated with [Claude Code](https://claude.com/claude-code)