### PR TITLE
feat(wave-2): migration 022 dashboard_settings.locked_widgets (W2-2 / PR-β)

### DIFF
--- a/backend/migrations/022_dashboard_locked_widgets.sql
+++ b/backend/migrations/022_dashboard_locked_widgets.sql
@@ -1,0 +1,37 @@
+-- 022: dashboard_settings.locked_widgets — Wave 2 W2-2 / PR-β
+--
+-- Spec lock:
+--   - docs/specs/requires/dashboard.md §커스터마이즈 v2 §잠금 머지 규칙
+--   - docs/specs/plans/wave-2-dashboard.md §3 W2-D3, §6.2 W2-2
+--
+-- Purpose: 2-tier 잠금 (Admin 강제 / 개인 자기 화면) 중 Admin tier 의 SSOT.
+-- Admin 행 (`user_id IS NULL`) 에서만 의미 있는 컬럼 — 개인 행은 `[]` 유지.
+-- 머지 규칙: `static = adminLocked || personalLocked` (개인 unlock 으로 Admin
+-- lock 해제 불가). FE/BE 양측 동일 규칙.
+--
+-- 도메인: 위젯 ID 문자열 배열. dashboard.md §위젯 상세 명세 1~11 의 stable
+-- ID — `kpi` / `distribution` / `priority-status-matrix` / `heatmap` /
+-- `weekly-trend` / `tag-bar` / `system-card` / `assignee-table` / `aging-top10`
+-- / `sla` / `aging`. 신규 위젯 추가 시 본 컬럼 schema 변경 없이 string append.
+--
+-- 권한: mutate 는 Admin only (BE 403 + FE 토글 hidden — `dashboard.md §잠금
+-- 머지 규칙`). 검증은 zod (`shared/contracts/dashboard.ts`) + 라우트 가드 이중.
+--
+-- Backfill: 기존 row 모두 `[]` 로 초기화 — DEFAULT '[]'::jsonb 가 NOT NULL
+-- 보장. Wave 2 미출시 시점에는 Admin 행이 1 건 (시드) — `[]` 유지.
+--
+-- 회귀 테스트: backend/src/__tests__/migration-022-dashboard-locked-widgets.test.ts
+-- (up 적용 → 컬럼 존재 / DEFAULT '[]' / 위젯 ID 배열 삽입, down 적용 → 컬럼 제거).
+
+-- Up Migration
+
+ALTER TABLE dashboard_settings
+  ADD COLUMN locked_widgets jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN dashboard_settings.locked_widgets IS
+  'Admin-tier widget lock list. Meaningful only on the Admin row (user_id IS NULL). Personal rows keep []. Merge rule: static = adminLocked || personalLocked.';
+
+-- Down Migration
+
+ALTER TABLE dashboard_settings
+  DROP COLUMN IF EXISTS locked_widgets;

--- a/backend/src/__tests__/migration-022-dashboard-locked-widgets.test.ts
+++ b/backend/src/__tests__/migration-022-dashboard-locked-widgets.test.ts
@@ -1,0 +1,88 @@
+/**
+ * migration 022 — Wave 2 W2-2: dashboard_settings.locked_widgets JSONB.
+ *
+ * Spec: docs/specs/requires/dashboard.md §커스터마이즈 v2 §잠금 머지 규칙.
+ * Plan: docs/specs/plans/wave-2-dashboard.md §3 W2-D3, §6.2 W2-2.
+ *
+ * Test boundaries:
+ *  - up 적용 → locked_widgets 컬럼 존재 / DEFAULT '[]' / 위젯 ID 문자열 배열 삽입 정상
+ *  - down 적용 → 컬럼 제거 (해당 컬럼 SELECT 시 throw)
+ *
+ * pg-mem 한계: jsonb DEFAULT '[]'::jsonb 는 round-trip 시 빈 배열 반환.
+ */
+import { newDb, DataType, IMemoryDb } from 'pg-mem';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../migrations');
+
+const DASHBOARD_SETTINGS_STUB = `
+  CREATE TABLE dashboard_settings (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid,
+    widget_order jsonb NOT NULL DEFAULT '[]'::jsonb,
+    widget_visibility jsonb NOT NULL DEFAULT '{}'::jsonb,
+    widget_sizes jsonb NOT NULL DEFAULT '{}'::jsonb,
+    locked_fields jsonb NOT NULL DEFAULT '[]'::jsonb,
+    default_date_range varchar(8) NOT NULL DEFAULT '1m',
+    heatmap_default_x_axis varchar(16) NOT NULL DEFAULT 'status',
+    globaltabs_order jsonb,
+    updated_at timestamptz NOT NULL DEFAULT NOW()
+  );
+`;
+
+function readMigration(file: string): { up: string; down: string } {
+  const raw = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf-8');
+  const upMatch = raw.match(/-- Up Migration([\s\S]*?)(?=-- Down Migration|$)/i);
+  const downMatch = raw.match(/-- Down Migration([\s\S]*)$/i);
+  if (!upMatch || !downMatch) {
+    throw new Error(`Migration ${file} missing Up/Down markers`);
+  }
+  return { up: upMatch[1].trim(), down: downMatch[1].trim() };
+}
+
+function bootDb(): IMemoryDb {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: DataType.uuid,
+    implementation: () => crypto.randomUUID(),
+    impure: true,
+  });
+  db.public.query(DASHBOARD_SETTINGS_STUB);
+  return db;
+}
+
+describe('migration 022 — dashboard_settings.locked_widgets (Wave 2 W2-2)', () => {
+  it('post-022: locked_widgets column exists with DEFAULT []', () => {
+    const db = bootDb();
+    const { up } = readMigration('022_dashboard_locked_widgets.sql');
+    db.public.query(up);
+
+    db.public.query(`INSERT INTO dashboard_settings (user_id) VALUES (NULL);`);
+    const rs = db.public.query(`SELECT locked_widgets FROM dashboard_settings;`);
+    expect(rs.rows[0].locked_widgets).toEqual([]);
+  });
+
+  it('post-022: accepts widget ID string array', () => {
+    const db = bootDb();
+    const { up } = readMigration('022_dashboard_locked_widgets.sql');
+    db.public.query(up);
+
+    db.public.query(
+      `INSERT INTO dashboard_settings (locked_widgets) VALUES ('["kpi","heatmap"]'::jsonb);`,
+    );
+    const rs = db.public.query(`SELECT locked_widgets FROM dashboard_settings;`);
+    expect(rs.rows[0].locked_widgets).toEqual(['kpi', 'heatmap']);
+  });
+
+  it('round-trip down: drops the locked_widgets column', () => {
+    const db = bootDb();
+    const { up, down } = readMigration('022_dashboard_locked_widgets.sql');
+    db.public.query(up);
+    db.public.query(down);
+
+    expect(() => db.public.query(`SELECT locked_widgets FROM dashboard_settings;`)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Wave 2 Phase A 의 마이그 PR — codex:rescue 적대적 리뷰 (2026-05-10) 가 011/012 SQL 스캔 후 \`locked_widgets\` 컬럼 부재 확정 → 본 PR 로 신설.

## Changes

- \`backend/migrations/022_dashboard_locked_widgets.sql\`: \`dashboard_settings.locked_widgets jsonb NOT NULL DEFAULT '[]'\` + COMMENT (Admin tier SSOT, 머지 규칙 = OR) + Down (\`DROP COLUMN IF EXISTS\`).
- \`backend/src/__tests__/migration-022-dashboard-locked-widgets.test.ts\`: pg-mem 회귀 3 건.

## 도메인

- Admin 행 (\`user_id IS NULL\`) 에서만 의미 — 개인 행은 \`[]\` 유지.
- 머지 규칙: \`static = adminLocked || personalLocked\`. 개인 unlock 으로 Admin lock 해제 불가 (FE/BE 양측 동일).
- 위젯 ID 도메인: \`dashboard.md §위젯 상세 명세\` 1~11 의 stable ID. 신규 위젯 추가 시 schema 변경 없이 string append.

## Plan / Spec

- Plan: \`docs/specs/plans/wave-2-dashboard.md\` §3 W2-D3, §6.2 W2-2 — PR #291 동시 진행 중.
- Spec: \`docs/specs/requires/dashboard.md\` §커스터마이즈 v2 §잠금 머지 규칙.

## 검증

- BE typecheck 0
- BE 465/465 그린 (462 → 465)
- 마이그 회귀: DEFAULT '[]' / 위젯 ID 배열 삽입 / down 적용 시 컬럼 제거 — 모두 그린

## Operator notes

- Up: \`ALTER TABLE dashboard_settings ADD COLUMN locked_widgets jsonb NOT NULL DEFAULT '[]'\`. 기존 row 모두 \`[]\` 자동 백필. Wave 2 미출시 시점 — 시드 1 행 (Admin) 만 영향, 잠금 정책 변동 X.
- Down: \`DROP COLUMN IF EXISTS\`. 본 컬럼 의존 코드 (Phase D/E 도입 예정) 머지 전이라면 안전.

## Test plan

- [ ] \`backend/migrations/022_*\` Up/Down marker 분리 정상
- [ ] pg-mem 회귀 3 건 통과
- [ ] BE 전체 회귀 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)