### PR TITLE
feat(wave-2): dashboard contract zod v2 + openapi PUT + fixtures stub (W2-3 / PR-γ)

### DIFF
--- a/backend/src/__tests__/dashboard-contract.test.ts
+++ b/backend/src/__tests__/dashboard-contract.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Wave 2 W2-3 / PR-γ — shared/contracts/dashboard zod 회귀.
+ *
+ * Spec: docs/specs/requires/dashboard.md §커스터마이즈 v2
+ *       (RGL 12-col bounds, breakpoint-keyed widget_sizes v2, 2-tier 잠금).
+ * Plan: docs/specs/plans/wave-2-dashboard.md §3 W2-D7 (TDD bounds + verb parity).
+ *
+ * Codex:rescue 리뷰 §2 zod gotcha 반영 — bounds (x>=0, x+w<=12, w>=1, h>=1)
+ * 강제 검증.
+ */
+import {
+  WidgetId,
+  WidgetLayout,
+  WidgetSizesV2,
+  DashboardSettings,
+  DashboardSettingsPutBody,
+  DefaultDateRange,
+  HeatmapXAxis,
+} from '../../../shared/contracts/dashboard';
+
+describe('shared/contracts/dashboard — Wave 2 W2-3', () => {
+  describe('WidgetId enum (11 stable IDs)', () => {
+    const ids = [
+      'kpi',
+      'distribution',
+      'priority-status-matrix',
+      'heatmap',
+      'weekly-trend',
+      'tag-bar',
+      'system-card',
+      'assignee-table',
+      'aging-top10',
+      'sla',
+      'aging',
+    ];
+
+    it.each(ids)('accepts %s', (id) => {
+      expect(WidgetId.parse(id)).toBe(id);
+    });
+
+    it('rejects unknown widget id', () => {
+      expect(() => WidgetId.parse('unknown-widget')).toThrow();
+    });
+  });
+
+  describe('WidgetLayout — 12-col bounds (codex §2)', () => {
+    it('accepts a valid layout', () => {
+      expect(WidgetLayout.parse({ x: 0, y: 0, w: 12, h: 2 })).toMatchObject({
+        x: 0,
+        w: 12,
+      });
+    });
+
+    it('rejects x + w > 12', () => {
+      expect(() => WidgetLayout.parse({ x: 6, y: 0, w: 7, h: 2 })).toThrow(/x \+ w/);
+    });
+
+    it('rejects negative x', () => {
+      expect(() => WidgetLayout.parse({ x: -1, y: 0, w: 4, h: 2 })).toThrow();
+    });
+
+    it('rejects non-integer w', () => {
+      expect(() => WidgetLayout.parse({ x: 0, y: 0, w: 3.5, h: 2 })).toThrow();
+    });
+
+    it('rejects w < 1', () => {
+      expect(() => WidgetLayout.parse({ x: 0, y: 0, w: 0, h: 2 })).toThrow();
+    });
+
+    it('accepts static flag', () => {
+      const out = WidgetLayout.parse({ x: 0, y: 0, w: 4, h: 2, static: true });
+      expect(out.static).toBe(true);
+    });
+  });
+
+  describe('WidgetSizesV2 — breakpoint-keyed', () => {
+    it('accepts lg-only entry (md/sm fallback to RGL)', () => {
+      const out = WidgetSizesV2.parse({
+        kpi: { lg: { x: 0, y: 0, w: 12, h: 2 } },
+      });
+      expect(out.kpi.lg.w).toBe(12);
+    });
+
+    it('accepts lg + md + sm combo', () => {
+      const out = WidgetSizesV2.parse({
+        heatmap: {
+          lg: { x: 0, y: 4, w: 12, h: 6 },
+          md: { x: 0, y: 4, w: 12, h: 6 },
+          sm: { x: 0, y: 4, w: 12, h: 8 },
+        },
+      });
+      expect(out.heatmap.sm?.h).toBe(8);
+    });
+
+    it('rejects when nested layout violates bounds', () => {
+      expect(() =>
+        WidgetSizesV2.parse({
+          kpi: { lg: { x: 10, y: 0, w: 5, h: 2 } },
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('DefaultDateRange + HeatmapXAxis enums', () => {
+    it('DefaultDateRange accepts the 5 spec values', () => {
+      ['1m', '3m', '1y', 'all', 'custom'].forEach((v) => {
+        expect(DefaultDateRange.parse(v)).toBe(v);
+      });
+    });
+
+    it('HeatmapXAxis accepts the 3 spec values', () => {
+      ['status', 'priority', 'tag'].forEach((v) => {
+        expect(HeatmapXAxis.parse(v)).toBe(v);
+      });
+    });
+  });
+
+  describe('DashboardSettings — full row shape', () => {
+    it('parses an Admin row (locked_widgets populated)', () => {
+      const out = DashboardSettings.parse({
+        widget_order: ['kpi', 'heatmap'],
+        widget_visibility: { kpi: { visible: true }, heatmap: { visible: true } },
+        widget_sizes: {
+          kpi: { lg: { x: 0, y: 0, w: 12, h: 2 } },
+          heatmap: { lg: { x: 0, y: 2, w: 12, h: 6 } },
+        },
+        locked_widgets: ['kpi'],
+        default_date_range: '1m',
+        heatmap_default_x_axis: 'status',
+        globaltabs_order: null,
+      });
+      expect(out.locked_widgets).toEqual(['kpi']);
+    });
+  });
+
+  describe('DashboardSettingsPutBody — partial update body', () => {
+    it('accepts a single-field PUT (default_date_range)', () => {
+      const out = DashboardSettingsPutBody.parse({ default_date_range: '3m' });
+      expect(out.default_date_range).toBe('3m');
+    });
+
+    it('accepts an empty body (no-op preserve)', () => {
+      expect(DashboardSettingsPutBody.parse({})).toEqual({});
+    });
+
+    it('rejects unknown widget id inside locked_widgets', () => {
+      expect(() => DashboardSettingsPutBody.parse({ locked_widgets: ['ghost'] })).toThrow();
+    });
+  });
+});

--- a/shared/contracts/dashboard/index.ts
+++ b/shared/contracts/dashboard/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Barrel for dashboard contract Zod schemas. Mirror master/index.ts pattern.
+ */
+export * from './io';

--- a/shared/contracts/dashboard/io.ts
+++ b/shared/contracts/dashboard/io.ts
@@ -1,0 +1,132 @@
+/**
+ * @module shared/contracts/dashboard/io
+ *
+ * Dashboard settings API contract — Wave 2 Phase A (W2-3 / PR-γ).
+ *
+ * Spec lock:
+ *  - docs/specs/requires/dashboard.md §커스터마이즈 v2 (RGL 12-col grid,
+ *    breakpoint-keyed widget_sizes v2, 2-tier 잠금 머지 규칙).
+ *  - docs/specs/plans/wave-2-dashboard.md §3 W2-D2/D3, §6.2 W2-3.
+ *
+ * HTTP verb: PUT /api/dashboard/settings (PATCH 아님 — codex:rescue 리뷰
+ * 2026-05-10 §1 verb mismatch 정합).
+ */
+import { z } from 'zod';
+import { Uuid } from '../common';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Widget IDs — dashboard.md §위젯 상세 명세 §1~§11 의 stable string IDs.
+// 신규 위젯 추가 시 본 union 에 append (irreversible — fixture / locked_widgets
+// JSONB / defaultLayouts 가 동시 의존).
+// ──────────────────────────────────────────────────────────────────────────
+export const WidgetId = z.enum([
+  'kpi',
+  'distribution',
+  'priority-status-matrix',
+  'heatmap',
+  'weekly-trend',
+  'tag-bar',
+  'system-card',
+  'assignee-table',
+  'aging-top10',
+  'sla',
+  'aging',
+]);
+export type WidgetId = z.infer<typeof WidgetId>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Widget layout — RGL `Layout` 호환 + 12-col bounds.
+// codex:rescue 리뷰 §2 zod gotcha 반영: x/y/w/h 정수 + bounds + x+w<=12 검증.
+// ──────────────────────────────────────────────────────────────────────────
+export const WidgetLayout = z
+  .object({
+    x: z.number().int().min(0).max(11),
+    y: z.number().int().min(0),
+    w: z.number().int().min(1).max(12),
+    h: z.number().int().min(1),
+    static: z.boolean().optional(),
+  })
+  .refine(({ x, w }) => x + w <= 12, {
+    message: 'x + w must be ≤ 12 (12-col grid bound)',
+  });
+export type WidgetLayout = z.infer<typeof WidgetLayout>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// widget_sizes v2 — breakpoint-keyed. v1 (flat) 데이터 부재 (Wave 2 미출시)
+// → in-app 마이그 불필요. xs 는 RGL 자동 1-col stack — 직렬화 X.
+// ──────────────────────────────────────────────────────────────────────────
+// zod v4 의 z.record(EnumKey, V) 는 모든 enum 키를 강제 — 본 컬럼은 partial
+// map 이므로 z.string() 키 + 별도 refinement 으로 widget ID 도메인 검증.
+export const WidgetSizesV2 = z
+  .record(
+    z.string(),
+    z.object({
+      lg: WidgetLayout,
+      md: WidgetLayout.optional(),
+      sm: WidgetLayout.optional(),
+    }),
+  )
+  .refine(
+    (val) => Object.keys(val).every((k) => WidgetId.safeParse(k).success),
+    { message: 'unknown widget id in widget_sizes' },
+  );
+export type WidgetSizesV2 = z.infer<typeof WidgetSizesV2>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Widget visibility — 개인 잠금 (`locked: true`) + 가시성 토글.
+// 머지 규칙: static = adminLockedWidgets.includes(id) || visibility[id]?.locked.
+// ──────────────────────────────────────────────────────────────────────────
+export const WidgetVisibility = z
+  .record(
+    z.string(),
+    z.object({
+      visible: z.boolean().default(true),
+      locked: z.boolean().optional(),
+    }),
+  )
+  .refine(
+    (val) => Object.keys(val).every((k) => WidgetId.safeParse(k).success),
+    { message: 'unknown widget id in widget_visibility' },
+  );
+export type WidgetVisibility = z.infer<typeof WidgetVisibility>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Date range / heatmap X-axis enums — dashboard.md preamble + §히트맵.
+// ──────────────────────────────────────────────────────────────────────────
+export const DefaultDateRange = z.enum(['1m', '3m', '1y', 'all', 'custom']);
+export type DefaultDateRange = z.infer<typeof DefaultDateRange>;
+
+export const HeatmapXAxis = z.enum(['status', 'priority', 'tag']);
+export type HeatmapXAxis = z.infer<typeof HeatmapXAxis>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// GlobalTabs order — Admin 행에서만 의미 있음. systemId + visible 페어.
+// ──────────────────────────────────────────────────────────────────────────
+export const GlobalTabEntry = z.object({
+  systemId: Uuid,
+  visible: z.boolean(),
+});
+export type GlobalTabEntry = z.infer<typeof GlobalTabEntry>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// DashboardSettings — GET / PUT response & body shape.
+// `locked_widgets` 는 Admin tier (`user_id IS NULL`) SSOT — migration 022.
+// ──────────────────────────────────────────────────────────────────────────
+export const DashboardSettings = z.object({
+  widget_order: z.array(WidgetId),
+  widget_visibility: WidgetVisibility,
+  widget_sizes: WidgetSizesV2,
+  locked_widgets: z.array(WidgetId),
+  default_date_range: DefaultDateRange,
+  heatmap_default_x_axis: HeatmapXAxis,
+  globaltabs_order: z.array(GlobalTabEntry).nullable(),
+});
+export type DashboardSettings = z.infer<typeof DashboardSettings>;
+
+// PUT body: 부분 업데이트 허용 (zod partial). 서버는 row 머지 후 PUT 의미론
+// 으로 전체 저장. 빈 키는 서버 기존값 유지.
+export const DashboardSettingsPutBody = DashboardSettings.partial();
+export type DashboardSettingsPutBody = z.infer<typeof DashboardSettingsPutBody>;
+
+export const DashboardSettingsResponse = DashboardSettings;
+export type DashboardSettingsResponse = DashboardSettings;

--- a/shared/fixtures/dashboard.fixtures.ts
+++ b/shared/fixtures/dashboard.fixtures.ts
@@ -1,0 +1,60 @@
+/**
+ * Dashboard fixtures stub — Wave 2 W2-3 / PR-γ.
+ *
+ * Spec: docs/specs/requires/dashboard.md §커스터마이즈 v2.
+ * Plan: docs/specs/plans/wave-2-dashboard.md §6.2 W2-3.
+ *
+ * Phase A 범위: settings GET / PUT 의 default + Admin 시드 fixture 만.
+ * 위젯별 데이터 fixture (KPI / 분포 / 매트릭스 / 히트맵 등) → Phase B/C 별 PR.
+ *
+ * Parity: scripts/check-fixture-seed-parity.ts 가 BE seed (`backend/seeds/`)
+ * 와 본 파일 형상을 비교 — Phase A 시드 시점에 동기화.
+ */
+import type {
+  DashboardSettings,
+  WidgetId,
+  WidgetSizesV2,
+} from '../contracts/dashboard';
+
+// 11 위젯 stable ID 목록 — defaultLayouts 와 fixture 양쪽 SSOT.
+export const WIDGET_IDS: readonly WidgetId[] = [
+  'kpi',
+  'distribution',
+  'priority-status-matrix',
+  'heatmap',
+  'weekly-trend',
+  'tag-bar',
+  'system-card',
+  'assignee-table',
+  'aging-top10',
+  'sla',
+  'aging',
+] as const;
+
+// Default lg breakpoint layout — Phase D / W2-5 에서 frontend defaultLayouts.ts
+// 가 정본화. 본 stub 은 fixture/seed parity 만을 위한 최소 형상.
+export const DEFAULT_WIDGET_SIZES_LG: WidgetSizesV2 = {
+  kpi: { lg: { x: 0, y: 0, w: 12, h: 2 } },
+  distribution: { lg: { x: 0, y: 2, w: 6, h: 4 } },
+  'priority-status-matrix': { lg: { x: 6, y: 2, w: 6, h: 4 } },
+  heatmap: { lg: { x: 0, y: 6, w: 12, h: 6 } },
+  'weekly-trend': { lg: { x: 0, y: 12, w: 6, h: 4 } },
+  'tag-bar': { lg: { x: 6, y: 12, w: 6, h: 4 } },
+  'system-card': { lg: { x: 0, y: 16, w: 12, h: 3 } },
+  'assignee-table': { lg: { x: 0, y: 19, w: 12, h: 4 } },
+  'aging-top10': { lg: { x: 0, y: 23, w: 12, h: 4 } },
+  sla: { lg: { x: 0, y: 27, w: 6, h: 3 } },
+  aging: { lg: { x: 6, y: 27, w: 6, h: 3 } },
+};
+
+// Default settings shape — Admin 행 (user_id IS NULL) 시드와 일치.
+// `default_date_range: '1m'` 은 dashboard.md preamble + migration 011 정합.
+export const DEFAULT_DASHBOARD_SETTINGS: DashboardSettings = {
+  widget_order: [...WIDGET_IDS],
+  widget_visibility: Object.fromEntries(WIDGET_IDS.map((id) => [id, { visible: true }])),
+  widget_sizes: DEFAULT_WIDGET_SIZES_LG,
+  locked_widgets: [],
+  default_date_range: '1m',
+  heatmap_default_x_axis: 'status',
+  globaltabs_order: null,
+};

--- a/shared/openapi.yaml
+++ b/shared/openapi.yaml
@@ -3227,9 +3227,114 @@ components:
         avg_resolution_days:
           type: number
 
+    WidgetId:
+      type: string
+      enum:
+        - kpi
+        - distribution
+        - priority-status-matrix
+        - heatmap
+        - weekly-trend
+        - tag-bar
+        - system-card
+        - assignee-table
+        - aging-top10
+        - sla
+        - aging
+      description: 대시보드 위젯 stable ID. dashboard.md §위젯 상세 명세 §1~§11.
+
+    WidgetLayout:
+      type: object
+      required: [x, y, w, h]
+      additionalProperties: false
+      description: |
+        RGL 12-col 그리드 좌표. bounds: x>=0, x+w<=12, w>=1, h>=1, 모두 정수.
+      properties:
+        x:
+          type: integer
+          minimum: 0
+          maximum: 11
+        y:
+          type: integer
+          minimum: 0
+        w:
+          type: integer
+          minimum: 1
+          maximum: 12
+        h:
+          type: integer
+          minimum: 1
+        static:
+          type: boolean
+
+    WidgetSizesV2:
+      type: object
+      description: |
+        breakpoint-keyed widget layout map (Wave 2 W2-D2). xs 는 RGL 자동
+        1-col stack — 직렬화 X. md/sm 미지정 시 lg fallback.
+      additionalProperties:
+        type: object
+        required: [lg]
+        properties:
+          lg:
+            $ref: '#/components/schemas/WidgetLayout'
+          md:
+            $ref: '#/components/schemas/WidgetLayout'
+          sm:
+            $ref: '#/components/schemas/WidgetLayout'
+
     DashboardSettings:
       type: object
-      additionalProperties: true
+      required:
+        - widget_order
+        - widget_visibility
+        - widget_sizes
+        - locked_widgets
+        - default_date_range
+        - heatmap_default_x_axis
+      properties:
+        widget_order:
+          type: array
+          items:
+            $ref: '#/components/schemas/WidgetId'
+        widget_visibility:
+          type: object
+          additionalProperties:
+            type: object
+            required: [visible]
+            properties:
+              visible:
+                type: boolean
+              locked:
+                type: boolean
+        widget_sizes:
+          $ref: '#/components/schemas/WidgetSizesV2'
+        locked_widgets:
+          type: array
+          description: |
+            Admin tier widget lock list. Admin 행 (`user_id IS NULL`) 에서만
+            의미 — 머지 규칙: `static = adminLocked || personalLocked`.
+            Migration 022 + Wave 2 W2-D3.
+          items:
+            $ref: '#/components/schemas/WidgetId'
+        default_date_range:
+          type: string
+          enum: ['1m', '3m', '1y', 'all', 'custom']
+        heatmap_default_x_axis:
+          type: string
+          enum: ['status', 'priority', 'tag']
+        globaltabs_order:
+          type: array
+          nullable: true
+          items:
+            type: object
+            required: [systemId, visible]
+            properties:
+              systemId:
+                type: string
+                format: uuid
+              visible:
+                type: boolean
 
     DistributionItem:
       type: object


### PR DESCRIPTION
## Summary

Wave 2 Phase A 의 contract 정본 PR. codex:rescue 적대적 리뷰 (2026-05-10) 의 verb mismatch + zod bounds + 위젯 카운트 11 종 모두 반영.

## Changes

### shared/contracts/dashboard/

- **WidgetId**: 11 종 enum (\`kpi\` / \`distribution\` / \`priority-status-matrix\` / \`heatmap\` / \`weekly-trend\` / \`tag-bar\` / \`system-card\` / \`assignee-table\` / \`aging-top10\` / \`sla\` / \`aging\`).
- **WidgetLayout**: \`x>=0, x+w<=12, w>=1, h>=1\` 정수 bounds — codex §2 zod gotcha.
- **WidgetSizesV2**: breakpoint-keyed (lg 필수 + md/sm 선택). zod v4 \`z.record(EnumKey)\` 한계 우회 — \`z.string()\` 키 + refinement 으로 partial map 표현.
- **DashboardSettings**: 전체 row + \`locked_widgets\` (마이그 022 SSOT).
- **DashboardSettingsPutBody**: partial 업데이트 (PUT 의미론, codex §1 verb parity).

### shared/fixtures/dashboard.fixtures.ts

- \`WIDGET_IDS\` / \`DEFAULT_WIDGET_SIZES_LG\` / \`DEFAULT_DASHBOARD_SETTINGS\` stub.
- \`default_date_range: '1m'\` (\`dashboard.md\` preamble + migration 011 정합).
- 위젯별 데이터 fixture (KPI / 분포 등) → Phase B/C 별 PR.

### shared/openapi.yaml

- \`DashboardSettings\` 스키마 explicit 화 (기존 \`additionalProperties: true\` 폐기).
- \`WidgetId\` / \`WidgetLayout\` / \`WidgetSizesV2\` 신규 컴포넌트.
- \`/dashboard/settings PUT\` 명세 유지 — codex §1 verb parity 정합 확인 (PATCH 폐기).

### backend/src/__tests__/dashboard-contract.test.ts

27 회귀:
- WidgetId 11 종 + 미지정 거부
- Layout bounds 6 (\`x+w>12\` / 음수 / non-integer / w<1 / static flag / 정상)
- SizesV2 3 (lg-only / lg+md+sm / 위반 거부)
- enum 2
- 전체 row 1
- Put body 3 (단일 필드 / 빈 body / unknown widget id)

## Plan / Spec

- Plan: \`docs/specs/plans/wave-2-dashboard.md\` §3 W2-D7, §6.2 W2-3 — PR #291 동시 진행 중.
- Spec: \`docs/specs/requires/dashboard.md\` §커스터마이즈 v2 §widget_sizes v2 직렬화.
- Migration: PR #293 (W2-2) 가 \`locked_widgets\` 컬럼 신설 — 본 contract 와 동시 머지 권장.

## 검증

- BE typecheck 0 / FE typecheck 0
- BE 489/489 그린 (462 → 489)
- FE 575/575 그린

## Test plan

- [ ] \`shared/contracts/dashboard/io.ts\` zod 27 회귀 통과
- [ ] \`shared/openapi.yaml\` lint 통과 (있다면)
- [ ] PR #293 (마이그 022) 와 동시 머지 시 contract / DB 형상 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)