### PR TITLE
docs: Wave 2 Phase D close — progress + next-session-tasks sync

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,6 +1,26 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점 (2026-05-10 P2 후속 batch 머지 완료 — Wave 2 또는 운영/배포 phase)
+## 다음 세션 시작점 (2026-05-10 Wave 2 Phase D 머지 완료 — Phase B/C/E 진입)
+
+→ **Wave 2 Phase D RGL Shell 머지 완료** (PR #295, 2026-05-10):
+   - **BE**: `routes/dashboard-settings.ts` + `services/dashboard/settings.service.ts` + `repository/dashboard.repo.ts` 신규. `GET/PUT /api/dashboard/settings` (auth required, per-field merge admin∘user). 권한: `scope=admin` + `locked_fields` + `globaltabs_order` 모두 admin-only (3종 별 403 코드).
+   - **FE**: `features/dashboard/*` (defaultLayouts × 8 widget × 5 breakpoint, lockMerge 순수 함수, useDashboardDraft state machine + saveCounter race guard, useDashboardSettings + useUpdateDashboardSettings TanStack hooks, DashboardShell ResponsiveRGL, WidgetPlaceholder, EditModeToggle), `pages/DashboardPage` + lazy 라우트 (StubPage 교체), `dashboard-rgl.css` + 토큰 3종 (`--dashboard-grid-margin/RowH/HandleSize`).
+   - **Contract**: `shared/contracts/dashboard/{entity,io}` (zod) + `shared/openapi.yaml` `DashboardSettings` 정형 schema + `RglLayoutItem.strict()` + `RglLayouts` 모든 breakpoint optional. `DashboardSettingsUpdate.strict()`.
+   - **Migration 022**: `dashboard_admin_default_unique.sql` — Postgres NULL UNIQUE 맹점 차단 (partial unique index `WHERE user_id IS NULL`).
+   - **codex:rescue 적대적 리뷰**: P0 1건 + P1 5건 + P2 2건 모두 close.
+   - **메트릭**: BE 462 → 487 (+25) 그린, FE 575 → 587 (+12) 그린, typecheck 0, lint 0.
+
+→ **다음 세션 작업**: Wave 2 잔여 phase 진입 후보:
+   - **Phase B (KPI Volume + Quality)** — `/dashboard/summary` BE + KPI 위젯 콘텐츠 FE.
+   - **Phase C (분포 / 매트릭스 / 히트맵 / 트렌드 / SLA / 담당자 / Top10)** — 위젯별 BE 엔드포인트 + 콘텐츠.
+   - **Phase E (설정 패널)** — widget toggle + default_date_range + heatmap_x_axis editor.
+   - **운영/배포 phase** — `connect-pg-simple` / OIDC / production Dockerfile / Playwright E2E.
+
+→ **마이그 번호** — 다음 마이그 번호 = **023**.
+
+---
+
+## 이전 세션 시작점 (2026-05-10 P2 후속 batch 머지 완료 — Wave 2 또는 운영/배포 phase)
 
 → **P2 후속 3건 머지 완료** (2026-05-10):
    - **FU-023** (PR #287): `createTag` slug 파생을 `<name>-<kind>` 로 변경 — FU-014 (name, kind) UNIQUE 와 정합. `('공통','general')` / `('공통','menu')` 둘 다 distinct slug. admin-tags.sql.test.ts `it.todo` → 실 테스트.

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -1,7 +1,7 @@
 # vocpage — 다음 세션 태스크 계획
 
-> 최종 업데이트: 2026-05-10 (P2 후속 3건 머지 완료 — Wave 2 또는 운영/배포 phase)
-> 현재 위치: **P2 후속 close (PR #287/#288/#289 머지) · 다음 = Wave 2 (Dashboard) 권장**
+> 최종 업데이트: 2026-05-10 (Wave 2 Phase D 머지 완료 — Phase B/C/E 진입)
+> 현재 위치: **Wave 2 Phase D RGL Shell close (PR #295) · 다음 = Phase B (KPI 콘텐츠) 권장**
 > 진행 포인터: `claude-progress.txt` 첫 30줄 → 본 문서 → 활성 plan
 > **2026-05-09 정책**: 구현 정본 = `requirements.md` + `uidesign.md` 만. prototype 참조 종료.
 
@@ -21,7 +21,7 @@
 | **P2 BE batch** | (별 plan 없음 — bucket FU-007/010/015/018)                                                                                                                              | ✅ **4건 전부 머지** (2026-05-10). FU-018 (PR #279, 권한 매트릭스 단일 파일 115 case) · FU-015 (PR #280, admin DB-backed 통합 13 pass + restore 트랜잭션 end-to-end) · FU-010 (PR #281, 마이그 021 user_role_log CHECK + NOT VALID backfill safety) · FU-007 (PR #282, doc-only timestamptz 정책 + inclusive-end + mismatch 명시). 신규 spawn: FU-021/022 (P1) · FU-023/024/025 (P2). |
 | **P1 후속**     | (별 plan 없음 — bucket FU-021/022)                                                                                                                                       | ✅ **2건 머지** (2026-05-10). FU-021 (PR #284, §8.3 spec 해석 확정 — read access 4 role ALLOW · matrix +10 case · service 코드 변경 0) · FU-022 (PR #285, adminTrash/adminUsers router-level guard → per-route guard · 회귀 9 case · API contract 변경 0). BE 456/461 그린. |
 | **P2 후속**     | (별 plan 없음 — bucket FU-023/024/025)                                                                                                                                   | ✅ **3건 머지** (2026-05-10). FU-023 (PR #287, createTag slug `<name>-<kind>` · admin-tags.sql.test.ts todo → 실 테스트) · FU-024 (PR #289, @testcontainers/postgresql 도입 + admin-sql-tc.test.ts 5 cell · skip 4 → 0) · FU-025 (PR #288, NoticeFormDialog KST 자정 직렬화 · 회귀 5 case). BE 462/462 그린, FE 575/575 그린. |
-| **2 (Dashboard)** | [`wave-2-dashboard.md`](./wave-2-dashboard.md) (Phase D 진행중)                                                                                                       | ⏳ **Phase D RGL Shell 진행중** (`feat/wave-2-phase-d-rgl-shell`, 2026-05-10) — settings BE (route+service+repo) + DashboardShell FE + 8 widget placeholder + EditModeToggle + lockMerge + useDashboardDraft. TDD 4종 (lockMerge / useDashboardDraft / DashboardShell xs / dashboard-settings 권한). 위젯 콘텐츠/설정 패널 별도 phase. |
+| **2 (Dashboard)** | [`wave-2-dashboard.md`](./wave-2-dashboard.md) (Phase D 완료, B/C/E 후속)                                                                                              | ✅ **Phase D RGL Shell 머지 완료** (PR #295, 2026-05-10) — settings BE + DashboardShell FE + 8 widget placeholder + EditModeToggle + lockMerge + useDashboardDraft + 마이그 022 (NULL UNIQUE 차단). codex:rescue P0/P1/P2 모두 close. BE 487 / FE 587 그린. 다음 = Phase B (KPI). |
 
 ### Hard-blocks
 
@@ -29,7 +29,7 @@
 
 ### 진행 순서
 
-~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → **Wave 2 (Dashboard)** → 운영/배포 phase.
+~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → ~~Wave 2 Phase D RGL Shell (PR #295)~~ → **Wave 2 Phase B (KPI 콘텐츠)** → Phase C → Phase E → 운영/배포 phase.
 
 ---
 


### PR DESCRIPTION
## Summary

PR #295 (Wave 2 Phase D RGL Shell) 머지 후속 docs 동기화. 다음 세션 시작점 + 활성 plan 표 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)