### PR TITLE
feat(wave-2 phase-b): KPI Volume + Quality widgets FE

### DIFF
--- a/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -1,12 +1,15 @@
 /**
- * DashboardShell.test.tsx — Wave 2 Phase D TDD
- * Tests for the DashboardShell RGL wrapper.
+ * DashboardShell.test.tsx — Wave 2 Phase D + B TDD.
+ * Tests for the DashboardShell RGL wrapper. Phase B wires KpiVolumeWidget
+ * and KpiQualityWidget for the `kpi-volume` / `kpi-quality` slots; the
+ * remaining 6 slots stay as placeholders.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { defaultLayouts } from '../defaultLayouts';
-import { WIDGET_IDS } from '../defaultLayouts';
+import { defaultLayouts, WIDGET_IDS } from '../defaultLayouts';
+import { DashboardFilterProvider } from '../model/dashboardFilter';
 
 // Mock react-grid-layout/legacy to match production import path
 vi.mock('react-grid-layout/legacy', () => {
@@ -25,54 +28,57 @@ vi.mock('react-grid-layout/legacy', () => {
 // Mock CSS imports
 vi.mock('react-grid-layout/css/styles.css', () => ({}));
 
+// Phase B widgets call /api/dashboard/summary — mock the hook so the shell
+// can mount without an MSW server in this unit-level test.
+vi.mock('../model/useDashboardSummary', () => ({
+  useDashboardSummary: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }),
+}));
+
 import { DashboardShell } from '../ui/DashboardShell';
 
-describe('DashboardShell', () => {
-  it('renders all 8 WidgetPlaceholder components', () => {
-    render(
-      <DashboardShell
-        layouts={defaultLayouts}
-        isEditing={false}
-        onLayoutChange={vi.fn()}
-      />,
-    );
+function renderShell(props: { isEditing: boolean }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DashboardFilterProvider initial={{ range: '1m' }}>
+        <DashboardShell
+          layouts={defaultLayouts}
+          isEditing={props.isEditing}
+          onLayoutChange={vi.fn()}
+        />
+      </DashboardFilterProvider>
+    </QueryClientProvider>,
+  );
+}
 
-    // All 8 widget IDs should render
+describe('DashboardShell', () => {
+  it('renders all 8 widgets — KPI slots use real widgets, others are placeholders', () => {
+    renderShell({ isEditing: false });
+    expect(screen.getByTestId('widget-kpi-volume')).toBeDefined();
+    expect(screen.getByTestId('widget-kpi-quality')).toBeDefined();
     for (const widgetId of WIDGET_IDS) {
+      if (widgetId === 'kpi-volume' || widgetId === 'kpi-quality') continue;
       expect(screen.getByTestId(`widget-placeholder-${widgetId}`)).toBeDefined();
     }
   });
 
-  it('passes isDraggable=false and isResizable=false when isEditing=false', () => {
-    const { container } = render(
-      <DashboardShell
-        layouts={defaultLayouts}
-        isEditing={false}
-        onLayoutChange={vi.fn()}
-      />,
-    );
-
-    // Drag handles should not be visible when not editing
-    const handles = container.querySelectorAll('.dashboard-widget-handle');
-    // handles exist in DOM but are hidden when not editing
-    handles.forEach((h) => {
-      expect(h.classList.contains('opacity-0')).toBe(true);
-    });
-  });
-
-  it('shows drag handles when isEditing=true', () => {
-    const { container } = render(
-      <DashboardShell
-        layouts={defaultLayouts}
-        isEditing={true}
-        onLayoutChange={vi.fn()}
-      />,
-    );
-
+  it('edit mode falls back to placeholders for KPI slots so drag handles are present', () => {
+    const { container } = renderShell({ isEditing: true });
+    expect(screen.queryByTestId('widget-kpi-volume')).toBeNull();
+    expect(screen.getByTestId('widget-placeholder-kpi-volume')).toBeDefined();
     const handles = container.querySelectorAll('.dashboard-widget-handle');
     expect(handles.length).toBe(8);
     handles.forEach((h) => {
       expect(h.classList.contains('opacity-0')).toBe(false);
+    });
+  });
+
+  it('drag handles are hidden when isEditing=false', () => {
+    const { container } = renderShell({ isEditing: false });
+    // Only the 6 placeholder slots have handles in display mode (kpi widgets don't).
+    const handles = container.querySelectorAll('.dashboard-widget-handle');
+    handles.forEach((h) => {
+      expect(h.classList.contains('opacity-0')).toBe(true);
     });
   });
 });

--- a/frontend/src/features/dashboard/__tests__/KpiWidgets.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/KpiWidgets.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * KpiVolumeWidget + KpiQualityWidget — Wave 2 Phase B TDD.
+ * Covers loading, success, error, and accent border behavior.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { DashboardFilterProvider } from '../model/dashboardFilter';
+import * as summaryHook from '../model/useDashboardSummary';
+import { KpiVolumeWidget } from '../widgets/KpiVolumeWidget';
+import { KpiQualityWidget } from '../widgets/KpiQualityWidget';
+import { KpiCard } from '../widgets/KpiCard';
+
+vi.mock('../model/useDashboardSummary', () => ({
+  useDashboardSummary: vi.fn(),
+}));
+const mockSummary = vi.mocked(summaryHook).useDashboardSummary;
+
+const ZERO_DATA = {
+  kpi_volume: {
+    total_voc: { value: 12, delta: 50, delta_kind: 'percent' as const },
+    unresolved: { value: 5, delta: -1, delta_kind: 'percent' as const },
+    this_week_new: { value: 3, delta: null, delta_kind: 'percent' as const },
+    this_week_completed: { value: 2, delta: 0, delta_kind: 'percent' as const },
+  },
+  kpi_quality: {
+    avg_resolution_days: { value: 4.2, delta: -0.8, delta_kind: 'days' as const },
+    resolution_rate: { value: 71.5, delta: 4.0, delta_kind: 'percentage_point' as const },
+    urgent_high_unresolved: { value: 7, delta: 3, delta_kind: 'count' as const },
+    overdue_14d: { value: 2, delta: 0, delta_kind: 'count' as const },
+  },
+};
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('KpiVolumeWidget', () => {
+  it('renders 4 skeletons during loading', () => {
+    mockSummary.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+      refetch: vi.fn(),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    wrap(<KpiVolumeWidget />);
+    expect(screen.getByTestId('kpi-volume-loading').children).toHaveLength(4);
+  });
+
+  it('renders 4 KPI cards on success', () => {
+    mockSummary.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: ZERO_DATA,
+      refetch: vi.fn(),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    wrap(<KpiVolumeWidget />);
+    expect(screen.getByTestId('kpi-card-총 VOC')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-card-미해결')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-card-이번주 신규')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-card-이번주 완료')).toBeInTheDocument();
+    // delta sign / formatting
+    expect(screen.getByTestId('kpi-delta-총 VOC').textContent).toMatch(/\+50/);
+    expect(screen.getByTestId('kpi-delta-미해결').textContent).toMatch(/−1/);
+  });
+
+  it('renders error state with retry that calls refetch', () => {
+    const refetch = vi.fn();
+    mockSummary.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+      refetch,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    wrap(<KpiVolumeWidget />);
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+    expect(refetch).toHaveBeenCalled();
+  });
+});
+
+describe('KpiQualityWidget', () => {
+  it('shows urgent + overdue accent labels and applies inverted color to 평균 처리시간', () => {
+    mockSummary.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: ZERO_DATA,
+      refetch: vi.fn(),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    wrap(<KpiQualityWidget />);
+    expect(screen.getByTestId('kpi-card-Urgent·High 미해결')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-card-14일+ 미처리')).toBeInTheDocument();
+    // avg processing time decreased (-0.8 days) → with inverted=true, treated as positive (emerald).
+    const avgDelta = screen.getByTestId('kpi-delta-평균 처리시간');
+    expect(avgDelta.className).toMatch(/--chart-emerald/);
+  });
+});
+
+describe('KpiCard formatting', () => {
+  it('formats `count` deltas with thousand separator', () => {
+    render(
+      <KpiCard
+        label="X"
+        metric={{ value: 1234, delta: 1500, delta_kind: 'count' }}
+      />,
+    );
+    expect(screen.getByTestId('kpi-card-X').textContent).toMatch(/1,234/);
+    expect(screen.getByTestId('kpi-delta-X').textContent).toMatch(/1,500/);
+  });
+
+  it('null delta renders no delta text', () => {
+    render(
+      <KpiCard label="Y" metric={{ value: 0, delta: null, delta_kind: 'percent' }} />,
+    );
+    expect(screen.queryByTestId('kpi-delta-Y')).toBeNull();
+  });
+
+  it('urgent accent applies red border when value > 0', () => {
+    render(
+      <KpiCard
+        label="Z"
+        metric={{ value: 5, delta: 0, delta_kind: 'count' }}
+        accent="urgent"
+      />,
+    );
+    expect(screen.getByTestId('kpi-card-Z').className).toMatch(/--chart-red/);
+  });
+
+  it('urgent accent does NOT apply red border when value is 0', () => {
+    render(
+      <KpiCard
+        label="W"
+        metric={{ value: 0, delta: 0, delta_kind: 'count' }}
+        accent="urgent"
+      />,
+    );
+    expect(screen.getByTestId('kpi-card-W').className).not.toMatch(/--chart-red/);
+  });
+});

--- a/frontend/src/features/dashboard/__tests__/KpiWidgets.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/KpiWidgets.test.tsx
@@ -12,7 +12,8 @@ import { KpiVolumeWidget } from '../widgets/KpiVolumeWidget';
 import { KpiQualityWidget } from '../widgets/KpiQualityWidget';
 import { KpiCard } from '../widgets/KpiCard';
 
-vi.mock('../model/useDashboardSummary', () => ({
+vi.mock('../model/useDashboardSummary', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useDashboardSummary')>()),
   useDashboardSummary: vi.fn(),
 }));
 const mockSummary = vi.mocked(summaryHook).useDashboardSummary;
@@ -124,25 +125,36 @@ describe('KpiCard formatting', () => {
     expect(screen.queryByTestId('kpi-delta-Y')).toBeNull();
   });
 
-  it('urgent accent applies red border when value > 0', () => {
+  it('urgent accent applies red border only when delta is increasing (spec §1)', () => {
     render(
       <KpiCard
         label="Z"
-        metric={{ value: 5, delta: 0, delta_kind: 'count' }}
+        metric={{ value: 5, delta: 2, delta_kind: 'count' }}
         accent="urgent"
       />,
     );
     expect(screen.getByTestId('kpi-card-Z').className).toMatch(/--chart-red/);
   });
 
-  it('urgent accent does NOT apply red border when value is 0', () => {
+  it('urgent accent does NOT apply when delta=0 even if value is high', () => {
     render(
       <KpiCard
         label="W"
-        metric={{ value: 0, delta: 0, delta_kind: 'count' }}
+        metric={{ value: 5, delta: 0, delta_kind: 'count' }}
         accent="urgent"
       />,
     );
     expect(screen.getByTestId('kpi-card-W').className).not.toMatch(/--chart-red/);
+  });
+
+  it('urgent accent does NOT apply when delta is negative', () => {
+    render(
+      <KpiCard
+        label="V"
+        metric={{ value: 5, delta: -1, delta_kind: 'count' }}
+        accent="urgent"
+      />,
+    );
+    expect(screen.getByTestId('kpi-card-V').className).not.toMatch(/--chart-red/);
   });
 });

--- a/frontend/src/features/dashboard/__tests__/useDashboardSummary.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/useDashboardSummary.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * useDashboardSummary — Wave 2 Phase B TDD.
+ * Verifies the hook reads filter from context, calls /api/dashboard/summary,
+ * and that filter changes invalidate the cache (queryKey dependency).
+ */
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { DashboardFilterProvider, useDashboardFilter } from '../model/dashboardFilter';
+import { useDashboardSummary } from '../model/useDashboardSummary';
+
+const ZERO_METRIC = { value: 0, delta: null, delta_kind: 'percent' as const };
+const ZERO_SUMMARY = {
+  kpi_volume: {
+    total_voc: ZERO_METRIC,
+    unresolved: ZERO_METRIC,
+    this_week_new: ZERO_METRIC,
+    this_week_completed: ZERO_METRIC,
+  },
+  kpi_quality: {
+    avg_resolution_days: { value: 0, delta: null, delta_kind: 'days' as const },
+    resolution_rate: { value: 0, delta: null, delta_kind: 'percentage_point' as const },
+    urgent_high_unresolved: { value: 0, delta: null, delta_kind: 'count' as const },
+    overdue_14d: { value: 0, delta: null, delta_kind: 'count' as const },
+  },
+};
+
+let lastUrl = '';
+const server = setupServer(
+  http.get('/api/dashboard/summary', ({ request }) => {
+    lastUrl = request.url;
+    return HttpResponse.json(ZERO_SUMMARY);
+  }),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  lastUrl = '';
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <DashboardFilterProvider initial={{ range: '1m' }}>{children}</DashboardFilterProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('useDashboardSummary', () => {
+  it('queries /api/dashboard/summary with the active filter as query string', async () => {
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => useDashboardSummary(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastUrl).toContain('range=1m');
+    expect(result.current.data?.kpi_volume.total_voc.value).toBe(0);
+  });
+
+  it('filter change triggers a new request (cache key includes filter)', async () => {
+    const Harness = () => {
+      const { patch } = useDashboardFilter();
+      const summary = useDashboardSummary();
+      return { summary, patch };
+    };
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => Harness(), { wrapper });
+    await waitFor(() => expect(result.current.summary.isSuccess).toBe(true));
+    expect(lastUrl).toContain('range=1m');
+    expect(lastUrl).not.toContain('range=3m');
+
+    await act(async () => {
+      result.current.patch({ range: '3m' });
+    });
+    await waitFor(() => expect(lastUrl).toContain('range=3m'));
+  });
+
+  it('forwards systemId / menuId / assigneeId verbatim', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider
+          initial={{
+            systemId: '11111111-1111-4111-8111-111111111111',
+            menuId: '22222222-2222-4222-8222-222222222222',
+            assigneeId: '33333333-3333-4333-8333-333333333333',
+            range: '3m',
+          }}
+        >
+          {children}
+        </DashboardFilterProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDashboardSummary(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastUrl).toContain('systemId=11111111-1111-4111-8111-111111111111');
+    expect(lastUrl).toContain('menuId=22222222-2222-4222-8222-222222222222');
+    expect(lastUrl).toContain('assigneeId=33333333-3333-4333-8333-333333333333');
+    expect(lastUrl).toContain('range=3m');
+  });
+});
+
+describe('useDashboardFilter — error', () => {
+  it('throws when used outside provider', () => {
+    const qc = new QueryClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    // suppress expected error console
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useDashboardFilter(), { wrapper })).toThrow(
+      /DashboardFilterProvider/,
+    );
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/features/dashboard/api/keys.ts
+++ b/frontend/src/features/dashboard/api/keys.ts
@@ -1,4 +1,7 @@
+import type { DashboardFilter } from '@contracts/dashboard';
+
 export const dashboardQueryKeys = {
   all: ['dashboard'] as const,
   settings: () => ['dashboard', 'settings'] as const,
+  summary: (filter: DashboardFilter) => ['dashboard', 'summary', filter] as const,
 } as const;

--- a/frontend/src/features/dashboard/api/queries.ts
+++ b/frontend/src/features/dashboard/api/queries.ts
@@ -1,12 +1,14 @@
 /**
- * Dashboard settings API functions.
- * Spec: shared/openapi.yaml#/paths/~1dashboard~1settings
+ * Dashboard API functions.
+ * Spec: shared/openapi.yaml#/paths/~1dashboard~1settings + ~1dashboard~1summary
  */
 import { apiGet, apiPut } from '@shared/api/client';
 import {
   DashboardSettings,
   DashboardSettingsUpdate,
   DashboardSettingsResponse,
+  DashboardSummary,
+  type DashboardFilter,
 } from '@contracts/dashboard';
 
 export const dashboardApi = {
@@ -16,5 +18,17 @@ export const dashboardApi = {
 
   updateSettings(payload: DashboardSettingsUpdate): Promise<DashboardSettings> {
     return apiPut('/api/dashboard/settings', payload, DashboardSettingsResponse);
+  },
+
+  getSummary(filter: DashboardFilter): Promise<DashboardSummary> {
+    const qs = new URLSearchParams();
+    if (filter.systemId) qs.set('systemId', filter.systemId);
+    if (filter.menuId) qs.set('menuId', filter.menuId);
+    if (filter.assigneeId) qs.set('assigneeId', filter.assigneeId);
+    if (filter.range) qs.set('range', filter.range);
+    if (filter.startDate) qs.set('startDate', filter.startDate);
+    if (filter.endDate) qs.set('endDate', filter.endDate);
+    const suffix = qs.toString() ? `?${qs.toString()}` : '';
+    return apiGet(`/api/dashboard/summary${suffix}`, DashboardSummary);
   },
 };

--- a/frontend/src/features/dashboard/index.ts
+++ b/frontend/src/features/dashboard/index.ts
@@ -6,3 +6,8 @@ export { useDashboardSettings } from './model/useDashboardSettings';
 export { useUpdateDashboardSettings } from './model/useUpdateDashboardSettings';
 export { defaultLayouts, WIDGET_IDS, RGL_BREAKPOINTS, RGL_COLS } from './defaultLayouts';
 export { mergeLockedLayout } from './lockMerge';
+export { DashboardFilterProvider, useDashboardFilter } from './model/dashboardFilter';
+export { useDashboardSummary } from './model/useDashboardSummary';
+export { KpiVolumeWidget } from './widgets/KpiVolumeWidget';
+export { KpiQualityWidget } from './widgets/KpiQualityWidget';
+export { KpiCard } from './widgets/KpiCard';

--- a/frontend/src/features/dashboard/model/dashboardFilter.tsx
+++ b/frontend/src/features/dashboard/model/dashboardFilter.tsx
@@ -1,0 +1,51 @@
+/**
+ * Dashboard filter context — Wave 2 Phase B (dashboard.md §글로벌 필터).
+ *
+ * Holds the mutable filter that drives every widget query: system / menu /
+ * assignee + date-range preset (custom uses startDate/endDate). Wrap the
+ * dashboard tree in `<DashboardFilterProvider>`; consume via
+ * `useDashboardFilter()`.
+ *
+ * Filter changes invalidate the summary query through TanStack Query's key
+ * dependency (the filter object is part of the queryKey).
+ */
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+import type { DashboardFilter } from '@contracts/dashboard';
+
+interface DashboardFilterContextValue {
+  filter: DashboardFilter;
+  setFilter: (next: DashboardFilter) => void;
+  patch: (delta: Partial<DashboardFilter>) => void;
+  reset: () => void;
+}
+
+const DashboardFilterContext = createContext<DashboardFilterContextValue | null>(null);
+
+export interface DashboardFilterProviderProps {
+  initial?: DashboardFilter;
+  children: ReactNode;
+}
+
+export function DashboardFilterProvider({ initial, children }: DashboardFilterProviderProps) {
+  const [filter, setFilter] = useState<DashboardFilter>(initial ?? {});
+  const value = useMemo<DashboardFilterContextValue>(
+    () => ({
+      filter,
+      setFilter,
+      patch: (delta) => setFilter((prev) => ({ ...prev, ...delta })),
+      reset: () => setFilter(initial ?? {}),
+    }),
+    [filter, initial],
+  );
+  return (
+    <DashboardFilterContext.Provider value={value}>{children}</DashboardFilterContext.Provider>
+  );
+}
+
+export function useDashboardFilter(): DashboardFilterContextValue {
+  const ctx = useContext(DashboardFilterContext);
+  if (!ctx) {
+    throw new Error('useDashboardFilter must be used within <DashboardFilterProvider>');
+  }
+  return ctx;
+}

--- a/frontend/src/features/dashboard/model/useDashboardSummary.ts
+++ b/frontend/src/features/dashboard/model/useDashboardSummary.ts
@@ -1,0 +1,19 @@
+/**
+ * useDashboardSummary — Wave 2 Phase B.
+ * Reads the active filter from `DashboardFilterProvider` and queries
+ * `/api/dashboard/summary`. The filter object is part of the queryKey so
+ * any patch invalidates the cache automatically.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useDashboardSummary() {
+  const { filter } = useDashboardFilter();
+  return useQuery({
+    queryKey: dashboardQueryKeys.summary(filter),
+    queryFn: () => dashboardApi.getSummary(filter),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/features/dashboard/ui/DashboardShell.tsx
+++ b/frontend/src/features/dashboard/ui/DashboardShell.tsx
@@ -6,6 +6,18 @@ import { Responsive, WidthProvider, type Layout, type LayoutItem } from 'react-g
 import type { RglLayouts } from '@contracts/dashboard';
 import { WIDGET_IDS, RGL_BREAKPOINTS, RGL_COLS } from '../defaultLayouts';
 import { WidgetPlaceholder } from './WidgetPlaceholder';
+import { KpiVolumeWidget } from '../widgets/KpiVolumeWidget';
+import { KpiQualityWidget } from '../widgets/KpiQualityWidget';
+
+function renderWidget(widgetId: string, isEditing: boolean) {
+  // Wave 2 Phase B — KPI widgets are wired. Other widgets remain placeholders
+  // until their phases (C / E). Edit mode keeps the drag handle visible by
+  // falling back to the placeholder, so resize gestures hit a stable target.
+  if (isEditing) return <WidgetPlaceholder widgetId={widgetId} isEditing={isEditing} />;
+  if (widgetId === 'kpi-volume') return <KpiVolumeWidget />;
+  if (widgetId === 'kpi-quality') return <KpiQualityWidget />;
+  return <WidgetPlaceholder widgetId={widgetId} isEditing={isEditing} />;
+}
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -33,9 +45,7 @@ export function DashboardShell({ layouts, isEditing, onLayoutChange }: Dashboard
         useCSSTransforms
       >
         {WIDGET_IDS.map((widgetId) => (
-          <div key={widgetId}>
-            <WidgetPlaceholder widgetId={widgetId} isEditing={isEditing} />
-          </div>
+          <div key={widgetId}>{renderWidget(widgetId, isEditing)}</div>
         ))}
       </ResponsiveGridLayout>
     </div>

--- a/frontend/src/features/dashboard/widgets/KpiCard.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiCard.tsx
@@ -71,13 +71,15 @@ export function KpiCard({
   const positive = inverted ? direction < 0 : direction > 0;
   const negative = inverted ? direction > 0 : direction < 0;
 
-  // Spec §1 강조 보더 — urgent uses chart-red @ 35% alpha, overdue uses
-  // chart-amber @ 30%. color-mix keeps the value derived from a token so
-  // the no-raw-color lint stays satisfied.
+  // Spec §1 강조 보더 — only on *increase* vs prior period (dashboard.md §1
+  // "증가 시 red 강조 보더" / "증가 시 amber 강조 보더"). Use chart-red @ 35%
+  // alpha (urgent) or chart-amber @ 30% (overdue); color-mix keeps the
+  // value derived from tokens so the no-raw-color lint stays satisfied.
+  const accentIncreased = metric.delta !== null && metric.delta > 0;
   const accentBorder =
-    accent === 'urgent' && metric.value > 0
+    accent === 'urgent' && accentIncreased
       ? 'border-[color-mix(in_oklch,var(--chart-red)_35%,transparent)]'
-      : accent === 'overdue' && metric.value > 0
+      : accent === 'overdue' && accentIncreased
       ? 'border-[color-mix(in_oklch,var(--chart-amber)_30%,transparent)]'
       : 'border-[var(--border-subtle)]';
 

--- a/frontend/src/features/dashboard/widgets/KpiCard.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiCard.tsx
@@ -1,0 +1,122 @@
+/**
+ * KpiCard — Wave 2 Phase B (dashboard.md §1 KPI 카드).
+ *
+ * Single-metric card. The parent widget arranges 4 cards in a row and
+ * supplies the section label (VOLUME / QUALITY).
+ *
+ * delta semantics:
+ * - delta_kind=percent / count / days / percentage_point — UI formats accordingly.
+ * - For `avg_resolution_days`, decrease is positive ("처리시간 ↓ = 좋음") so
+ *   the parent passes `inverted=true` to flip the color treatment.
+ * - `accent` adds the §1 강조 보더 (urgent/high → red, overdue → amber) when
+ *   the metric is non-zero. Border tone is taken from the spec verbatim.
+ */
+import { cn } from '@shared/lib/cn';
+import type { KpiMetric } from '@contracts/dashboard';
+
+export type KpiAccent = 'none' | 'urgent' | 'overdue';
+
+export interface KpiCardProps {
+  label: string;
+  metric: KpiMetric;
+  /** Format applied to the value before rendering. Falls back per delta_kind. */
+  formatValue?: (value: number) => string;
+  /** Treat decrease as positive (used by 평균 처리시간). */
+  inverted?: boolean;
+  /** Spec-defined emphasis border. */
+  accent?: KpiAccent;
+  /** Sublabel shown beneath the value, e.g. "N일차" for week-fixed cards. */
+  subLabel?: string;
+  /** Optional click target — typically navigates to `/voc?...`. */
+  onActivate?: () => void;
+}
+
+const DEFAULT_FORMATTERS: Record<KpiMetric['delta_kind'], (n: number) => string> = {
+  percent: (n) => `${n.toFixed(0)}`,
+  count: (n) => n.toLocaleString('ko-KR'),
+  days: (n) => `${n.toFixed(1)}일`,
+  percentage_point: (n) => `${n.toFixed(1)}%`,
+};
+
+function formatDelta(metric: KpiMetric): string | null {
+  if (metric.delta === null) return null;
+  const d = metric.delta;
+  const sign = d > 0 ? '+' : d < 0 ? '−' : '';
+  const abs = Math.abs(d);
+  switch (metric.delta_kind) {
+    case 'percent':
+      return `${sign}${abs.toFixed(1)}%`;
+    case 'percentage_point':
+      return `${sign}${abs.toFixed(1)}%p`;
+    case 'days':
+      return `${sign}${abs.toFixed(1)}일`;
+    case 'count':
+      return `${sign}${abs.toLocaleString('ko-KR')}`;
+  }
+}
+
+export function KpiCard({
+  label,
+  metric,
+  formatValue,
+  inverted = false,
+  accent = 'none',
+  subLabel,
+  onActivate,
+}: KpiCardProps) {
+  const valueText = (formatValue ?? DEFAULT_FORMATTERS[metric.delta_kind])(metric.value);
+  const deltaText = formatDelta(metric);
+  // Direction colors: positive movement = chart-emerald (or red when inverted).
+  const direction = metric.delta === null ? 0 : metric.delta > 0 ? 1 : metric.delta < 0 ? -1 : 0;
+  const positive = inverted ? direction < 0 : direction > 0;
+  const negative = inverted ? direction > 0 : direction < 0;
+
+  // Spec §1 강조 보더 — urgent uses chart-red @ 35% alpha, overdue uses
+  // chart-amber @ 30%. color-mix keeps the value derived from a token so
+  // the no-raw-color lint stays satisfied.
+  const accentBorder =
+    accent === 'urgent' && metric.value > 0
+      ? 'border-[color-mix(in_oklch,var(--chart-red)_35%,transparent)]'
+      : accent === 'overdue' && metric.value > 0
+      ? 'border-[color-mix(in_oklch,var(--chart-amber)_30%,transparent)]'
+      : 'border-[var(--border-subtle)]';
+
+  const Tag = onActivate ? 'button' : 'div';
+  return (
+    <Tag
+      type={onActivate ? 'button' : undefined}
+      onClick={onActivate}
+      data-testid={`kpi-card-${label}`}
+      className={cn(
+        'flex h-full flex-col items-start justify-between gap-1 rounded-md border bg-[var(--bg-surface)] p-4 text-left',
+        accentBorder,
+        onActivate && 'transition-colors hover:bg-[var(--bg-elevated)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]',
+      )}
+    >
+      <span className="text-xs font-medium text-[var(--text-tertiary)]">{label}</span>
+      <span className="font-pretendard text-2xl font-semibold tabular-nums text-[var(--text-primary)]">
+        {valueText}
+      </span>
+      <div className="flex w-full items-center justify-between text-xs">
+        {subLabel ? (
+          <span className="text-[var(--text-quaternary)]">{subLabel}</span>
+        ) : (
+          <span />
+        )}
+        {deltaText !== null && (
+          <span
+            data-testid={`kpi-delta-${label}`}
+            className={cn(
+              'tabular-nums',
+              positive && 'text-[var(--chart-emerald)]',
+              negative && 'text-[var(--chart-red)]',
+              !positive && !negative && 'text-[var(--text-quaternary)]',
+            )}
+          >
+            {deltaText}
+          </span>
+        )}
+      </div>
+    </Tag>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/KpiQualityWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiQualityWidget.tsx
@@ -16,6 +16,7 @@ export function KpiQualityWidget() {
   return (
     <div
       data-testid="widget-kpi-quality"
+      aria-busy={isLoading}
       className="flex h-full flex-col gap-3 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
     >
       <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
@@ -23,7 +24,12 @@ export function KpiQualityWidget() {
       </div>
 
       {isLoading && (
-        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4" data-testid="kpi-quality-loading">
+        <div
+          role="status"
+          aria-live="polite"
+          className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4"
+          data-testid="kpi-quality-loading"
+        >
           {Array.from({ length: 4 }, (_, i) => (
             <Skeleton key={i} className="h-24" />
           ))}

--- a/frontend/src/features/dashboard/widgets/KpiQualityWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiQualityWidget.tsx
@@ -1,0 +1,64 @@
+/**
+ * KpiQualityWidget — Wave 2 Phase B (dashboard.md §1 QUALITY 줄).
+ * 4 cards: 평균 처리시간 / 해결율 / Urgent·High 미해결 / 14일+ 미처리.
+ *
+ * - 평균 처리시간: 감소가 긍정 → KpiCard inverted=true.
+ * - Urgent·High 미해결: 비-제로일 때 §1 red 강조 보더.
+ * - 14일+ 미처리: 비-제로일 때 §1 amber 강조 보더.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import { useDashboardSummary } from '../model/useDashboardSummary';
+import { KpiCard } from './KpiCard';
+
+export function KpiQualityWidget() {
+  const { data, isLoading, isError, refetch } = useDashboardSummary();
+
+  return (
+    <div
+      data-testid="widget-kpi-quality"
+      className="flex h-full flex-col gap-3 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+        QUALITY
+      </div>
+
+      {isLoading && (
+        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4" data-testid="kpi-quality-loading">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>KPI 데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && (
+        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4">
+          <KpiCard
+            label="평균 처리시간"
+            metric={data.kpi_quality.avg_resolution_days}
+            inverted
+          />
+          <KpiCard label="해결율" metric={data.kpi_quality.resolution_rate} />
+          <KpiCard
+            label="Urgent·High 미해결"
+            metric={data.kpi_quality.urgent_high_unresolved}
+            accent="urgent"
+          />
+          <KpiCard label="14일+ 미처리" metric={data.kpi_quality.overdue_14d} accent="overdue" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/KpiVolumeWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiVolumeWidget.tsx
@@ -12,6 +12,7 @@ export function KpiVolumeWidget() {
   return (
     <div
       data-testid="widget-kpi-volume"
+      aria-busy={isLoading}
       className="flex h-full flex-col gap-3 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
     >
       <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
@@ -19,7 +20,12 @@ export function KpiVolumeWidget() {
       </div>
 
       {isLoading && (
-        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4" data-testid="kpi-volume-loading">
+        <div
+          role="status"
+          aria-live="polite"
+          className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4"
+          data-testid="kpi-volume-loading"
+        >
           {Array.from({ length: 4 }, (_, i) => (
             <Skeleton key={i} className="h-24" />
           ))}

--- a/frontend/src/features/dashboard/widgets/KpiVolumeWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/KpiVolumeWidget.tsx
@@ -1,0 +1,52 @@
+/**
+ * KpiVolumeWidget — Wave 2 Phase B (dashboard.md §1 VOLUME 줄).
+ * 4 cards: 총 VOC / 미해결 / 이번주 신규 / 이번주 완료.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import { useDashboardSummary } from '../model/useDashboardSummary';
+import { KpiCard } from './KpiCard';
+
+export function KpiVolumeWidget() {
+  const { data, isLoading, isError, refetch } = useDashboardSummary();
+
+  return (
+    <div
+      data-testid="widget-kpi-volume"
+      className="flex h-full flex-col gap-3 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+        VOLUME
+      </div>
+
+      {isLoading && (
+        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4" data-testid="kpi-volume-loading">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>KPI 데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && (
+        <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-4">
+          <KpiCard label="총 VOC" metric={data.kpi_volume.total_voc} />
+          <KpiCard label="미해결" metric={data.kpi_volume.unresolved} />
+          <KpiCard label="이번주 신규" metric={data.kpi_volume.this_week_new} />
+          <KpiCard label="이번주 완료" metric={data.kpi_volume.this_week_completed} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,7 +4,12 @@
  */
 import '../styles/dashboard-rgl.css';
 import { PageLayout, PageHeader } from '@widgets/app-shell';
-import { DashboardShell, EditModeToggle, useDashboardDraft } from '@features/dashboard';
+import {
+  DashboardShell,
+  EditModeToggle,
+  useDashboardDraft,
+  DashboardFilterProvider,
+} from '@features/dashboard';
 
 export default function DashboardPage() {
   const { layouts, isEditing, isDirty, isSaving, setIsEditing, onLayoutChange, save, discard } =
@@ -28,11 +33,13 @@ export default function DashboardPage() {
         />
       }
     >
-      <DashboardShell
-        layouts={layouts}
-        isEditing={isEditing}
-        onLayoutChange={onLayoutChange}
-      />
+      <DashboardFilterProvider>
+        <DashboardShell
+          layouts={layouts}
+          isEditing={isEditing}
+          onLayoutChange={onLayoutChange}
+        />
+      </DashboardFilterProvider>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Wires `/api/dashboard/summary` (PR #297) into the dashboard shell.
- New filter context (`DashboardFilterProvider` + `useDashboardFilter`) + TanStack Query hook (`useDashboardSummary`) — queryKey embeds the filter so patches auto-invalidate.
- 8 KPI cards (Volume + Quality) with delta_kind-aware formatting, inverted color for 평균 처리시간, and spec §1 강조 보더 (urgent / overdue) via `color-mix` to stay token-pure.
- DashboardShell swaps `kpi-volume` / `kpi-quality` slots for real widgets outside edit mode; remaining 6 slots stay as placeholders until Phase C / E.

## Test plan
- [x] FE typecheck 0
- [x] FE lint + token lint 0
- [x] FE tests 587 → 599 (+12) green — KpiWidgets ×8, useDashboardSummary ×4, DashboardShell rewritten ×3
- [ ] codex:rescue adversarial review
- [ ] Manual smoke `/dashboard` displays KPI cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)