### PR TITLE
docs: Wave 2 Phase B close — claude-progress + next-session-tasks sync

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,6 +1,25 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점 (2026-05-10 Wave 2 Phase D 머지 완료 — Phase B/C/E 진입)
+## 다음 세션 시작점 (2026-05-10 Wave 2 Phase B 머지 완료 — 사용자 피드백 대기 → Phase C/E)
+
+→ **Wave 2 Phase B KPI Volume + Quality 머지 완료** (PR #297 BE + PR #298 FE, 2026-05-10):
+   - **BE (PR #297)**: `GET /api/dashboard/summary` (8 KPI = Volume × 4 + Quality × 4). `dashboard-metrics.repo.ts` (5 SQL: countCreatedAndCompleted / snapshotUnresolved / snapshotUrgentHighUnresolved / snapshotOverdue14d / avgResolutionDaysInWindow) + `services/dashboard/summary.service.ts` (KST midnight helpers, `default_date_range` fallback user → admin → '1m', custom-range validation, 전주 동기간/동시점 delta 산출) + `routes/dashboard-summary.ts` (auth + `requireRole('dev','manager','admin')` — User 403). `index.ts` 마운트.
+   - **Contract (PR #297)**: `shared/contracts/dashboard/summary.ts` (zod) — `KpiMetric { value, delta, delta_kind }` (delta_kind enum: percent/count/days/percentage_point) + `DashboardSummary` + `DashboardFilter` (.strict). `shared/openapi.yaml` `DashboardSummary` 스텁 정형화 + `dashboardRange` parameter 신설 (1m/3m/1y/all/custom).
+   - **FE (PR #298)**: `features/dashboard/model/dashboardFilter.tsx` (`DashboardFilterProvider` + `useDashboardFilter`) · `model/useDashboardSummary.ts` (TanStack, queryKey embeds filter → 자동 invalidation, staleTime 30s) · `widgets/KpiCard.tsx` (delta_kind 별 포맷 + inverted 평균처리시간 + accent 보더 delta-driven `color-mix(in oklch, var(--chart-red) 35%, transparent)`) · `widgets/KpiVolumeWidget.tsx` + `KpiQualityWidget.tsx` (loading skeleton + error retry + aria-busy/role=status) · `DashboardShell` `kpi-volume`/`kpi-quality` 슬롯 실제 위젯 교체 (편집 모드는 placeholder fallback) · `DashboardPage` `<DashboardFilterProvider>` wrap.
+   - **codex:rescue 적대적 리뷰 (BE)**: P1 2건 + P2 1건 close. P1-1 = `snapshotUnresolved` as-of 정합 (status_changed_at > at OR NOT_DONE) — 그 시점엔 미해결이었지만 후에 완료된 VOC 누락 차단. P1-2 = 스냅샷 KPI는 KST 자정이 아닌 exact `now` 인스턴트 기준. P2 = `resolution_rate` 분모를 period-end snapshot 으로 정합 (numerator/denominator window-consistent).
+   - **codex:rescue 적대적 리뷰 (FE)**: P1 1건 + P2 2건 close. P1 = accent 보더는 `value > 0` 이 아닌 `delta > 0` (spec §1 "증가 시 강조"). P2-1 = `aria-busy` + `role="status"` + `aria-live="polite"` loading 영역 a11y. P2-2 = `vi.mock(factory, importOriginal spread)` 로 향후 re-export 보존.
+   - **메트릭**: BE 487 → 518 (+31), FE 587 → 599 (+12). typecheck 0 / lint 0 / 토큰 lint 0.
+
+→ **다음 세션 작업**: 사용자 피드백 수집 후 Wave 2 잔여 phase 진입:
+   - **Phase C (분포 / 매트릭스 / 히트맵 / 트렌드 / SLA / 담당자 / Top10)** — 7 endpoint BE 단일 PR + 7 위젯 FE PR.
+   - **Phase E (설정 패널)** — `DashboardSettingsDialog` (widget toggle + default_date_range + heatmap x-axis + admin lock).
+   - **운영/배포 phase** — `connect-pg-simple` / OIDC / production Dockerfile / Playwright E2E.
+
+→ **마이그 번호** — 다음 마이그 번호 = **023** (Phase B 마이그 추가 없음).
+
+---
+
+## 이전 세션 시작점 (2026-05-10 Wave 2 Phase D 머지 완료 — Phase B/C/E 진입)
 
 → **Wave 2 Phase D RGL Shell 머지 완료** (PR #295, 2026-05-10):
    - **BE**: `routes/dashboard-settings.ts` + `services/dashboard/settings.service.ts` + `repository/dashboard.repo.ts` 신규. `GET/PUT /api/dashboard/settings` (auth required, per-field merge admin∘user). 권한: `scope=admin` + `locked_fields` + `globaltabs_order` 모두 admin-only (3종 별 403 코드).

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -1,7 +1,7 @@
 # vocpage — 다음 세션 태스크 계획
 
-> 최종 업데이트: 2026-05-10 (Wave 2 Phase D 머지 완료 — Phase B/C/E 진입)
-> 현재 위치: **Wave 2 Phase D RGL Shell close (PR #295) · 다음 = Phase B (KPI 콘텐츠) 권장**
+> 최종 업데이트: 2026-05-10 (Wave 2 Phase B 머지 완료 — 사용자 피드백 대기 → Phase C/E)
+> 현재 위치: **Wave 2 Phase B KPI Volume+Quality close (PR #297 BE + PR #298 FE) · 다음 = 사용자 피드백 → Phase C 권장**
 > 진행 포인터: `claude-progress.txt` 첫 30줄 → 본 문서 → 활성 plan
 > **2026-05-09 정책**: 구현 정본 = `requirements.md` + `uidesign.md` 만. prototype 참조 종료.
 
@@ -21,7 +21,7 @@
 | **P2 BE batch** | (별 plan 없음 — bucket FU-007/010/015/018)                                                                                                                              | ✅ **4건 전부 머지** (2026-05-10). FU-018 (PR #279, 권한 매트릭스 단일 파일 115 case) · FU-015 (PR #280, admin DB-backed 통합 13 pass + restore 트랜잭션 end-to-end) · FU-010 (PR #281, 마이그 021 user_role_log CHECK + NOT VALID backfill safety) · FU-007 (PR #282, doc-only timestamptz 정책 + inclusive-end + mismatch 명시). 신규 spawn: FU-021/022 (P1) · FU-023/024/025 (P2). |
 | **P1 후속**     | (별 plan 없음 — bucket FU-021/022)                                                                                                                                       | ✅ **2건 머지** (2026-05-10). FU-021 (PR #284, §8.3 spec 해석 확정 — read access 4 role ALLOW · matrix +10 case · service 코드 변경 0) · FU-022 (PR #285, adminTrash/adminUsers router-level guard → per-route guard · 회귀 9 case · API contract 변경 0). BE 456/461 그린. |
 | **P2 후속**     | (별 plan 없음 — bucket FU-023/024/025)                                                                                                                                   | ✅ **3건 머지** (2026-05-10). FU-023 (PR #287, createTag slug `<name>-<kind>` · admin-tags.sql.test.ts todo → 실 테스트) · FU-024 (PR #289, @testcontainers/postgresql 도입 + admin-sql-tc.test.ts 5 cell · skip 4 → 0) · FU-025 (PR #288, NoticeFormDialog KST 자정 직렬화 · 회귀 5 case). BE 462/462 그린, FE 575/575 그린. |
-| **2 (Dashboard)** | [`wave-2-dashboard.md`](./wave-2-dashboard.md) (Phase D 완료, B/C/E 후속)                                                                                              | ✅ **Phase D RGL Shell 머지 완료** (PR #295, 2026-05-10) — settings BE + DashboardShell FE + 8 widget placeholder + EditModeToggle + lockMerge + useDashboardDraft + 마이그 022 (NULL UNIQUE 차단). codex:rescue P0/P1/P2 모두 close. BE 487 / FE 587 그린. 다음 = Phase B (KPI). |
+| **2 (Dashboard)** | [`wave-2-dashboard.md`](./wave-2-dashboard.md) (Phase B/D 완료, C/E 후속)                                                                                              | ✅ **Phase D RGL Shell 머지 완료** (PR #295, 2026-05-10). ✅ **Phase B KPI Volume+Quality 머지 완료** (PR #297 BE + PR #298 FE, 2026-05-10) — `/api/dashboard/summary` 8 KPI · `dashboard-metrics.repo` 5 SQL + `summary.service` (KST/range/default_date_range/delta) · `KpiCard` + `Kpi{Volume,Quality}Widget` (delta_kind 포맷, inverted 평균처리시간, color-mix accent) · `DashboardFilterProvider` + `useDashboardSummary` (queryKey embeds filter). codex:rescue BE P1×2+P2×1 / FE P1×1+P2×2 close. BE 518 / FE 599 그린. 다음 = Phase C (분포/매트릭스/히트맵/트렌드/SLA/담당자/Top10). |
 
 ### Hard-blocks
 
@@ -29,7 +29,7 @@
 
 ### 진행 순서
 
-~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → ~~Wave 2 Phase D RGL Shell (PR #295)~~ → **Wave 2 Phase B (KPI 콘텐츠)** → Phase C → Phase E → 운영/배포 phase.
+~~FSD Migration~~ → ~~`/voc 완성` PR #242~~ → ~~Wave 4 PR #245~~ → ~~Wave 3 Phase A (4 PR + hotfix)~~ → ~~Wave 3 Phase B+C (PR #262/#263)~~ → ~~Phase D+E 병렬 (PR #269/#270)~~ → ~~Phase F 종합 검증 (PR #271)~~ → ~~FU P1 batch close (PR #273)~~ → ~~Wave 5 plan 작성~~ → ~~Wave 5 Phase A (notifications + comments BE, PR #276)~~ → ~~Wave 5 Phase B PR-2 (PR #278)~~ → ~~P2 BE batch (FU-007/010/015/018, PR #279/#280/#281/#282)~~ → ~~FU-021 / FU-022 P1 batch (PR #284/#285)~~ → ~~FU-023/024/025 P2 후속 (PR #287/#288/#289)~~ → ~~Wave 2 Phase D RGL Shell (PR #295)~~ → ~~Wave 2 Phase B KPI (PR #297 BE / PR #298 FE)~~ → **사용자 피드백 수집** → Wave 2 Phase C (분포/매트릭스/히트맵/트렌드/SLA/담당자/Top10) → Phase E (설정 패널) → 운영/배포 phase.
 
 ---
 


### PR DESCRIPTION
## Summary
- Sync progress docs after Wave 2 Phase B merges (PR #297 BE + PR #298 FE).
- New "다음 세션 시작점" entry summarizes Phase B scope, codex review outcomes (BE P1×2+P2×1 / FE P1×1+P2×2 close), and updated metrics (BE 487 → 518, FE 587 → 599).
- `next-session-tasks.md` table reflects Phase B done; pointer = user feedback → Phase C.

## Test plan
- [x] Docs only — no code change