### PR TITLE
chore(harness): week 5 supplemental diet — uninstall OMC + slim user hooks

### DIFF
--- a/.claude/hookify.warn-no-verify.local.md
+++ b/.claude/hookify.warn-no-verify.local.md
@@ -1,0 +1,15 @@
+---
+name: warn-no-verify
+enabled: true
+event: bash
+pattern: git\s+(commit|push|merge|rebase)\s+.*(--no-verify|--no-gpg-sign)
+action: warn
+---
+
+⚠️ **`--no-verify` / `--no-gpg-sign` blocked unless user explicitly asked for it.**
+
+Per CLAUDE.md (root) and system rules:
+
+- Never skip pre-commit hooks. If a hook fails, fix the underlying issue.
+- Never bypass commit signing.
+- Only proceed if the user has explicitly authorized this in the current turn.

--- a/.claude/specs/harness-diet.md
+++ b/.claude/specs/harness-diet.md
@@ -27,8 +27,10 @@
 
 4. **Plugin pruning** — `claude-md-management` disabled in
    `.claude/settings.local.json` (0 invocations in last 30 days).
-   Kept: `oh-my-claudecode`, `impeccable`, `playwright`, `codex`
-   (all show real use). `superpowers` already false locally.
+   Kept: `impeccable`, `playwright`, `codex` (all show real use).
+   `superpowers` already false locally. `oh-my-claudecode` (OMC) was
+   kept here originally but fully uninstalled on 2026-05-10 — see
+   `## Week 5 supplemental diet (2026-05-10)`.
 
 5. **opt-prompt skill family frozen** — see `Sunset clauses` below.
 
@@ -73,6 +75,42 @@ threshold, roll back the corresponding change.
    Threshold: ≥ 3 events/day means model is fighting the hooks; reverse.
    Zero events means the hooks are no longer earning their cost; relax
    the trigger or remove.
+
+## Week 5 supplemental diet (2026-05-10)
+
+Trigger: noticeable per-prompt freezes during Wave 2 Phase B work. Audit
+showed OMC magic-word path was never used in practice while still firing
+~1k+ lines of JS per prompt and per Stop. Branch: `docs/claude-harness-diet`.
+
+Changes:
+
+1. **OMC fully uninstalled** — `npm uninstall -g oh-my-claude-sisyphus` plus
+   removal of `~/.omc/`, `~/.claude/.omc*`, `~/.claude/plugins/oh-my-claudecode/`,
+   and 8 OMC hook files (`keyword-detector.mjs`, `session-start.mjs`,
+   `post-tool-use.mjs`, `post-tool-use-failure.mjs`, `persistent-mode.mjs`,
+   `code-simplifier.mjs`, `pre-tool-use.mjs`, `find-node.sh`) plus the
+   `hooks/lib/` shared modules. GSD (`gsd-*`) is a separate plugin and
+   stays — used in other repos.
+2. **`~/.claude/settings.json` slimmed** — UserPromptSubmit, PostCompact,
+   PostToolUseFailure blocks removed (all OMC-driven); Stop block emptied
+   (was OMC `persistent-mode` + `code-simplifier`); SessionStart trimmed
+   to two GSD entries. 232 → 158 lines.
+3. **`~/.claude/read-once/`** — disabled (project-side
+   `block-reread`/`block-read-after-edit` already cover the same role
+   per spec). Still on disk in case re-enable is needed.
+4. **`vocpage/.claude/settings.local.json`** — SessionStart printf for
+   Serena `initial_instructions` removed (project-side `serena-hooks
+   activate` already handles activation).
+5. **CLAUDE.md surface** — `AGENTS.md` deleted (one-line redirect to
+   `CLAUDE.md`; Codex now reads `CLAUDE.md` directly via project rule).
+   `prototype/CLAUDE.md` opening duplicate (the "not a reference 2026-05-09~"
+   line, already in root §1) removed.
+6. **`hookify.warn-no-verify.local.md`** added — was previously text-only
+   in root §3 / system prompt; now hookify catches `--no-verify` /
+   `--no-gpg-sign` on `git commit|push|merge|rebase`.
+
+Anti-pattern note (below) still applies: this is the second one-shot
+diet, not a recurring loop. Next diet only when metrics regress.
 
 ## Anti-pattern: "do not optimize the harness while building the product"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,0 @@
-# AGENTS.md
-
-정본은 [`CLAUDE.md`](./CLAUDE.md). Codex / 기타 AI agent 도 그 파일을 따른다.

--- a/prototype/CLAUDE.md
+++ b/prototype/CLAUDE.md
@@ -1,8 +1,8 @@
 # prototype/CLAUDE.md
 
-Static HTML visual sandbox — dashboard mockups, widget experiments, layout studies. Read root `CLAUDE.md` first.
+Static HTML visual sandbox — dashboard mockups, widget experiments, layout studies. Read root `CLAUDE.md` first (note: `prototype/` is no longer an implementation reference per root §1).
 
-**Not a reference (2026-05-09~):** `prototype/` is no longer a visual / behavior reference. No pixel / DOM / CSS citation. Implementation references are `requirements.md` + `uidesign.md` only. Active reviews → `docs/specs/reviews/`; archived → `docs/specs/archive/reviews/`. Token / typography / grid rules live in `uidesign.md` — not duplicated here.
+Active reviews → `docs/specs/reviews/`; archived → `docs/specs/archive/reviews/`.
 
 **Throwaway scope:**
 


### PR DESCRIPTION
## Summary

- Uninstall `oh-my-claude-sisyphus` (OMC) — never used the magic-word path (`ralph`/`autopilot`/`ultrawork` etc) but it fired ~1k+ lines of JS per prompt and per Stop, causing per-prompt freezes.
- Slim `~/.claude/settings.json` (232 → 158 lines) and `vocpage/.claude/settings.local.json` to drop OMC + Serena reminder duplicates already covered by other layers.
- Reconcile `harness-diet.md` Week 1 baseline (kept OMC) with this Week 5 supplemental.

## Scope

- **OMC removed**: npm package, `~/.omc`, `~/.claude/.omc*`, `~/.claude/plugins/oh-my-claudecode/`, 8 OMC hook files + `hooks/lib/`. GSD (`gsd-*`) is a separate plugin and stays.
- **`~/.claude/settings.json`**: drop UserPromptSubmit / PostCompact / PostToolUseFailure blocks; empty Stop; trim SessionStart to GSD entries; Read PreToolUse drops `read-once/hook.sh` (project-side `block-reread` already covers).
- **`vocpage/.claude/settings.local.json`**: drop SessionStart Serena printf (project-side `serena-hooks activate` already covers).
- **`vocpage/.claude/hookify.warn-no-verify.local.md`**: new — was previously text-only in root §3.
- **`AGENTS.md`**: delete (was a 1-line redirect to `CLAUDE.md`; Codex reads `CLAUDE.md` directly per project rule).
- **`prototype/CLAUDE.md`**: drop the duplicate "not a reference 2026-05-09~" sentence (already in root §1).
- **`harness-diet.md`**: log Week 5 supplemental section, fix the line that listed `oh-my-claudecode` as "kept (real use)".

## Hook firing per ToolUse (before → after)

| Event | before | after |
|---|---|---|
| UserPromptSubmit | 1 (1073 lines JS) | 0 |
| SessionStart | 5 | 3 |
| PreToolUse Read | 6 | 4 |
| PostToolUse | 5 | 3 |
| Stop | 3 | 1 |

## Test plan

- [x] No source code changes — typecheck / test not applicable.
- [x] `which omc` → not found (post-uninstall).
- [x] `~/.claude/hooks/` contains only GSD + dormant generic helpers.
- [x] `git push` pre-push hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)