### PR TITLE
fix(sidebar): wire missing admin nav items (사용자 / 외부 마스터)

### DIFF
--- a/frontend/src/widgets/app-shell/Sidebar.tsx
+++ b/frontend/src/widgets/app-shell/Sidebar.tsx
@@ -9,6 +9,8 @@ import {
   Code2,
   ChevronDown,
   Trash2,
+  Users,
+  Database,
 } from 'lucide-react';
 import { cn } from '@shared/lib/cn';
 import { useRole } from '@entities/user/model/useRole';
@@ -45,6 +47,8 @@ const NAV_ITEMS: NavItem[] = [
  */
 const ADMIN_NAV_ITEMS: NavItem[] = [
   { to: '/admin/tags', label: '태그 마스터', icon: Tag, adminGroup: true },
+  { to: '/admin/masters', label: '외부 마스터', icon: Database, adminGroup: true },
+  { to: '/admin/users', label: '사용자', icon: Users, adminStrict: true },
   { to: '/admin/vocs/trash', label: '휴지통', icon: Trash2, adminStrict: true },
 ];
 


### PR DESCRIPTION
## Summary
- `/admin/masters` (외부 마스터, admin/manager/dev) + `/admin/users` (사용자, admin only) 가 라우터·페이지·API·MSW·테스트는 W3-6 / W3-7 Phase E 에서 모두 머지됐는데 `Sidebar.tsx` `ADMIN_NAV_ITEMS` 등록만 누락되어 있어 admin 사용자가 메뉴를 통해 접근할 수 없었음 — 등록 추가
- 순서: 마스터 데이터 (tags → masters) → admin-only ops (users → trash)

## Test plan
- [x] `npm run typecheck -w frontend` (0 errors)
- [x] `npm run test -w frontend -- --run` (80 files / 603 pass)
- [ ] 사용자 시각 확인: admin 역할로 사이드바에 4개 메뉴 (태그 마스터 / 외부 마스터 / 사용자 / 휴지통) 노출, manager/dev 역할로 2개 (태그 마스터 / 외부 마스터) 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)