### PR TITLE
fix(backend): align local PORT default with vite proxy (3001)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,7 +37,7 @@ if (isProduction && !process.env.SESSION_SECRET) {
 }
 
 const app = express();
-const PORT = process.env.PORT ?? 3000;
+const PORT = process.env.PORT ?? 3001;
 
 app.use(pinoHttp({ logger }));
 app.use(cors({ origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173' }));


### PR DESCRIPTION
## Summary
- Backend default port 3000 → 3001 to match frontend vite proxy target.
- Docker compose still sets `PORT=3000` explicitly inside the container; host port mapping `3001:3000` is unchanged.

## Why
`frontend/vite.config.ts` proxies `/api → http://localhost:3001`. Without docker, `npm run dev -w backend` listened on 3000 → SPA dev fetches 502'd. The fix shifts only the bare `tsx` default; docker behavior is preserved.

## Test plan
- [x] `npm run typecheck -w backend` clean
- [ ] Local: `npm run dev -w backend` → bind to :3001, FE `/api/health` reaches BE
- [ ] Docker: `docker compose up backend` → container :3000, host :3001 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)