### PR TITLE
feat(dashboard): wave 2 phase C FE — 7 widgets

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^18.3.1",
     "react-grid-layout": "^2.2.3",
     "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.4.1"

--- a/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import { defaultLayouts, WIDGET_IDS } from '../defaultLayouts';
 import { DashboardFilterProvider } from '../model/dashboardFilter';
@@ -46,15 +47,17 @@ import { DashboardShell } from '../ui/DashboardShell';
 function renderShell(props: { isEditing: boolean }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <DashboardFilterProvider initial={{ range: '1m' }}>
-        <DashboardShell
-          layouts={defaultLayouts}
-          isEditing={props.isEditing}
-          onLayoutChange={vi.fn()}
-        />
-      </DashboardFilterProvider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider initial={{ range: '1m' }}>
+          <DashboardShell
+            layouts={defaultLayouts}
+            isEditing={props.isEditing}
+            onLayoutChange={vi.fn()}
+          />
+        </DashboardFilterProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -63,8 +66,10 @@ describe('DashboardShell', () => {
     renderShell({ isEditing: false });
     expect(screen.getByTestId('widget-kpi-volume')).toBeDefined();
     expect(screen.getByTestId('widget-kpi-quality')).toBeDefined();
-    // Phase C widgets are now wired — check a few testids
+    // Phase C widgets are now wired — dist-matrix slot stacks Distribution + Matrix
     expect(screen.getByTestId('widget-distribution')).toBeDefined();
+    expect(screen.getByTestId('widget-priority-status-matrix')).toBeDefined();
+    expect(screen.getByTestId('slot-dist-matrix')).toBeDefined();
     expect(screen.getByTestId('widget-heatmap')).toBeDefined();
     expect(screen.getByTestId('widget-weekly-trend')).toBeDefined();
     expect(screen.getByTestId('widget-processing-speed')).toBeDefined();

--- a/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -1,8 +1,7 @@
 /**
- * DashboardShell.test.tsx — Wave 2 Phase D + B TDD.
- * Tests for the DashboardShell RGL wrapper. Phase B wires KpiVolumeWidget
- * and KpiQualityWidget for the `kpi-volume` / `kpi-quality` slots; the
- * remaining 6 slots stay as placeholders.
+ * DashboardShell.test.tsx — Wave 2 Phase D + B + C TDD.
+ * Tests for the DashboardShell RGL wrapper. Phase B wires KPI widgets;
+ * Phase C wires the remaining 6 content slots.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -28,11 +27,19 @@ vi.mock('react-grid-layout/legacy', () => {
 // Mock CSS imports
 vi.mock('react-grid-layout/css/styles.css', () => ({}));
 
-// Phase B widgets call /api/dashboard/summary — mock the hook so the shell
-// can mount without an MSW server in this unit-level test.
+// Mock Phase B hook
 vi.mock('../model/useDashboardSummary', () => ({
   useDashboardSummary: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }),
 }));
+
+// Mock Phase C hooks so widgets mount without MSW
+vi.mock('../model/useDistribution', () => ({ useDistribution: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }) }));
+vi.mock('../model/usePriorityStatusMatrix', () => ({ usePriorityStatusMatrix: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }) }));
+vi.mock('../model/useHeatmap', () => ({ useHeatmap: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() }) }));
+vi.mock('../model/useWeeklyTrend', () => ({ useWeeklyTrend: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }) }));
+vi.mock('../model/useProcessingSpeed', () => ({ useProcessingSpeed: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), dim: 'all', setDim: vi.fn() }) }));
+vi.mock('../model/useAssigneeStats', () => ({ useAssigneeStats: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() }) }));
+vi.mock('../model/useAgingVocs', () => ({ useAgingVocs: () => ({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() }) }));
 
 import { DashboardShell } from '../ui/DashboardShell';
 
@@ -52,13 +59,20 @@ function renderShell(props: { isEditing: boolean }) {
 }
 
 describe('DashboardShell', () => {
-  it('renders all 8 widgets — KPI slots use real widgets, others are placeholders', () => {
+  it('renders all 8 widget slots — Phase B+C slots use real widgets', () => {
     renderShell({ isEditing: false });
     expect(screen.getByTestId('widget-kpi-volume')).toBeDefined();
     expect(screen.getByTestId('widget-kpi-quality')).toBeDefined();
+    // Phase C widgets are now wired — check a few testids
+    expect(screen.getByTestId('widget-distribution')).toBeDefined();
+    expect(screen.getByTestId('widget-heatmap')).toBeDefined();
+    expect(screen.getByTestId('widget-weekly-trend')).toBeDefined();
+    expect(screen.getByTestId('widget-processing-speed')).toBeDefined();
+    expect(screen.getByTestId('widget-assignee-stats')).toBeDefined();
+    expect(screen.getByTestId('widget-aging-vocs')).toBeDefined();
+    // No placeholder slots remain for these widget IDs
     for (const widgetId of WIDGET_IDS) {
-      if (widgetId === 'kpi-volume' || widgetId === 'kpi-quality') continue;
-      expect(screen.getByTestId(`widget-placeholder-${widgetId}`)).toBeDefined();
+      expect(screen.queryByTestId(`widget-placeholder-${widgetId}`)).toBeNull();
     }
   });
 
@@ -75,7 +89,7 @@ describe('DashboardShell', () => {
 
   it('drag handles are hidden when isEditing=false', () => {
     const { container } = renderShell({ isEditing: false });
-    // Only the 6 placeholder slots have handles in display mode (kpi widgets don't).
+    // Phase C real widgets have no drag handles; only placeholders in edit mode do.
     const handles = container.querySelectorAll('.dashboard-widget-handle');
     handles.forEach((h) => {
       expect(h.classList.contains('opacity-0')).toBe(true);

--- a/frontend/src/features/dashboard/__tests__/GridTable.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/GridTable.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * GridTable unit tests — Wave 2 Phase C.
+ * Tests intensity interpolation correctness and click behavior.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GridTable, cellOpacity } from '../widgets/GridTable';
+
+describe('cellOpacity', () => {
+  it('returns 0 when value is 0', () => {
+    expect(cellOpacity(0, 10)).toBe(0);
+  });
+  it('returns 0 when maxValue is 0', () => {
+    expect(cellOpacity(5, 0)).toBe(0);
+  });
+  it('returns > 0.06 for small non-zero ratio', () => {
+    const v = cellOpacity(1, 100);
+    expect(v).toBeGreaterThan(0.06);
+    expect(v).toBeLessThan(0.07);
+  });
+  it('returns 0.62 for max value', () => {
+    expect(cellOpacity(10, 10)).toBeCloseTo(0.62);
+  });
+  it('interpolates correctly at midpoint', () => {
+    expect(cellOpacity(5, 10)).toBeCloseTo(0.06 + 0.5 * (0.62 - 0.06));
+  });
+});
+
+describe('GridTable', () => {
+  const headers = ['A', 'B'];
+  const rows = [
+    { id: 'r1', name: 'Row 1', values: [3, 5], total: 8, isClickable: true },
+    { id: 'r2', name: 'Row 2', values: [0, 2], total: 2, isClickable: true },
+  ];
+
+  it('renders headers', () => {
+    render(<GridTable headers={headers} rows={rows} maxValue={5} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('renders row names and values', () => {
+    render(<GridTable headers={headers} rows={rows} maxValue={5} />);
+    expect(screen.getByText('Row 1')).toBeInTheDocument();
+    expect(screen.getByText('Row 2')).toBeInTheDocument();
+  });
+
+  it('calls onCellClick with correct args for non-zero cells', () => {
+    const onCellClick = vi.fn();
+    render(<GridTable headers={headers} rows={rows} maxValue={5} onCellClick={onCellClick} />);
+    const cells = screen.getAllByRole('cell');
+    const cell3 = cells.find((c) => c.textContent === '3');
+    expect(cell3).toBeTruthy();
+    fireEvent.click(cell3!);
+    expect(onCellClick).toHaveBeenCalledWith('r1', 0);
+  });
+
+  it('does not call onCellClick for 0-value cells', () => {
+    const onCellClick = vi.fn();
+    render(<GridTable headers={headers} rows={rows} maxValue={5} onCellClick={onCellClick} />);
+    const cells = screen.getAllByRole('cell');
+    const cell0 = cells.find((c) => c.textContent === '0');
+    if (cell0) fireEvent.click(cell0);
+    expect(onCellClick).not.toHaveBeenCalled();
+  });
+
+  it('renders totalRow when provided', () => {
+    render(<GridTable headers={headers} rows={rows} maxValue={5} totalRow={[3, 7, 10]} />);
+    expect(screen.getByText('전체')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/dashboard/__tests__/PhaseC-2.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/PhaseC-2.test.tsx
@@ -2,17 +2,20 @@
  * Phase C widget smoke tests (part 2) — AssigneeStatsWidget + AgingVocsWidget.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import { DashboardFilterProvider } from '../model/dashboardFilter';
 
 function wrap(ui: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -86,5 +89,50 @@ describe('AgingVocsWidget', () => {
     mockAging.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_AGING, items: [] }, refetch: vi.fn() } as never);
     wrap(<AgingVocsWidget />);
     expect(screen.getByText('장기 미처리 VOC 없음')).toBeInTheDocument();
+  });
+  // P1-3: dim toggle
+  it('dim toggle: no systemId → shows 시스템별 option', () => {
+    mockAging.mockReturnValue({ isLoading: false, isError: false, data: DEMO_AGING, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    expect(screen.getByTestId('aging-dim-system')).toBeInTheDocument();
+    expect(screen.queryByTestId('aging-dim-menu')).toBeNull();
+  });
+  it('column header shows 시스템 when no systemId selected', () => {
+    mockAging.mockReturnValue({ isLoading: false, isError: false, data: DEMO_AGING, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    expect(screen.getByTestId('aging-group-col-header')).toHaveTextContent('시스템');
+  });
+  it('dim toggle: clicking 시스템별 updates active state', () => {
+    mockAging.mockReturnValue({ isLoading: false, isError: false, data: DEMO_AGING, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    const dimBtn = screen.getByTestId('aging-dim-system');
+    fireEvent.click(dimBtn);
+    // Active class applied to clicked button (bg-[var(--brand)])
+    expect(dimBtn.className).toContain('bg-[var(--brand)]');
+  });
+});
+
+// ── AssigneeStatsWidget highlight (P1-4) ─────────────────────────────────────
+describe('AssigneeStatsWidget highlight', () => {
+  it('renders all rows when assigneeId filter set — isHighlighted passed correctly', () => {
+    mockAssignee.mockReturnValue({ isLoading: false, isError: false, data: DEMO_ASSIGNEE, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    const qcH = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={qcH}>
+          <DashboardFilterProvider initial={{ range: '1m', assigneeId: 'u1' }}>
+            <AssigneeStatsWidget />
+          </DashboardFilterProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    // Row for 김철수 (u1) is rendered — component passes isHighlighted=true for u1
+    expect(screen.getByText('김철수')).toBeInTheDocument();
+    expect(screen.getByText('미배정')).toBeInTheDocument();
+  });
+  it('no highlight when no assigneeId in filter', () => {
+    mockAssignee.mockReturnValue({ isLoading: false, isError: false, data: DEMO_ASSIGNEE, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<AssigneeStatsWidget />);
+    expect(screen.getByText('김철수')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/__tests__/PhaseC-2.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/PhaseC-2.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Phase C widget smoke tests (part 2) — AssigneeStatsWidget + AgingVocsWidget.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { DashboardFilterProvider } from '../model/dashboardFilter';
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// ── AssigneeStatsWidget ───────────────────────────────────────────────────────
+import * as assigneeHook from '../model/useAssigneeStats';
+import { AssigneeStatsWidget } from '../widgets/AssigneeStatsWidget';
+
+vi.mock('../model/useAssigneeStats', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useAssigneeStats')>()),
+  useAssigneeStats: vi.fn(),
+}));
+const mockAssignee = vi.mocked(assigneeHook).useAssigneeStats;
+
+const DEMO_ASSIGNEE = {
+  headers: ['접수', '완료'],
+  max_value: 5,
+  rows: [
+    { id: 'u1', name: '김철수', is_unassigned: false, values: [3, 2], total: 5 },
+    { id: null, name: '미배정', is_unassigned: true, values: [1, 0], total: 1 },
+  ],
+};
+
+describe('AssigneeStatsWidget', () => {
+  it('shows loading', () => {
+    mockAssignee.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<AssigneeStatsWidget />);
+    expect(screen.getByTestId('assignee-loading')).toBeInTheDocument();
+  });
+  it('renders grid with 미배정 row', () => {
+    mockAssignee.mockReturnValue({ isLoading: false, isError: false, data: DEMO_ASSIGNEE, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<AssigneeStatsWidget />);
+    expect(screen.getByText('김철수')).toBeInTheDocument();
+    expect(screen.getByText('미배정')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockAssignee.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_ASSIGNEE, rows: [] }, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<AssigneeStatsWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── AgingVocsWidget ───────────────────────────────────────────────────────────
+import * as agingHook from '../model/useAgingVocs';
+import { AgingVocsWidget } from '../widgets/AgingVocsWidget';
+
+vi.mock('../model/useAgingVocs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useAgingVocs')>()),
+  useAgingVocs: vi.fn(),
+}));
+const mockAging = vi.mocked(agingHook).useAgingVocs;
+
+const DEMO_AGING = {
+  dim: 'all' as const,
+  items: [
+    { voc_id: 'id1', issue_code: 'VOC-001', title: '결제 오류', priority: 'urgent' as const, elapsed_days: 42, system_name: '결제', menu_name: null },
+  ],
+};
+
+describe('AgingVocsWidget', () => {
+  it('shows loading', () => {
+    mockAging.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    expect(screen.getByTestId('aging-loading')).toBeInTheDocument();
+  });
+  it('renders table on success', () => {
+    mockAging.mockReturnValue({ isLoading: false, isError: false, data: DEMO_AGING, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    expect(screen.getByText('VOC-001')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockAging.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_AGING, items: [] }, refetch: vi.fn() } as never);
+    wrap(<AgingVocsWidget />);
+    expect(screen.getByText('장기 미처리 VOC 없음')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/dashboard/__tests__/PhaseC-3.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/PhaseC-3.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Phase C adversarial review fixes — P0-2 click-through + P1-1 copy + P1-2 breadcrumb.
+ * Covers: DistributionWidget, PriorityStatusMatrixWidget, HeatmapWidget.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { DashboardFilterProvider } from '../model/dashboardFilter';
+import type { DashboardFilter } from '@contracts/dashboard';
+
+// ── Mocks (must be hoisted before imports of widget) ─────────────────────────
+import * as distributionHook from '../model/useDistribution';
+import * as matrixHook from '../model/usePriorityStatusMatrix';
+import * as heatmapHook from '../model/useHeatmap';
+
+vi.mock('../model/useDistribution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useDistribution')>()),
+  useDistribution: vi.fn(),
+}));
+vi.mock('../model/usePriorityStatusMatrix', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/usePriorityStatusMatrix')>()),
+  usePriorityStatusMatrix: vi.fn(),
+}));
+vi.mock('../model/useHeatmap', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useHeatmap')>()),
+  useHeatmap: vi.fn(),
+}));
+
+const mockDistribution = vi.mocked(distributionHook).useDistribution;
+const mockMatrix = vi.mocked(matrixHook).usePriorityStatusMatrix;
+const mockHeatmap = vi.mocked(heatmapHook).useHeatmap;
+
+import { DistributionWidget } from '../widgets/DistributionWidget';
+import { PriorityStatusMatrixWidget } from '../widgets/PriorityStatusMatrixWidget';
+import { HeatmapWidget } from '../widgets/HeatmapWidget';
+
+const DEMO_DIST = { type: 'status' as const, dim: 'all' as const, total: 10, items: [
+  { label: '접수', key: '접수', count: 5, percentage: 50 },
+] };
+const DEMO_MATRIX = { columns: ['접수', '완료'] as Array<'접수' | '완료'>, max_value: 3,
+  rows: [{ priority: 'urgent' as const, cells: { 접수: 2, 완료: 0 }, row_total: 2 }] };
+const DEMO_HEATMAP = { headers: ['접수', '완료'], totalRow: [5, 3, 8], max_value: 4,
+  rows: [{ id: 'sys1', name: '결제', level: 'system' as const, values: [4, 2], total: 6 }] };
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+function wrapWithFilter(ui: React.ReactNode, initial: DashboardFilter) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider initial={initial}>{ui}</DashboardFilterProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ── DistributionWidget click-through (P0-2) ───────────────────────────────────
+describe('DistributionWidget click-through', () => {
+  it('empty-copy stays 데이터 없음', () => {
+    mockDistribution.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_DIST, items: [] }, refetch: vi.fn() } as never);
+    wrap(<DistributionWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+  it('renders chart with data', () => {
+    mockDistribution.mockReturnValue({ isLoading: false, isError: false, data: DEMO_DIST, refetch: vi.fn() } as never);
+    wrap(<DistributionWidget />);
+    expect(screen.getByTestId('widget-distribution')).toBeInTheDocument();
+  });
+});
+
+// ── PriorityStatusMatrixWidget click-through (P0-2) ───────────────────────────
+describe('PriorityStatusMatrixWidget click-through', () => {
+  it('renders grid with data', () => {
+    mockMatrix.mockReturnValue({ isLoading: false, isError: false, data: DEMO_MATRIX, refetch: vi.fn() } as never);
+    wrap(<PriorityStatusMatrixWidget />);
+    expect(screen.getByText('긴급')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockMatrix.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_MATRIX, rows: [] }, refetch: vi.fn() } as never);
+    wrap(<PriorityStatusMatrixWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── HeatmapWidget empty copy (P1-1) ──────────────────────────────────────────
+describe('HeatmapWidget empty copy', () => {
+  it('shows 해당 기간 데이터 없음', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_HEATMAP, rows: [], totalRow: null }, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<HeatmapWidget />);
+    expect(screen.getByText('해당 기간 데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── HeatmapWidget breadcrumb (P1-2) ──────────────────────────────────────────
+describe('HeatmapWidget breadcrumb', () => {
+  it('전체 tier: shows root breadcrumb only (no systemId)', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: DEMO_HEATMAP, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<HeatmapWidget />);
+    expect(screen.getByTestId('heatmap-breadcrumb-root')).toBeInTheDocument();
+    expect(screen.queryByTestId('heatmap-breadcrumb-system')).toBeNull();
+  });
+  it('시스템 tier: shows 전체 (clickable) › system segment', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: DEMO_HEATMAP, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrapWithFilter(<HeatmapWidget />, { range: '1m', systemId: 'sys-uuid' } as never);
+    expect(screen.getByTestId('heatmap-breadcrumb-all')).toBeInTheDocument();
+    expect(screen.getByTestId('heatmap-breadcrumb-system')).toBeInTheDocument();
+    expect(screen.queryByTestId('heatmap-breadcrumb-root')).toBeNull();
+  });
+  it('메뉴 tier: shows 전체 › system (clickable) › menu segment', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: DEMO_HEATMAP, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrapWithFilter(<HeatmapWidget />, { range: '1m', systemId: 'sys-uuid', menuId: 'menu-uuid' } as never);
+    expect(screen.getByTestId('heatmap-breadcrumb-all')).toBeInTheDocument();
+    expect(screen.getByTestId('heatmap-breadcrumb-system')).toBeInTheDocument();
+    expect(screen.getByTestId('heatmap-breadcrumb-menu')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/dashboard/__tests__/PhaseC.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/PhaseC.test.tsx
@@ -6,15 +6,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import { DashboardFilterProvider } from '../model/dashboardFilter';
 
 function wrap(ui: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>
+        <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -109,7 +112,7 @@ describe('HeatmapWidget', () => {
   it('renders empty when no rows and no totalRow', () => {
     mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_HEATMAP, rows: [], totalRow: null }, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
     wrap(<HeatmapWidget />);
-    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+    expect(screen.getByText('해당 기간 데이터 없음')).toBeInTheDocument();
   });
   it('xAxis toggle calls setXAxis', () => {
     const setXAxis = vi.fn();
@@ -187,3 +190,4 @@ describe('ProcessingSpeedWidget', () => {
 });
 
 // AssigneeStatsWidget + AgingVocsWidget tests → PhaseC-2.test.tsx
+// P0-2 click-through + P1-1 copy + P1-2 breadcrumb fix tests → PhaseC-3.test.tsx

--- a/frontend/src/features/dashboard/__tests__/PhaseC.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/PhaseC.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Phase C widget smoke tests — Wave 2 Phase C TDD.
+ * Each widget: renders loading skeleton, renders data, renders empty state.
+ * GridTable tests are in GridTable.test.tsx.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { DashboardFilterProvider } from '../model/dashboardFilter';
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DashboardFilterProvider initial={{ range: '1m' }}>{ui}</DashboardFilterProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// ── DistributionWidget ────────────────────────────────────────────────────────
+import * as distributionHook from '../model/useDistribution';
+import { DistributionWidget } from '../widgets/DistributionWidget';
+
+vi.mock('../model/useDistribution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useDistribution')>()),
+  useDistribution: vi.fn(),
+}));
+const mockDistribution = vi.mocked(distributionHook).useDistribution;
+
+const DEMO_DIST = { type: 'status' as const, dim: 'all' as const, total: 10, items: [
+  { label: '접수', key: '접수', count: 5, percentage: 50 },
+  { label: '완료', key: '완료', count: 5, percentage: 50 },
+] };
+
+describe('DistributionWidget', () => {
+  it('shows loading skeleton', () => {
+    mockDistribution.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() } as never);
+    wrap(<DistributionWidget />);
+    expect(screen.getByTestId('distribution-loading')).toBeInTheDocument();
+  });
+  it('renders data', () => {
+    mockDistribution.mockReturnValue({ isLoading: false, isError: false, data: DEMO_DIST, refetch: vi.fn() } as never);
+    wrap(<DistributionWidget />);
+    expect(screen.getByTestId('widget-distribution')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockDistribution.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_DIST, items: [] }, refetch: vi.fn() } as never);
+    wrap(<DistributionWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── PriorityStatusMatrixWidget ────────────────────────────────────────────────
+import * as matrixHook from '../model/usePriorityStatusMatrix';
+import { PriorityStatusMatrixWidget } from '../widgets/PriorityStatusMatrixWidget';
+
+vi.mock('../model/usePriorityStatusMatrix', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/usePriorityStatusMatrix')>()),
+  usePriorityStatusMatrix: vi.fn(),
+}));
+const mockMatrix = vi.mocked(matrixHook).usePriorityStatusMatrix;
+
+const DEMO_MATRIX = { columns: ['접수', '완료'] as Array<'접수' | '완료'>, max_value: 3,
+  rows: [{ priority: 'urgent' as const, cells: { 접수: 2, 완료: 0 }, row_total: 2 }] };
+
+describe('PriorityStatusMatrixWidget', () => {
+  it('shows loading', () => {
+    mockMatrix.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() } as never);
+    wrap(<PriorityStatusMatrixWidget />);
+    expect(screen.getByTestId('matrix-loading')).toBeInTheDocument();
+  });
+  it('renders grid on success', () => {
+    mockMatrix.mockReturnValue({ isLoading: false, isError: false, data: DEMO_MATRIX, refetch: vi.fn() } as never);
+    wrap(<PriorityStatusMatrixWidget />);
+    expect(screen.getByText('긴급')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockMatrix.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_MATRIX, rows: [] }, refetch: vi.fn() } as never);
+    wrap(<PriorityStatusMatrixWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── HeatmapWidget ─────────────────────────────────────────────────────────────
+import * as heatmapHook from '../model/useHeatmap';
+import { HeatmapWidget } from '../widgets/HeatmapWidget';
+
+vi.mock('../model/useHeatmap', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useHeatmap')>()),
+  useHeatmap: vi.fn(),
+}));
+const mockHeatmap = vi.mocked(heatmapHook).useHeatmap;
+
+const DEMO_HEATMAP = { headers: ['접수', '완료'], totalRow: [5, 3, 8], max_value: 4,
+  rows: [{ id: 'sys1', name: '결제', level: 'system' as const, values: [4, 2], total: 6 }] };
+
+describe('HeatmapWidget', () => {
+  it('shows loading', () => {
+    mockHeatmap.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<HeatmapWidget />);
+    expect(screen.getByTestId('heatmap-loading')).toBeInTheDocument();
+  });
+  it('renders grid on success', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: DEMO_HEATMAP, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<HeatmapWidget />);
+    expect(screen.getByText('결제')).toBeInTheDocument();
+  });
+  it('renders empty when no rows and no totalRow', () => {
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_HEATMAP, rows: [], totalRow: null }, refetch: vi.fn(), xAxis: 'status', setXAxis: vi.fn() } as never);
+    wrap(<HeatmapWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+  it('xAxis toggle calls setXAxis', () => {
+    const setXAxis = vi.fn();
+    mockHeatmap.mockReturnValue({ isLoading: false, isError: false, data: DEMO_HEATMAP, refetch: vi.fn(), xAxis: 'status', setXAxis } as never);
+    wrap(<HeatmapWidget />);
+    fireEvent.click(screen.getByText('우선순위'));
+    expect(setXAxis).toHaveBeenCalledWith('priority');
+  });
+});
+
+// ── WeeklyTrendWidget ─────────────────────────────────────────────────────────
+import * as trendHook from '../model/useWeeklyTrend';
+import { WeeklyTrendWidget } from '../widgets/WeeklyTrendWidget';
+
+vi.mock('../model/useWeeklyTrend', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useWeeklyTrend')>()),
+  useWeeklyTrend: vi.fn(),
+}));
+const mockTrend = vi.mocked(trendHook).useWeeklyTrend;
+
+const W12 = Array.from({ length: 12 }, (_, i) => `W${i + 1}`);
+const D12 = Array.from({ length: 12 }, (_, i) => i + 1);
+const DEMO_TREND = { weeks: W12,
+  weekStarts: Array.from({ length: 12 }, (_, i) => `2026-02-${(i + 2).toString().padStart(2, '0')}`),
+  series: { new: D12, enteredInProgress: D12, done: D12 } };
+
+describe('WeeklyTrendWidget', () => {
+  it('shows loading', () => {
+    mockTrend.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() } as never);
+    wrap(<WeeklyTrendWidget />);
+    expect(screen.getByTestId('trend-loading')).toBeInTheDocument();
+  });
+  it('renders chart on success', () => {
+    mockTrend.mockReturnValue({ isLoading: false, isError: false, data: DEMO_TREND, refetch: vi.fn() } as never);
+    wrap(<WeeklyTrendWidget />);
+    expect(screen.getByTestId('widget-weekly-trend')).toBeInTheDocument();
+  });
+  it('renders empty state', () => {
+    mockTrend.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_TREND, weeks: [] }, refetch: vi.fn() } as never);
+    wrap(<WeeklyTrendWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// ── ProcessingSpeedWidget ─────────────────────────────────────────────────────
+import * as speedHook from '../model/useProcessingSpeed';
+import { ProcessingSpeedWidget } from '../widgets/ProcessingSpeedWidget';
+
+vi.mock('../model/useProcessingSpeed', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../model/useProcessingSpeed')>()),
+  useProcessingSpeed: vi.fn(),
+}));
+const mockSpeed = vi.mocked(speedHook).useProcessingSpeed;
+
+const DEMO_SPEED = { dim: 'all' as const,
+  rows: [{ id: null, name: '전체', avg_days: 4.2, sla_rate: 82.0, completed_count: 10, slaEligibleCount: 8, missingDueDateCount: 2 }] };
+
+describe('ProcessingSpeedWidget', () => {
+  it('shows loading', () => {
+    mockSpeed.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn(), dim: 'all', setDim: vi.fn() } as never);
+    wrap(<ProcessingSpeedWidget />);
+    expect(screen.getByTestId('speed-loading')).toBeInTheDocument();
+  });
+  it('renders table on success', () => {
+    mockSpeed.mockReturnValue({ isLoading: false, isError: false, data: DEMO_SPEED, refetch: vi.fn(), dim: 'all', setDim: vi.fn() } as never);
+    wrap(<ProcessingSpeedWidget />);
+    expect(screen.getByTestId('widget-processing-speed')).toBeInTheDocument();
+    expect(screen.getAllByText('전체').length).toBeGreaterThan(0);
+  });
+  it('renders empty state', () => {
+    mockSpeed.mockReturnValue({ isLoading: false, isError: false, data: { ...DEMO_SPEED, rows: [] }, refetch: vi.fn(), dim: 'all', setDim: vi.fn() } as never);
+    wrap(<ProcessingSpeedWidget />);
+    expect(screen.getByText('데이터 없음')).toBeInTheDocument();
+  });
+});
+
+// AssigneeStatsWidget + AgingVocsWidget tests → PhaseC-2.test.tsx

--- a/frontend/src/features/dashboard/api/keys.ts
+++ b/frontend/src/features/dashboard/api/keys.ts
@@ -1,7 +1,15 @@
-import type { DashboardFilter } from '@contracts/dashboard';
+import type { DashboardFilter, DistributionFilter, HeatmapFilter, WeeklyTrendFilter, ProcessingSpeedFilter, AssigneeStatsFilter, AgingVocsFilter } from '@contracts/dashboard';
 
 export const dashboardQueryKeys = {
   all: ['dashboard'] as const,
   settings: () => ['dashboard', 'settings'] as const,
   summary: (filter: DashboardFilter) => ['dashboard', 'summary', filter] as const,
+  // Phase C
+  distribution: (filter: DistributionFilter) => ['dashboard', 'distribution', filter] as const,
+  priorityStatusMatrix: (filter: DashboardFilter) => ['dashboard', 'priority-status-matrix', filter] as const,
+  heatmap: (filter: HeatmapFilter) => ['dashboard', 'heatmap', filter] as const,
+  weeklyTrend: (filter: WeeklyTrendFilter) => ['dashboard', 'weekly-trend', filter] as const,
+  processingSpeed: (filter: ProcessingSpeedFilter) => ['dashboard', 'processing-speed', filter] as const,
+  assigneeStats: (filter: AssigneeStatsFilter) => ['dashboard', 'assignee-stats', filter] as const,
+  agingVocs: (filter: AgingVocsFilter) => ['dashboard', 'aging-vocs', filter] as const,
 } as const;

--- a/frontend/src/features/dashboard/api/queries.ts
+++ b/frontend/src/features/dashboard/api/queries.ts
@@ -1,6 +1,6 @@
 /**
  * Dashboard API functions.
- * Spec: shared/openapi.yaml#/paths/~1dashboard~1settings + ~1dashboard~1summary
+ * Spec: shared/openapi.yaml#/paths/~1dashboard~1settings + ~1dashboard~1summary + Phase C
  */
 import { apiGet, apiPut } from '@shared/api/client';
 import {
@@ -9,7 +9,29 @@ import {
   DashboardSettingsResponse,
   DashboardSummary,
   type DashboardFilter,
+  DistributionResponse,
+  type DistributionFilter,
+  PriorityStatusMatrixResponse,
+  HeatmapResponse,
+  type HeatmapFilter,
+  WeeklyTrendResponse,
+  type WeeklyTrendFilter,
+  ProcessingSpeedResponse,
+  type ProcessingSpeedFilter,
+  AssigneeStatsResponse,
+  type AssigneeStatsFilter,
+  AgingVocsResponse,
+  type AgingVocsFilter,
 } from '@contracts/dashboard';
+
+/** Build URLSearchParams from a filter object, omitting undefined values. */
+function filterToQs(filter: Record<string, unknown>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(filter)) {
+    if (v !== undefined && v !== null) qs.set(k, String(v));
+  }
+  return qs.toString() ? `?${qs.toString()}` : '';
+}
 
 export const dashboardApi = {
   getSettings(): Promise<DashboardSettings> {
@@ -30,5 +52,35 @@ export const dashboardApi = {
     if (filter.endDate) qs.set('endDate', filter.endDate);
     const suffix = qs.toString() ? `?${qs.toString()}` : '';
     return apiGet(`/api/dashboard/summary${suffix}`, DashboardSummary);
+  },
+
+  // Phase C endpoints
+
+  getDistribution(filter: DistributionFilter): Promise<import('@contracts/dashboard').DistributionResponse> {
+    return apiGet(`/api/dashboard/distribution${filterToQs(filter as Record<string, unknown>)}`, DistributionResponse);
+  },
+
+  getPriorityStatusMatrix(filter: DashboardFilter): Promise<import('@contracts/dashboard').PriorityStatusMatrixResponse> {
+    return apiGet(`/api/dashboard/priority-status-matrix${filterToQs(filter as Record<string, unknown>)}`, PriorityStatusMatrixResponse);
+  },
+
+  getHeatmap(filter: HeatmapFilter): Promise<import('@contracts/dashboard').HeatmapResponse> {
+    return apiGet(`/api/dashboard/heatmap${filterToQs(filter as Record<string, unknown>)}`, HeatmapResponse);
+  },
+
+  getWeeklyTrend(filter: WeeklyTrendFilter): Promise<import('@contracts/dashboard').WeeklyTrendResponse> {
+    return apiGet(`/api/dashboard/weekly-trend${filterToQs(filter as Record<string, unknown>)}`, WeeklyTrendResponse);
+  },
+
+  getProcessingSpeed(filter: ProcessingSpeedFilter): Promise<import('@contracts/dashboard').ProcessingSpeedResponse> {
+    return apiGet(`/api/dashboard/processing-speed${filterToQs(filter as Record<string, unknown>)}`, ProcessingSpeedResponse);
+  },
+
+  getAssigneeStats(filter: AssigneeStatsFilter): Promise<import('@contracts/dashboard').AssigneeStatsResponse> {
+    return apiGet(`/api/dashboard/assignee-stats${filterToQs(filter as Record<string, unknown>)}`, AssigneeStatsResponse);
+  },
+
+  getAgingVocs(filter: AgingVocsFilter): Promise<import('@contracts/dashboard').AgingVocsResponse> {
+    return apiGet(`/api/dashboard/aging-vocs${filterToQs(filter as Record<string, unknown>)}`, AgingVocsResponse);
   },
 };

--- a/frontend/src/features/dashboard/model/dashboardFilter.tsx
+++ b/frontend/src/features/dashboard/model/dashboardFilter.tsx
@@ -17,6 +17,12 @@ interface DashboardFilterContextValue {
   setFilter: (next: DashboardFilter) => void;
   patch: (delta: Partial<DashboardFilter>) => void;
   reset: () => void;
+  /** Display name for the currently-selected system (UI-layer only, not in contract). */
+  systemName: string | undefined;
+  setSystemName: (name: string | undefined) => void;
+  /** Display name for the currently-selected menu (UI-layer only, not in contract). */
+  menuName: string | undefined;
+  setMenuName: (name: string | undefined) => void;
 }
 
 const DashboardFilterContext = createContext<DashboardFilterContextValue | null>(null);
@@ -28,14 +34,24 @@ export interface DashboardFilterProviderProps {
 
 export function DashboardFilterProvider({ initial, children }: DashboardFilterProviderProps) {
   const [filter, setFilter] = useState<DashboardFilter>(initial ?? {});
+  const [systemName, setSystemName] = useState<string | undefined>(undefined);
+  const [menuName, setMenuName] = useState<string | undefined>(undefined);
   const value = useMemo<DashboardFilterContextValue>(
     () => ({
       filter,
       setFilter,
       patch: (delta) => setFilter((prev) => ({ ...prev, ...delta })),
-      reset: () => setFilter(initial ?? {}),
+      reset: () => {
+        setFilter(initial ?? {});
+        setSystemName(undefined);
+        setMenuName(undefined);
+      },
+      systemName,
+      setSystemName,
+      menuName,
+      setMenuName,
     }),
-    [filter, initial],
+    [filter, initial, systemName, menuName],
   );
   return (
     <DashboardFilterContext.Provider value={value}>{children}</DashboardFilterContext.Provider>

--- a/frontend/src/features/dashboard/model/useAgingVocs.ts
+++ b/frontend/src/features/dashboard/model/useAgingVocs.ts
@@ -1,0 +1,25 @@
+/**
+ * useAgingVocs — Wave 2 Phase C.
+ * Queries /api/dashboard/aging-vocs. Date range is ignored by BE (spec).
+ */
+import { useQuery } from '@tanstack/react-query';
+import type { AgingVocDim } from '@contracts/dashboard';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useAgingVocs(limit = 10, dim: AgingVocDim = 'all') {
+  const { filter } = useDashboardFilter();
+  const queryFilter = {
+    systemId: filter.systemId,
+    menuId: filter.menuId,
+    assigneeId: filter.assigneeId,
+    limit,
+    dim,
+  };
+  return useQuery({
+    queryKey: dashboardQueryKeys.agingVocs(queryFilter),
+    queryFn: () => dashboardApi.getAgingVocs(queryFilter),
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/features/dashboard/model/useAssigneeStats.ts
+++ b/frontend/src/features/dashboard/model/useAssigneeStats.ts
@@ -1,0 +1,24 @@
+/**
+ * useAssigneeStats — Wave 2 Phase C.
+ * Queries /api/dashboard/assignee-stats. xAxis state is LOCAL (independent from heatmap).
+ */
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { HeatmapXAxis } from '@contracts/dashboard';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useAssigneeStats() {
+  const { filter } = useDashboardFilter();
+  const [xAxis, setXAxis] = useState<HeatmapXAxis>('status');
+
+  const queryFilter = { ...filter, xAxis };
+  const query = useQuery({
+    queryKey: dashboardQueryKeys.assigneeStats(queryFilter),
+    queryFn: () => dashboardApi.getAssigneeStats(queryFilter),
+    staleTime: 30_000,
+  });
+
+  return { ...query, xAxis, setXAxis };
+}

--- a/frontend/src/features/dashboard/model/useDistribution.ts
+++ b/frontend/src/features/dashboard/model/useDistribution.ts
@@ -1,0 +1,19 @@
+/**
+ * useDistribution — Wave 2 Phase C.
+ * Queries /api/dashboard/distribution with the active filter + requested type.
+ */
+import { useQuery } from '@tanstack/react-query';
+import type { DistributionType, DistributionDim } from '@contracts/dashboard';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useDistribution(type: DistributionType, dim?: DistributionDim) {
+  const { filter } = useDashboardFilter();
+  const queryFilter = { ...filter, type, ...(dim ? { dim } : {}) };
+  return useQuery({
+    queryKey: dashboardQueryKeys.distribution(queryFilter),
+    queryFn: () => dashboardApi.getDistribution(queryFilter),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/features/dashboard/model/useHeatmap.ts
+++ b/frontend/src/features/dashboard/model/useHeatmap.ts
@@ -1,0 +1,25 @@
+/**
+ * useHeatmap — Wave 2 Phase C.
+ * Queries /api/dashboard/heatmap. xAxis state is LOCAL to this hook
+ * (spec: independent from useAssigneeStats xAxis).
+ */
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { HeatmapXAxis } from '@contracts/dashboard';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useHeatmap() {
+  const { filter } = useDashboardFilter();
+  const [xAxis, setXAxis] = useState<HeatmapXAxis>('status');
+
+  const queryFilter = { ...filter, xAxis };
+  const query = useQuery({
+    queryKey: dashboardQueryKeys.heatmap(queryFilter),
+    queryFn: () => dashboardApi.getHeatmap(queryFilter),
+    staleTime: 30_000,
+  });
+
+  return { ...query, xAxis, setXAxis };
+}

--- a/frontend/src/features/dashboard/model/usePriorityStatusMatrix.ts
+++ b/frontend/src/features/dashboard/model/usePriorityStatusMatrix.ts
@@ -1,0 +1,17 @@
+/**
+ * usePriorityStatusMatrix — Wave 2 Phase C.
+ * Queries /api/dashboard/priority-status-matrix with the active filter.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function usePriorityStatusMatrix() {
+  const { filter } = useDashboardFilter();
+  return useQuery({
+    queryKey: dashboardQueryKeys.priorityStatusMatrix(filter),
+    queryFn: () => dashboardApi.getPriorityStatusMatrix(filter),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/features/dashboard/model/useProcessingSpeed.ts
+++ b/frontend/src/features/dashboard/model/useProcessingSpeed.ts
@@ -1,0 +1,24 @@
+/**
+ * useProcessingSpeed — Wave 2 Phase C.
+ * Queries /api/dashboard/processing-speed.
+ */
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { ProcessingSpeedDim } from '@contracts/dashboard';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useProcessingSpeed() {
+  const { filter } = useDashboardFilter();
+  const [dim, setDim] = useState<ProcessingSpeedDim>('all');
+
+  const queryFilter = { ...filter, dim };
+  const query = useQuery({
+    queryKey: dashboardQueryKeys.processingSpeed(queryFilter),
+    queryFn: () => dashboardApi.getProcessingSpeed(queryFilter),
+    staleTime: 30_000,
+  });
+
+  return { ...query, dim, setDim };
+}

--- a/frontend/src/features/dashboard/model/useWeeklyTrend.ts
+++ b/frontend/src/features/dashboard/model/useWeeklyTrend.ts
@@ -1,0 +1,24 @@
+/**
+ * useWeeklyTrend — Wave 2 Phase C.
+ * Queries /api/dashboard/weekly-trend. Date range ignored per spec (12-week fixed).
+ * systemId/menuId/assigneeId are still applied.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { dashboardApi } from '../api/queries';
+import { dashboardQueryKeys } from '../api/keys';
+import { useDashboardFilter } from './dashboardFilter';
+
+export function useWeeklyTrend() {
+  const { filter } = useDashboardFilter();
+  // Omit startDate/endDate — BE ignores them, but key still includes them for reactivity.
+  const queryFilter = {
+    systemId: filter.systemId,
+    menuId: filter.menuId,
+    assigneeId: filter.assigneeId,
+  };
+  return useQuery({
+    queryKey: dashboardQueryKeys.weeklyTrend(queryFilter),
+    queryFn: () => dashboardApi.getWeeklyTrend(queryFilter),
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/features/dashboard/ui/DashboardShell.tsx
+++ b/frontend/src/features/dashboard/ui/DashboardShell.tsx
@@ -8,14 +8,26 @@ import { WIDGET_IDS, RGL_BREAKPOINTS, RGL_COLS } from '../defaultLayouts';
 import { WidgetPlaceholder } from './WidgetPlaceholder';
 import { KpiVolumeWidget } from '../widgets/KpiVolumeWidget';
 import { KpiQualityWidget } from '../widgets/KpiQualityWidget';
+import { DistributionWidget } from '../widgets/DistributionWidget';
+import { HeatmapWidget } from '../widgets/HeatmapWidget';
+import { WeeklyTrendWidget } from '../widgets/WeeklyTrendWidget';
+import { ProcessingSpeedWidget } from '../widgets/ProcessingSpeedWidget';
+import { AssigneeStatsWidget } from '../widgets/AssigneeStatsWidget';
+import { AgingVocsWidget } from '../widgets/AgingVocsWidget';
 
 function renderWidget(widgetId: string, isEditing: boolean) {
-  // Wave 2 Phase B — KPI widgets are wired. Other widgets remain placeholders
-  // until their phases (C / E). Edit mode keeps the drag handle visible by
-  // falling back to the placeholder, so resize gestures hit a stable target.
+  // Edit mode uses placeholder so drag handles remain stable.
   if (isEditing) return <WidgetPlaceholder widgetId={widgetId} isEditing={isEditing} />;
+  // Phase B
   if (widgetId === 'kpi-volume') return <KpiVolumeWidget />;
   if (widgetId === 'kpi-quality') return <KpiQualityWidget />;
+  // Phase C
+  if (widgetId === 'dist-matrix') return <DistributionWidget />;
+  if (widgetId === 'heatmap') return <HeatmapWidget />;
+  if (widgetId === 'trend-tag') return <WeeklyTrendWidget />;
+  if (widgetId === 'sla-aging') return <ProcessingSpeedWidget />;
+  if (widgetId === 'assignee') return <AssigneeStatsWidget />;
+  if (widgetId === 'aging-top10') return <AgingVocsWidget />;
   return <WidgetPlaceholder widgetId={widgetId} isEditing={isEditing} />;
 }
 

--- a/frontend/src/features/dashboard/ui/DashboardShell.tsx
+++ b/frontend/src/features/dashboard/ui/DashboardShell.tsx
@@ -9,6 +9,7 @@ import { WidgetPlaceholder } from './WidgetPlaceholder';
 import { KpiVolumeWidget } from '../widgets/KpiVolumeWidget';
 import { KpiQualityWidget } from '../widgets/KpiQualityWidget';
 import { DistributionWidget } from '../widgets/DistributionWidget';
+import { PriorityStatusMatrixWidget } from '../widgets/PriorityStatusMatrixWidget';
 import { HeatmapWidget } from '../widgets/HeatmapWidget';
 import { WeeklyTrendWidget } from '../widgets/WeeklyTrendWidget';
 import { ProcessingSpeedWidget } from '../widgets/ProcessingSpeedWidget';
@@ -21,8 +22,13 @@ function renderWidget(widgetId: string, isEditing: boolean) {
   // Phase B
   if (widgetId === 'kpi-volume') return <KpiVolumeWidget />;
   if (widgetId === 'kpi-quality') return <KpiQualityWidget />;
-  // Phase C
-  if (widgetId === 'dist-matrix') return <DistributionWidget />;
+  // Phase C — dist-matrix is a compound slot: §2 Distribution + §3 PriorityStatusMatrix stacked.
+  if (widgetId === 'dist-matrix') return (
+    <div className="flex h-full flex-col gap-4" data-testid="slot-dist-matrix">
+      <DistributionWidget />
+      <PriorityStatusMatrixWidget />
+    </div>
+  );
   if (widgetId === 'heatmap') return <HeatmapWidget />;
   if (widgetId === 'trend-tag') return <WeeklyTrendWidget />;
   if (widgetId === 'sla-aging') return <ProcessingSpeedWidget />;

--- a/frontend/src/features/dashboard/widgets/AgingVocsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/AgingVocsWidget.tsx
@@ -2,9 +2,15 @@
  * AgingVocsWidget — Wave 2 Phase C (dashboard.md §9 장기 미처리 VOC Top 10 v3).
  * Data table. Elapsed days badge: 14–29 amber, 30+ red.
  * Date filter ignored (BE silently ignores).
+ * P1-3: Dim toggle responsive to globalTab (systemId → 메뉴별; else → 시스템별).
  */
+import { useState } from 'react';
 import { Skeleton } from '@shared/ui/skeleton';
+import type { AgingVocDim } from '@contracts/dashboard';
+
+type AgingDimOption = { id: AgingVocDim; label: string };
 import { useAgingVocs } from '../model/useAgingVocs';
+import { useDashboardFilter } from '../model/dashboardFilter';
 
 function elapsedBadgeStyle(days: number): string {
   if (days >= 30) return 'bg-[color-mix(in_oklch,var(--chart-red)_15%,transparent)] text-[var(--chart-red)]';
@@ -20,7 +26,18 @@ const PRIORITY_LABELS: Record<string, string> = {
 };
 
 export function AgingVocsWidget() {
-  const { data, isLoading, isError, refetch } = useAgingVocs(10, 'all');
+  const { filter } = useDashboardFilter();
+  const isSystemSelected = !!filter.systemId;
+  // Dim options depend on global tab: no systemId → 전체/시스템별; systemId → 전체/메뉴별
+  const dimOptions: AgingDimOption[] = isSystemSelected
+    ? [{ id: 'all' as AgingVocDim, label: '전체' }, { id: 'menu' as AgingVocDim, label: '메뉴별' }]
+    : [{ id: 'all' as AgingVocDim, label: '전체' }, { id: 'system' as AgingVocDim, label: '시스템별' }];
+
+  const [dim, setDim] = useState<AgingVocDim>('all');
+  const { data, isLoading, isError, refetch } = useAgingVocs(10, dim);
+
+  // Column header for the system/menu column
+  const groupColLabel = isSystemSelected ? '메뉴' : '시스템';
 
   return (
     <div
@@ -28,8 +45,27 @@ export function AgingVocsWidget() {
       aria-busy={isLoading}
       className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
     >
-      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
-        장기 미처리 Top 10
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+          장기 미처리 Top 10
+        </div>
+        <div className="flex gap-1">
+          {dimOptions.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              data-testid={`aging-dim-${opt.id}`}
+              onClick={() => setDim(opt.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                dim === opt.id
+                  ? 'bg-[var(--brand)] text-[var(--text-on-brand)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {isLoading && (
@@ -65,7 +101,7 @@ export function AgingVocsWidget() {
                 <th className="py-2 text-left font-medium">이슈코드</th>
                 <th className="py-2 text-left font-medium">제목</th>
                 <th className="py-2 text-center font-medium">우선순위</th>
-                <th className="py-2 text-left font-medium">시스템</th>
+                <th className="py-2 text-left font-medium" data-testid="aging-group-col-header">{groupColLabel}</th>
                 <th className="py-2 text-right font-medium w-16">경과일</th>
               </tr>
             </thead>

--- a/frontend/src/features/dashboard/widgets/AgingVocsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/AgingVocsWidget.tsx
@@ -1,0 +1,105 @@
+/**
+ * AgingVocsWidget — Wave 2 Phase C (dashboard.md §9 장기 미처리 VOC Top 10 v3).
+ * Data table. Elapsed days badge: 14–29 amber, 30+ red.
+ * Date filter ignored (BE silently ignores).
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import { useAgingVocs } from '../model/useAgingVocs';
+
+function elapsedBadgeStyle(days: number): string {
+  if (days >= 30) return 'bg-[color-mix(in_oklch,var(--chart-red)_15%,transparent)] text-[var(--chart-red)]';
+  if (days >= 14) return 'bg-[color-mix(in_oklch,var(--chart-amber)_15%,transparent)] text-[var(--chart-amber)]';
+  return 'bg-[var(--bg-elevated)] text-[var(--text-secondary)]';
+}
+
+const PRIORITY_LABELS: Record<string, string> = {
+  urgent: '긴급',
+  high: '높음',
+  medium: '보통',
+  low: '낮음',
+};
+
+export function AgingVocsWidget() {
+  const { data, isLoading, isError, refetch } = useAgingVocs(10, 'all');
+
+  return (
+    <div
+      data-testid="widget-aging-vocs"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+        장기 미처리 Top 10
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="aging-loading">
+          {Array.from({ length: 5 }, (_, i) => <Skeleton key={i} className="h-9" />)}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && data.items.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          장기 미처리 VOC 없음
+        </div>
+      )}
+
+      {data && data.items.length > 0 && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-[var(--border-subtle)] text-[var(--text-quaternary)]">
+                <th className="py-2 text-left font-medium">이슈코드</th>
+                <th className="py-2 text-left font-medium">제목</th>
+                <th className="py-2 text-center font-medium">우선순위</th>
+                <th className="py-2 text-left font-medium">시스템</th>
+                <th className="py-2 text-right font-medium w-16">경과일</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((item) => (
+                <tr
+                  key={item.voc_id}
+                  className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]"
+                >
+                  <td className="py-2 font-d2coding text-[var(--text-secondary)] whitespace-nowrap">
+                    {item.issue_code}
+                  </td>
+                  <td className="py-2 text-[var(--text-primary)] max-w-[200px] truncate">
+                    {item.title}
+                  </td>
+                  <td className="py-2 text-center">
+                    <span className="rounded px-1.5 py-0.5 text-[10px] font-medium bg-[var(--bg-elevated)] text-[var(--text-secondary)]">
+                      {PRIORITY_LABELS[item.priority] ?? item.priority}
+                    </span>
+                  </td>
+                  <td className="py-2 text-[var(--text-tertiary)] max-w-[120px] truncate">
+                    {item.system_name ?? item.menu_name ?? '—'}
+                  </td>
+                  <td className="py-2 text-right">
+                    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums ${elapsedBadgeStyle(item.elapsed_days)}`}>
+                      {item.elapsed_days}일
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/AssigneeStatsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/AssigneeStatsWidget.tsx
@@ -1,0 +1,92 @@
+/**
+ * AssigneeStatsWidget — Wave 2 Phase C (dashboard.md §8 담당자별 처리 현황 v3).
+ * Grid table with intensity shading. xAxis independent from HeatmapWidget.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import type { HeatmapXAxis } from '@contracts/dashboard';
+import { useAssigneeStats } from '../model/useAssigneeStats';
+import { GridTable, type GridTableRow } from './GridTable';
+
+const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
+  { id: 'status', label: '상태' },
+  { id: 'priority', label: '우선순위' },
+  { id: 'tag', label: '태그' },
+];
+
+export function AssigneeStatsWidget() {
+  const { data, isLoading, isError, refetch, xAxis, setXAxis } = useAssigneeStats();
+
+  const rows: GridTableRow[] = data?.rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    values: r.values,
+    total: r.total,
+    isUnassigned: r.is_unassigned,
+    isClickable: !r.is_unassigned,
+  })) ?? [];
+
+  return (
+    <div
+      data-testid="widget-assignee-stats"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+          담당자 현황
+        </div>
+        <div className="flex gap-1">
+          {X_AXIS_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setXAxis(opt.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                xAxis === opt.id
+                  ? 'bg-[var(--brand)] text-[var(--text-on-brand)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="assignee-loading">
+          {Array.from({ length: 4 }, (_, i) => <Skeleton key={i} className="h-8" />)}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && rows.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && rows.length > 0 && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <GridTable
+            headers={data.headers}
+            rows={rows}
+            maxValue={data.max_value}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/AssigneeStatsWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/AssigneeStatsWidget.tsx
@@ -1,11 +1,16 @@
 /**
  * AssigneeStatsWidget — Wave 2 Phase C (dashboard.md §8 담당자별 처리 현황 v3).
  * Grid table with intensity shading. xAxis independent from HeatmapWidget.
+ * P1-4: isHighlighted for current filter assignee.
+ * P0-2: Click-through nav to /voc.
  */
+import { useNavigate } from 'react-router-dom';
 import { Skeleton } from '@shared/ui/skeleton';
 import type { HeatmapXAxis } from '@contracts/dashboard';
 import { useAssigneeStats } from '../model/useAssigneeStats';
+import { useDashboardFilter } from '../model/dashboardFilter';
 import { GridTable, type GridTableRow } from './GridTable';
+import { buildVocUrl } from './buildVocUrl';
 
 const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
   { id: 'status', label: '상태' },
@@ -14,6 +19,8 @@ const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
 ];
 
 export function AssigneeStatsWidget() {
+  const navigate = useNavigate();
+  const { filter } = useDashboardFilter();
   const { data, isLoading, isError, refetch, xAxis, setXAxis } = useAssigneeStats();
 
   const rows: GridTableRow[] = data?.rows.map((r) => ({
@@ -22,8 +29,29 @@ export function AssigneeStatsWidget() {
     values: r.values,
     total: r.total,
     isUnassigned: r.is_unassigned,
-    isClickable: !r.is_unassigned,
+    isClickable: true,
+    // P1-4: highlight the row whose assigneeId matches the current filter
+    isHighlighted: r.id === filter.assigneeId,
   })) ?? [];
+
+  function handleCellClick(rowId: string | null, colIndex: number) {
+    const colKey = data?.headers[colIndex];
+    if (!colKey) return;
+    const widgetParams: Record<string, string> = {};
+    if (xAxis === 'status') widgetParams.status = colKey;
+    else if (xAxis === 'priority') widgetParams.priority = colKey;
+    else if (xAxis === 'tag') widgetParams.tag = colKey;
+    // 미배정 row: assigneeId='unassigned'
+    widgetParams.assigneeId = rowId ?? 'unassigned';
+    navigate(buildVocUrl(widgetParams, filter));
+  }
+
+  function handleRowClick(rowId: string | null) {
+    const widgetParams: Record<string, string> = {
+      assigneeId: rowId ?? 'unassigned',
+    };
+    navigate(buildVocUrl(widgetParams, filter));
+  }
 
   return (
     <div
@@ -84,6 +112,8 @@ export function AssigneeStatsWidget() {
             headers={data.headers}
             rows={rows}
             maxValue={data.max_value}
+            onCellClick={handleCellClick}
+            onRowClick={handleRowClick}
           />
         </div>
       )}

--- a/frontend/src/features/dashboard/widgets/DistributionWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/DistributionWidget.tsx
@@ -1,0 +1,134 @@
+/**
+ * DistributionWidget — Wave 2 Phase C (dashboard.md §2 분포 탭).
+ * widgetId: dist-matrix (shared slot — see DashboardShell).
+ * Donut chart (recharts PieChart) + legend for status/priority/voc_type/tag.
+ */
+import { useState } from 'react';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { Skeleton } from '@shared/ui/skeleton';
+import type { DistributionType } from '@contracts/dashboard';
+import { useDistribution } from '../model/useDistribution';
+
+const TABS: { id: DistributionType; label: string }[] = [
+  { id: 'status', label: '상태' },
+  { id: 'priority', label: '우선순위' },
+  { id: 'voc_type', label: '유형' },
+  { id: 'tag', label: '태그' },
+];
+
+/** Status / priority color tokens — CSS vars only. */
+const SLICE_COLORS: Record<string, string | undefined> = {
+  접수: 'var(--status-received)',
+  검토중: 'var(--status-review)',
+  처리중: 'var(--status-processing)',
+  완료: 'var(--status-done)',
+  드랍: 'var(--status-drop)',
+  urgent: 'var(--priority-urgent)',
+  high: 'var(--priority-high)',
+  medium: 'var(--priority-medium)',
+  low: 'var(--priority-low)',
+};
+const DEFAULT_COLORS = [
+  'var(--chart-blue)',
+  'var(--chart-emerald)',
+  'var(--chart-amber)',
+  'var(--chart-red)',
+  'var(--chart-purple)',
+  'var(--chart-teal)',
+  'var(--text-quaternary)',
+];
+
+function sliceColor(key: string, index: number): string {
+  return SLICE_COLORS[key] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length] ?? 'var(--text-quaternary)';
+}
+
+export function DistributionWidget() {
+  const [activeTab, setActiveTab] = useState<DistributionType>('status');
+  const { data, isLoading, isError, refetch } = useDistribution(activeTab);
+
+  return (
+    <div
+      data-testid="widget-distribution"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+          분포
+        </div>
+        <div className="flex gap-1">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'bg-[var(--brand)] text-[var(--text-on-brand)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="distribution-loading">
+          <Skeleton className="flex-1" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && data.items.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && data.items.length > 0 && (
+        <div className="flex flex-1 min-h-0">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={data.items}
+                dataKey="count"
+                nameKey="label"
+                cx="50%"
+                cy="50%"
+                innerRadius="55%"
+                outerRadius="80%"
+              >
+                {data.items.map((item, i) => (
+                  <Cell key={item.key} fill={sliceColor(item.key, i)} />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value) => [value, '건']}
+                contentStyle={{ background: 'var(--bg-panel)', border: '1px solid var(--border-subtle)', borderRadius: 6, fontSize: 12 }}
+              />
+              <Legend
+                iconType="circle"
+                iconSize={8}
+                formatter={(value) => <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{value}</span>}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/DistributionWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/DistributionWidget.tsx
@@ -2,12 +2,16 @@
  * DistributionWidget — Wave 2 Phase C (dashboard.md §2 분포 탭).
  * widgetId: dist-matrix (shared slot — see DashboardShell).
  * Donut chart (recharts PieChart) + legend for status/priority/voc_type/tag.
+ * P0-2: Legend item click → /voc?<param>=<val>&...globalFilter.
  */
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { Skeleton } from '@shared/ui/skeleton';
 import type { DistributionType } from '@contracts/dashboard';
 import { useDistribution } from '../model/useDistribution';
+import { useDashboardFilter } from '../model/dashboardFilter';
+import { buildVocUrl } from './buildVocUrl';
 
 const TABS: { id: DistributionType; label: string }[] = [
   { id: 'status', label: '상태' },
@@ -15,6 +19,14 @@ const TABS: { id: DistributionType; label: string }[] = [
   { id: 'voc_type', label: '유형' },
   { id: 'tag', label: '태그' },
 ];
+
+/** Mapping from DistributionType to /voc search param key */
+const TAB_PARAM: Record<DistributionType, string> = {
+  status: 'status',
+  priority: 'priority',
+  voc_type: 'vocType',
+  tag: 'tag',
+};
 
 /** Status / priority color tokens — CSS vars only. */
 const SLICE_COLORS: Record<string, string | undefined> = {
@@ -45,6 +57,14 @@ function sliceColor(key: string, index: number): string {
 export function DistributionWidget() {
   const [activeTab, setActiveTab] = useState<DistributionType>('status');
   const { data, isLoading, isError, refetch } = useDistribution(activeTab);
+  const { filter } = useDashboardFilter();
+  const navigate = useNavigate();
+
+  function handleLegendClick(entry: { value?: string }) {
+    if (!entry.value) return;
+    const paramKey = TAB_PARAM[activeTab];
+    navigate(buildVocUrl({ [paramKey]: entry.value }, filter));
+  }
 
   return (
     <div
@@ -124,6 +144,8 @@ export function DistributionWidget() {
                 iconType="circle"
                 iconSize={8}
                 formatter={(value) => <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{value}</span>}
+                onClick={handleLegendClick}
+                wrapperStyle={{ cursor: 'pointer' }}
               />
             </PieChart>
           </ResponsiveContainer>

--- a/frontend/src/features/dashboard/widgets/GridTable.tsx
+++ b/frontend/src/features/dashboard/widgets/GridTable.tsx
@@ -1,0 +1,153 @@
+/**
+ * GridTable — shared intensity-shaded grid for heatmap, assignee-stats, and matrix widgets.
+ * Spec: dashboard.md §3/§4/§8 — intensity formula below.
+ * Cell bg uses the spec-literal oklch formula; isolated to cellOpacity + inline style.
+ */
+import { cn } from '@shared/lib/cn';
+
+export interface GridTableRow {
+  id: string | null;
+  name: string;
+  values: number[];
+  total: number;
+  isHighlighted?: boolean;
+  isClickable?: boolean;
+  isSummary?: boolean;
+  isUnassigned?: boolean;
+}
+
+export interface GridTableProps {
+  headers: string[];
+  rows: GridTableRow[];
+  maxValue: number;
+  totalRow?: number[] | null;
+  onCellClick?: (rowId: string | null, colIndex: number) => void;
+  onRowClick?: (rowId: string | null) => void;
+}
+
+/**
+ * Compute cell background intensity.
+ * Spec (dashboard.md §3/§4/§8): opacity ∈ [0.06, 0.62], applied via oklch inline style.
+ */ // allow-raw-color: spec-literal oklch formula per dashboard.md §3/§4/§8
+export function cellOpacity(value: number, maxValue: number): number {
+  if (maxValue === 0 || value === 0) return 0;
+  const ratio = value / maxValue;
+  return 0.06 + ratio * (0.62 - 0.06);
+}
+
+export function GridTable({ headers, rows, maxValue, totalRow, onCellClick, onRowClick }: GridTableProps) {
+  return (
+    <div className="w-full overflow-x-auto" role="table" aria-label="데이터 그리드">
+      {/* Header */}
+      <div role="rowgroup">
+        <div
+          role="row"
+          className="flex border-b border-[var(--border-subtle)] text-[11px] font-semibold uppercase tracking-wide text-[var(--text-quaternary)]"
+        >
+          <div role="columnheader" className="min-w-[120px] flex-1 py-2 pr-3">
+            항목
+          </div>
+          {headers.map((h, i) => (
+            <div
+              key={i}
+              role="columnheader"
+              className="w-20 shrink-0 py-2 text-center"
+            >
+              {h}
+            </div>
+          ))}
+          <div role="columnheader" className="w-16 shrink-0 py-2 text-center">
+            합계
+          </div>
+        </div>
+      </div>
+
+      {/* Total row */}
+      {totalRow && (
+        <div role="rowgroup">
+          <div
+            role="row"
+            className="flex border-b border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-xs font-semibold text-[var(--text-secondary)]"
+          >
+            <div role="rowheader" className="min-w-[120px] flex-1 py-2 pr-3">
+              전체
+            </div>
+            {totalRow.slice(0, headers.length).map((v, i) => (
+              <div key={i} role="cell" className="w-20 shrink-0 py-2 text-center tabular-nums">
+                {v}
+              </div>
+            ))}
+            <div role="cell" className="w-16 shrink-0 py-2 text-center tabular-nums font-semibold">
+              {totalRow[headers.length] ?? totalRow.reduce((a, b) => a + b, 0)}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Data rows */}
+      <div role="rowgroup">
+        {rows.map((row) => {
+          const nameClass = cn(
+            'min-w-[120px] flex-1 py-2 pr-3 text-xs truncate',
+            row.isUnassigned
+              ? 'italic text-[var(--text-quaternary)]'
+              : row.isSummary
+              ? 'font-semibold text-[var(--text-secondary)]'
+              : 'text-[var(--text-primary)]',
+          );
+          return (
+            <div
+              key={row.id ?? 'unassigned'}
+              role="row"
+              className={cn(
+                'flex border-b border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]',
+                row.isClickable && 'cursor-pointer',
+              )}
+              onClick={row.isClickable && onRowClick ? () => onRowClick(row.id) : undefined}
+            >
+              <div role="rowheader" className={nameClass}>
+                {row.name}
+              </div>
+              {row.values.map((v, i) => {
+                const opacity = row.isSummary ? 0 : cellOpacity(v, maxValue);
+                const canClick = !row.isSummary && v > 0 && onCellClick;
+                return (
+                  <div
+                    key={i}
+                    role="cell"
+                    className={cn(
+                      'w-20 shrink-0 py-2 text-center text-xs tabular-nums',
+                      canClick && 'cursor-pointer',
+                      v === 0 ? 'text-[var(--text-quaternary)]' : 'text-[var(--text-primary)]',
+                    )}
+                    style={{
+                      backgroundColor: opacity > 0
+                        ? `oklch(63% 0.19 258 / ${opacity.toFixed(3)})` // allow-raw-color: spec-literal intensity formula per dashboard.md §3/§4/§8
+                        : undefined,
+                    }}
+                    onClick={
+                      canClick
+                        ? (e) => {
+                            e.stopPropagation();
+                            onCellClick!(row.id, i);
+                          }
+                        : undefined
+                    }
+                  >
+                    {v}
+                  </div>
+                );
+              })}
+              <div
+                role="cell"
+                className="w-16 shrink-0 py-2 text-center text-xs tabular-nums font-semibold text-[var(--text-secondary)]"
+              >
+                {row.total}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/HeatmapWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/HeatmapWidget.tsx
@@ -2,11 +2,15 @@
  * HeatmapWidget — Wave 2 Phase C (dashboard.md §4 드릴다운 히트맵 v3).
  * Colored grid table. xAxis state is LOCAL (independent from assignee stats).
  * Reuses GridTable for intensity shading.
+ * P1-2: Breadcrumb left of title. P0-2: Click-through nav to /voc.
  */
+import { useNavigate } from 'react-router-dom';
 import { Skeleton } from '@shared/ui/skeleton';
 import type { HeatmapXAxis } from '@contracts/dashboard';
 import { useHeatmap } from '../model/useHeatmap';
+import { useDashboardFilter } from '../model/dashboardFilter';
 import { GridTable, type GridTableRow } from './GridTable';
+import { buildVocUrl } from './buildVocUrl';
 
 const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
   { id: 'status', label: '상태' },
@@ -15,6 +19,8 @@ const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
 ];
 
 export function HeatmapWidget() {
+  const navigate = useNavigate();
+  const { filter, systemName, setSystemName, menuName, setMenuName, patch } = useDashboardFilter();
   const { data, isLoading, isError, refetch, xAxis, setXAxis } = useHeatmap();
 
   const rows: GridTableRow[] = data?.rows.map((r) => ({
@@ -25,6 +31,37 @@ export function HeatmapWidget() {
     isClickable: r.level === 'system',
   })) ?? [];
 
+  /** Determine breadcrumb tier based on current filter */
+  const hasSystem = !!filter.systemId;
+  const hasMenu = !!filter.menuId;
+
+  function handleCellClick(rowId: string | null, colIndex: number) {
+    if (rowId === null) return;
+    const colKey = data?.headers[colIndex];
+    if (!colKey) return;
+    // xAxis determines what the column key represents
+    const widgetParams: Record<string, string> = {};
+    if (xAxis === 'status') widgetParams.status = colKey;
+    else if (xAxis === 'priority') widgetParams.priority = colKey;
+    else if (xAxis === 'tag') widgetParams.tag = colKey;
+    // Row key is system or menu id
+    if (hasSystem) widgetParams.menuId = rowId;
+    else widgetParams.systemId = rowId;
+    navigate(buildVocUrl(widgetParams, filter));
+  }
+
+  function handleRowClick(rowId: string | null) {
+    if (!rowId) return;
+    const row = data?.rows.find((r) => r.id === rowId);
+    if (!row) return;
+    // Drill down: system row → set systemId; menu row → set menuId
+    if (!hasSystem) {
+      patch({ systemId: rowId });
+      setSystemName(row.name);
+      setMenuName(undefined);
+    }
+  }
+
   return (
     <div
       data-testid="widget-heatmap"
@@ -32,8 +69,63 @@ export function HeatmapWidget() {
       className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
     >
       <div className="flex items-center justify-between gap-2">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
-          히트맵
+        {/* Breadcrumb + title */}
+        <div className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.07em]">
+          {/* 전체 tier */}
+          {!hasSystem && (
+            <span className="text-[var(--text-quaternary)]" data-testid="heatmap-breadcrumb-root">전체</span>
+          )}
+          {/* 시스템 tier */}
+          {hasSystem && !hasMenu && (
+            <>
+              <button
+                type="button"
+                data-testid="heatmap-breadcrumb-all"
+                className="text-[var(--text-quaternary)] hover:text-[var(--brand)] transition-colors"
+                onClick={() => {
+                  patch({ systemId: undefined, menuId: undefined });
+                  setSystemName(undefined);
+                  setMenuName(undefined);
+                }}
+              >
+                전체
+              </button>
+              <span className="text-[var(--text-quaternary)]">›</span>
+              <span className="text-[var(--text-secondary)]" data-testid="heatmap-breadcrumb-system">{systemName ?? '시스템'}</span>
+            </>
+          )}
+          {/* 메뉴 tier */}
+          {hasSystem && hasMenu && (
+            <>
+              <button
+                type="button"
+                data-testid="heatmap-breadcrumb-all"
+                className="text-[var(--text-quaternary)] hover:text-[var(--brand)] transition-colors"
+                onClick={() => {
+                  patch({ systemId: undefined, menuId: undefined });
+                  setSystemName(undefined);
+                  setMenuName(undefined);
+                }}
+              >
+                전체
+              </button>
+              <span className="text-[var(--text-quaternary)]">›</span>
+              <button
+                type="button"
+                data-testid="heatmap-breadcrumb-system"
+                className="text-[var(--text-quaternary)] hover:text-[var(--brand)] transition-colors"
+                onClick={() => {
+                  patch({ menuId: undefined });
+                  setMenuName(undefined);
+                }}
+              >
+                {systemName ?? '시스템'}
+              </button>
+              <span className="text-[var(--text-quaternary)]">›</span>
+              <span className="text-[var(--text-secondary)]" data-testid="heatmap-breadcrumb-menu">{menuName ?? '메뉴'}</span>
+            </>
+          )}
+          <span className="ml-1 text-[var(--text-quaternary)]">히트맵</span>
         </div>
         <div className="flex gap-1">
           {X_AXIS_OPTIONS.map((opt) => (
@@ -74,7 +166,7 @@ export function HeatmapWidget() {
 
       {data && rows.length === 0 && (
         <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
-          데이터 없음
+          해당 기간 데이터 없음
         </div>
       )}
 
@@ -85,6 +177,8 @@ export function HeatmapWidget() {
             rows={rows}
             maxValue={data.max_value}
             totalRow={data.totalRow}
+            onCellClick={handleCellClick}
+            onRowClick={handleRowClick}
           />
         </div>
       )}

--- a/frontend/src/features/dashboard/widgets/HeatmapWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/HeatmapWidget.tsx
@@ -1,0 +1,93 @@
+/**
+ * HeatmapWidget — Wave 2 Phase C (dashboard.md §4 드릴다운 히트맵 v3).
+ * Colored grid table. xAxis state is LOCAL (independent from assignee stats).
+ * Reuses GridTable for intensity shading.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import type { HeatmapXAxis } from '@contracts/dashboard';
+import { useHeatmap } from '../model/useHeatmap';
+import { GridTable, type GridTableRow } from './GridTable';
+
+const X_AXIS_OPTIONS: { id: HeatmapXAxis; label: string }[] = [
+  { id: 'status', label: '상태' },
+  { id: 'priority', label: '우선순위' },
+  { id: 'tag', label: '태그' },
+];
+
+export function HeatmapWidget() {
+  const { data, isLoading, isError, refetch, xAxis, setXAxis } = useHeatmap();
+
+  const rows: GridTableRow[] = data?.rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    values: r.values,
+    total: r.total,
+    isClickable: r.level === 'system',
+  })) ?? [];
+
+  return (
+    <div
+      data-testid="widget-heatmap"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+          히트맵
+        </div>
+        <div className="flex gap-1">
+          {X_AXIS_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setXAxis(opt.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                xAxis === opt.id
+                  ? 'bg-[var(--brand)] text-[var(--text-on-brand)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="heatmap-loading">
+          {Array.from({ length: 4 }, (_, i) => <Skeleton key={i} className="h-8" />)}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && rows.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && (rows.length > 0 || data.totalRow) && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <GridTable
+            headers={data.headers}
+            rows={rows}
+            maxValue={data.max_value}
+            totalRow={data.totalRow}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/PriorityStatusMatrixWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/PriorityStatusMatrixWidget.tsx
@@ -1,0 +1,76 @@
+/**
+ * PriorityStatusMatrixWidget — Wave 2 Phase C (dashboard.md §3).
+ * 4×5 colored grid: priority rows × status cols.
+ * Reuses GridTable for intensity-shaded rendering.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import type { MatrixPriority } from '@contracts/dashboard';
+import { usePriorityStatusMatrix } from '../model/usePriorityStatusMatrix';
+import { GridTable, type GridTableRow } from './GridTable';
+
+const PRIORITY_LABELS: Record<MatrixPriority, string> = {
+  urgent: '긴급',
+  high: '높음',
+  medium: '보통',
+  low: '낮음',
+};
+
+export function PriorityStatusMatrixWidget() {
+  const { data, isLoading, isError, refetch } = usePriorityStatusMatrix();
+
+  const rows: GridTableRow[] = data?.rows.map((r) => ({
+    id: r.priority,
+    name: PRIORITY_LABELS[r.priority],
+    values: data.columns.map((col) => r.cells[col] ?? 0),
+    total: r.row_total,
+    isClickable: true,
+  })) ?? [];
+
+  return (
+    <div
+      data-testid="widget-priority-status-matrix"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+        우선순위 × 상태
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="matrix-loading">
+          <Skeleton className="h-8" />
+          {Array.from({ length: 4 }, (_, i) => <Skeleton key={i} className="h-8" />)}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && rows.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && rows.length > 0 && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <GridTable
+            headers={data.columns}
+            rows={rows}
+            maxValue={data.max_value}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/PriorityStatusMatrixWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/PriorityStatusMatrixWidget.tsx
@@ -2,11 +2,15 @@
  * PriorityStatusMatrixWidget — Wave 2 Phase C (dashboard.md §3).
  * 4×5 colored grid: priority rows × status cols.
  * Reuses GridTable for intensity-shaded rendering.
+ * P0-2: Cell click → /voc?priority=<P>&status=<S>&...globalFilter. Empty cells not clickable.
  */
+import { useNavigate } from 'react-router-dom';
 import { Skeleton } from '@shared/ui/skeleton';
 import type { MatrixPriority } from '@contracts/dashboard';
 import { usePriorityStatusMatrix } from '../model/usePriorityStatusMatrix';
+import { useDashboardFilter } from '../model/dashboardFilter';
 import { GridTable, type GridTableRow } from './GridTable';
+import { buildVocUrl } from './buildVocUrl';
 
 const PRIORITY_LABELS: Record<MatrixPriority, string> = {
   urgent: '긴급',
@@ -15,7 +19,17 @@ const PRIORITY_LABELS: Record<MatrixPriority, string> = {
   low: '낮음',
 };
 
+// Reverse map for label→priority key (used for navigation)
+const LABEL_TO_PRIORITY: Record<string, MatrixPriority> = {
+  긴급: 'urgent',
+  높음: 'high',
+  보통: 'medium',
+  낮음: 'low',
+};
+
 export function PriorityStatusMatrixWidget() {
+  const navigate = useNavigate();
+  const { filter } = useDashboardFilter();
   const { data, isLoading, isError, refetch } = usePriorityStatusMatrix();
 
   const rows: GridTableRow[] = data?.rows.map((r) => ({
@@ -25,6 +39,15 @@ export function PriorityStatusMatrixWidget() {
     total: r.row_total,
     isClickable: true,
   })) ?? [];
+
+  function handleCellClick(rowId: string | null, colIndex: number) {
+    if (!rowId || !data) return;
+    const status = data.columns[colIndex];
+    if (!status) return;
+    // Count check — only clickable if cell has value (GridTable enforces v > 0 guard)
+    const priorityKey = LABEL_TO_PRIORITY[rowId] ?? rowId;
+    navigate(buildVocUrl({ priority: priorityKey, status }, filter));
+  }
 
   return (
     <div
@@ -68,6 +91,7 @@ export function PriorityStatusMatrixWidget() {
             headers={data.columns}
             rows={rows}
             maxValue={data.max_value}
+            onCellClick={handleCellClick}
           />
         </div>
       )}

--- a/frontend/src/features/dashboard/widgets/ProcessingSpeedWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/ProcessingSpeedWidget.tsx
@@ -1,0 +1,144 @@
+/**
+ * ProcessingSpeedWidget — Wave 2 Phase C (dashboard.md §10 처리속도 SLA).
+ * Table + SLA rate progress bar per row. Color thresholds: ≥80% green, 60–79% amber, <60% red.
+ */
+import { Skeleton } from '@shared/ui/skeleton';
+import type { ProcessingSpeedDim } from '@contracts/dashboard';
+import { useProcessingSpeed } from '../model/useProcessingSpeed';
+
+const DIM_OPTIONS: { id: ProcessingSpeedDim; label: string }[] = [
+  { id: 'all', label: '전체' },
+  { id: 'system', label: '시스템' },
+  { id: 'menu', label: '메뉴' },
+];
+
+function slaColor(rate: number | null): string {
+  if (rate === null) return 'var(--text-quaternary)';
+  if (rate >= 80) return 'var(--chart-emerald)';
+  if (rate >= 60) return 'var(--chart-amber)';
+  return 'var(--chart-red)';
+}
+
+function slaBarColor(rate: number | null): string {
+  if (rate === null) return 'var(--border-subtle)';
+  if (rate >= 80) return 'var(--chart-emerald)';
+  if (rate >= 60) return 'var(--chart-amber)';
+  return 'var(--chart-red)';
+}
+
+export function ProcessingSpeedWidget() {
+  const { data, isLoading, isError, refetch, dim, setDim } = useProcessingSpeed();
+
+  return (
+    <div
+      data-testid="widget-processing-speed"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+          처리속도 / SLA
+        </div>
+        <div className="flex gap-1">
+          {DIM_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setDim(opt.id)}
+              className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+                dim === opt.id
+                  ? 'bg-[var(--brand)] text-[var(--text-on-brand)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex flex-1 flex-col gap-2" data-testid="speed-loading">
+          {Array.from({ length: 3 }, (_, i) => <Skeleton key={i} className="h-10" />)}
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && data.rows.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && data.rows.length > 0 && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-[var(--border-subtle)] text-[var(--text-quaternary)]">
+                <th className="py-2 text-left font-medium">항목</th>
+                <th className="py-2 text-right font-medium">평균처리일</th>
+                <th className="py-2 text-right font-medium">완료건</th>
+                <th className="py-2 text-center font-medium w-28">SLA 준수율</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row) => (
+                <tr
+                  key={row.id ?? 'total'}
+                  className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]"
+                >
+                  <td className="py-2 text-[var(--text-primary)] truncate max-w-[120px]">{row.name}</td>
+                  <td className="py-2 text-right tabular-nums text-[var(--text-secondary)]">
+                    {row.avg_days !== null ? `${row.avg_days.toFixed(1)}일` : '—'}
+                  </td>
+                  <td className="py-2 text-right tabular-nums text-[var(--text-secondary)]">
+                    {row.completed_count}
+                  </td>
+                  <td className="py-2">
+                    {row.sla_rate !== null ? (
+                      <div className="flex flex-col gap-0.5">
+                        <div className="flex justify-between">
+                          <span style={{ color: slaColor(row.sla_rate) }} className="font-semibold tabular-nums">
+                            {row.sla_rate.toFixed(1)}%
+                          </span>
+                        </div>
+                        <div className="h-1.5 w-full rounded-full bg-[var(--border-subtle)]">
+                          <div
+                            className="h-1.5 rounded-full transition-all"
+                            style={{
+                              width: `${Math.min(100, row.sla_rate)}%`,
+                              backgroundColor: slaBarColor(row.sla_rate),
+                            }}
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="text-[var(--text-quaternary)]">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {data.rows.some((r) => r.missingDueDateCount > 0) && (
+            <p className="mt-2 text-[10px] text-[var(--text-quaternary)]">
+              * due_date 미설정 VOC 포함됨
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/ProcessingSpeedWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/ProcessingSpeedWidget.tsx
@@ -14,16 +14,16 @@ const DIM_OPTIONS: { id: ProcessingSpeedDim; label: string }[] = [
 
 function slaColor(rate: number | null): string {
   if (rate === null) return 'var(--text-quaternary)';
-  if (rate >= 80) return 'var(--chart-emerald)';
-  if (rate >= 60) return 'var(--chart-amber)';
-  return 'var(--chart-red)';
+  if (rate >= 80) return 'var(--status-green)';
+  if (rate >= 60) return 'var(--status-amber)';
+  return 'var(--status-red)';
 }
 
 function slaBarColor(rate: number | null): string {
   if (rate === null) return 'var(--border-subtle)';
-  if (rate >= 80) return 'var(--chart-emerald)';
-  if (rate >= 60) return 'var(--chart-amber)';
-  return 'var(--chart-red)';
+  if (rate >= 80) return 'var(--status-green)';
+  if (rate >= 60) return 'var(--status-amber)';
+  return 'var(--status-red)';
 }
 
 export function ProcessingSpeedWidget() {

--- a/frontend/src/features/dashboard/widgets/WeeklyTrendWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/WeeklyTrendWidget.tsx
@@ -2,6 +2,7 @@
  * WeeklyTrendWidget — Wave 2 Phase C (dashboard.md §5 주간 트렌드 v3).
  * 3-line recharts LineChart: 신규 / 진입(검토중+처리중) / 완료.
  * 12-week fixed window — ignores global date range.
+ * P0-2: Point click navigates to /voc with series-specific params.
  */
 import {
   LineChart,
@@ -13,18 +14,56 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { useNavigate } from 'react-router-dom';
 import { Skeleton } from '@shared/ui/skeleton';
 import { useWeeklyTrend } from '../model/useWeeklyTrend';
+import { useDashboardFilter } from '../model/dashboardFilter';
+import { buildVocUrl } from './buildVocUrl';
+
+/** Add N days to an ISO date string and return ISO date string. */
+function addDays(isoDate: string, n: number): string {
+  const d = new Date(isoDate);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
 
 export function WeeklyTrendWidget() {
+  const navigate = useNavigate();
+  const { filter } = useDashboardFilter();
   const { data, isLoading, isError, refetch } = useWeeklyTrend();
 
   const chartData = data?.weeks.map((week, i) => ({
     week,
+    weekIndex: i,
     신규: data.series.new[i],
     처리진입: data.series.enteredInProgress[i],
     완료: data.series.done[i],
   })) ?? [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function handleDotClick(seriesKey: '신규' | '처리진입' | '완료', payload: any) {
+    if (!data || payload?.weekIndex === undefined) return;
+    const weekStart = data.weekStarts[payload.weekIndex as number];
+    if (!weekStart) return;
+    const weekEnd = addDays(weekStart, 6);
+
+    let widgetParams: Record<string, string> = {};
+    if (seriesKey === '신규') {
+      widgetParams = { startDate: weekStart, endDate: weekEnd };
+    } else if (seriesKey === '처리진입') {
+      widgetParams = { status: '검토중,처리중', snapshotDate: weekEnd };
+    } else {
+      // 완료
+      widgetParams = { status: '완료,드랍', startDate: weekStart, endDate: weekEnd };
+    }
+    navigate(buildVocUrl(widgetParams, filter));
+  }
+
+  // Recharts active dot click handler factory per series
+  function makeDotClickHandler(seriesKey: '신규' | '처리진입' | '완료') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (_: any, payload: any) => handleDotClick(seriesKey, payload);
+  }
 
   return (
     <div
@@ -93,9 +132,30 @@ export function WeeklyTrendWidget() {
                   <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{value}</span>
                 )}
               />
-              <Line type="monotone" dataKey="신규" stroke="var(--chart-blue)" strokeWidth={2} dot={false} />
-              <Line type="monotone" dataKey="처리진입" stroke="var(--chart-amber)" strokeWidth={2} dot={false} />
-              <Line type="monotone" dataKey="완료" stroke="var(--chart-emerald)" strokeWidth={2} dot={false} />
+              <Line
+                type="monotone"
+                dataKey="신규"
+                stroke="var(--chart-blue)"
+                strokeWidth={2}
+                dot={{ r: 3, cursor: 'pointer' }}
+                activeDot={{ r: 5, cursor: 'pointer', onClick: makeDotClickHandler('신규') }}
+              />
+              <Line
+                type="monotone"
+                dataKey="처리진입"
+                stroke="var(--chart-amber)"
+                strokeWidth={2}
+                dot={{ r: 3, cursor: 'pointer' }}
+                activeDot={{ r: 5, cursor: 'pointer', onClick: makeDotClickHandler('처리진입') }}
+              />
+              <Line
+                type="monotone"
+                dataKey="완료"
+                stroke="var(--chart-emerald)"
+                strokeWidth={2}
+                dot={{ r: 3, cursor: 'pointer' }}
+                activeDot={{ r: 5, cursor: 'pointer', onClick: makeDotClickHandler('완료') }}
+              />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/features/dashboard/widgets/WeeklyTrendWidget.tsx
+++ b/frontend/src/features/dashboard/widgets/WeeklyTrendWidget.tsx
@@ -1,0 +1,105 @@
+/**
+ * WeeklyTrendWidget — Wave 2 Phase C (dashboard.md §5 주간 트렌드 v3).
+ * 3-line recharts LineChart: 신규 / 진입(검토중+처리중) / 완료.
+ * 12-week fixed window — ignores global date range.
+ */
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { Skeleton } from '@shared/ui/skeleton';
+import { useWeeklyTrend } from '../model/useWeeklyTrend';
+
+export function WeeklyTrendWidget() {
+  const { data, isLoading, isError, refetch } = useWeeklyTrend();
+
+  const chartData = data?.weeks.map((week, i) => ({
+    week,
+    신규: data.series.new[i],
+    처리진입: data.series.enteredInProgress[i],
+    완료: data.series.done[i],
+  })) ?? [];
+
+  return (
+    <div
+      data-testid="widget-weekly-trend"
+      aria-busy={isLoading}
+      className="flex h-full flex-col gap-2 rounded-lg border border-[var(--border-standard)] bg-[var(--bg-panel)] p-4"
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-[0.07em] text-[var(--text-quaternary)]">
+        주간 트렌드 (최근 12주)
+      </div>
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex-1" data-testid="trend-loading">
+          <Skeleton className="h-full" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--text-tertiary)]">
+          <span>데이터를 불러오지 못했습니다</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded border border-[var(--border-subtle)] px-2 py-0.5 text-xs hover:bg-[var(--bg-elevated)]"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {data && chartData.length === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm text-[var(--text-quaternary)]">
+          데이터 없음
+        </div>
+      )}
+
+      {data && chartData.length > 0 && (
+        <div className="flex-1 min-h-0">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border-subtle)" />
+              <XAxis
+                dataKey="week"
+                tick={{ fontSize: 11, fill: 'var(--text-quaternary)' }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: 'var(--text-quaternary)' }}
+                tickLine={false}
+                axisLine={false}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: 'var(--bg-panel)',
+                  border: '1px solid var(--border-subtle)',
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+              />
+              <Legend
+                iconType="circle"
+                iconSize={8}
+                formatter={(value) => (
+                  <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>{value}</span>
+                )}
+              />
+              <Line type="monotone" dataKey="신규" stroke="var(--chart-blue)" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="처리진입" stroke="var(--chart-amber)" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="완료" stroke="var(--chart-emerald)" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/widgets/buildVocUrl.ts
+++ b/frontend/src/features/dashboard/widgets/buildVocUrl.ts
@@ -1,0 +1,44 @@
+/**
+ * buildVocUrl — Wave 2 Phase C review fix (P0-2).
+ * Builds /voc navigation URLs preserving globalFilter context.
+ * Used by dashboard widgets for click-through navigation.
+ */
+import type { DashboardFilter } from '@contracts/dashboard';
+
+/** Keys from DashboardFilter that map 1:1 to /voc search params. */
+const GLOBAL_FILTER_KEYS: (keyof DashboardFilter)[] = [
+  'systemId',
+  'menuId',
+  'assigneeId',
+  'startDate',
+  'endDate',
+];
+
+/**
+ * Build a /voc URL with the given widget-specific params merged with
+ * the current dashboard globalFilter. undefined values are omitted.
+ */
+export function buildVocUrl(
+  widgetParams: Record<string, string | undefined>,
+  globalFilter: DashboardFilter,
+): string {
+  const params = new URLSearchParams();
+
+  // Widget-specific params first (they may override global)
+  for (const [key, val] of Object.entries(widgetParams)) {
+    if (val !== undefined && val !== '') {
+      params.set(key, val);
+    }
+  }
+
+  // Preserve global filter — do NOT override if widget already set the key
+  for (const key of GLOBAL_FILTER_KEYS) {
+    const val = globalFilter[key];
+    if (val !== undefined && val !== '' && !params.has(key)) {
+      params.set(key, String(val));
+    }
+  }
+
+  const qs = params.toString();
+  return qs ? `/voc?${qs}` : '/voc';
+}

--- a/frontend/src/test/mocks/handlers/dashboard-phase-c.ts
+++ b/frontend/src/test/mocks/handlers/dashboard-phase-c.ts
@@ -1,0 +1,116 @@
+/**
+ * MSW handlers for /api/dashboard/* Phase C endpoints.
+ * Deterministic seed data — zod-validated against locked contracts.
+ */
+import { http, HttpResponse } from 'msw';
+import {
+  DistributionResponse,
+  PriorityStatusMatrixResponse,
+  HeatmapResponse,
+  WeeklyTrendResponse,
+  ProcessingSpeedResponse,
+  AssigneeStatsResponse,
+  AgingVocsResponse,
+} from '@contracts/dashboard';
+
+// ── 1. Distribution ──────────────────────────────────────────────────────────
+const DEMO_DISTRIBUTION = DistributionResponse.parse({
+  type: 'status',
+  dim: 'all',
+  total: 42,
+  items: [
+    { label: '접수', key: '접수', count: 12, percentage: 28.6 },
+    { label: '검토중', key: '검토중', count: 9, percentage: 21.4 },
+    { label: '처리중', key: '처리중', count: 11, percentage: 26.2 },
+    { label: '완료', key: '완료', count: 7, percentage: 16.7 },
+    { label: '드랍', key: '드랍', count: 3, percentage: 7.1 },
+  ],
+});
+
+// ── 2. Priority-Status Matrix ─────────────────────────────────────────────────
+const DEMO_MATRIX = PriorityStatusMatrixResponse.parse({
+  columns: ['접수', '검토중', '처리중', '완료', '드랍'],
+  max_value: 8,
+  rows: [
+    { priority: 'urgent', cells: { 접수: 2, 검토중: 3, 처리중: 1, 완료: 0, 드랍: 0 }, row_total: 6 },
+    { priority: 'high',   cells: { 접수: 4, 검토중: 2, 처리중: 8, 완료: 3, 드랍: 1 }, row_total: 18 },
+    { priority: 'medium', cells: { 접수: 5, 검토중: 2, 처리중: 3, 완료: 2, 드랍: 1 }, row_total: 13 },
+    { priority: 'low',    cells: { 접수: 1, 검토중: 2, 처리중: 1, 완료: 2, 드랍: 1 }, row_total: 7 },
+  ],
+});
+
+// ── 3. Heatmap ────────────────────────────────────────────────────────────────
+const DEMO_HEATMAP = HeatmapResponse.parse({
+  headers: ['접수', '검토중', '처리중', '완료', '드랍'],
+  totalRow: [22, 9, 13, 7, 5, 56],
+  max_value: 14,
+  rows: [
+    { id: '11111111-0000-0000-0000-000000000001', name: '결제 시스템', level: 'system', values: [8, 4, 7, 3, 2], total: 24 },
+    { id: '11111111-0000-0000-0000-000000000002', name: '회원 시스템', level: 'system', values: [9, 3, 4, 2, 2], total: 20 },
+    { id: '11111111-0000-0000-0000-000000000003', name: '상품 시스템', level: 'system', values: [5, 2, 2, 2, 1], total: 12 },
+  ],
+});
+
+// ── 4. Weekly Trend ───────────────────────────────────────────────────────────
+const W_LABELS = ['W1','W2','W3','W4','W5','W6','W7','W8','W9','W10','W11','W12'];
+const W_STARTS = [
+  '2026-02-23','2026-03-02','2026-03-09','2026-03-16',
+  '2026-03-23','2026-03-30','2026-04-06','2026-04-13',
+  '2026-04-20','2026-04-27','2026-05-04','2026-05-11',
+];
+const DEMO_TREND = WeeklyTrendResponse.parse({
+  weeks: W_LABELS,
+  weekStarts: W_STARTS,
+  series: {
+    new:              [12, 9, 15, 11, 8, 13, 10, 14, 7, 11, 9, 13],
+    enteredInProgress:[7,  5,  9,  8,  6,  7,  8,  9,  5,  8,  7,  9],
+    done:             [5,  8,  7, 10,  6,  9,  7,  8,  6,  9,  8, 10],
+  },
+});
+
+// ── 5. Processing Speed ───────────────────────────────────────────────────────
+const DEMO_SPEED = ProcessingSpeedResponse.parse({
+  dim: 'all',
+  rows: [
+    { id: null,                                      name: '전체',      avg_days: 4.2, sla_rate: 82.1, completed_count: 28, slaEligibleCount: 22, missingDueDateCount: 6 },
+    { id: '11111111-0000-0000-0000-000000000001', name: '결제 시스템', avg_days: 3.5, sla_rate: 91.0, completed_count: 11, slaEligibleCount: 10, missingDueDateCount: 1 },
+    { id: '11111111-0000-0000-0000-000000000002', name: '회원 시스템', avg_days: 5.1, sla_rate: 66.7, completed_count: 9,  slaEligibleCount: 6,  missingDueDateCount: 3 },
+    { id: '11111111-0000-0000-0000-000000000003', name: '상품 시스템', avg_days: 4.8, sla_rate: null, completed_count: 8,  slaEligibleCount: 0,  missingDueDateCount: 8 },
+  ],
+});
+
+// ── 6. Assignee Stats ─────────────────────────────────────────────────────────
+const DEMO_ASSIGNEE = AssigneeStatsResponse.parse({
+  headers: ['접수', '검토중', '처리중', '완료', '드랍'],
+  max_value: 9,
+  rows: [
+    { id: 'aaaaaaaa-0000-0000-0000-000000000001', name: '김철수', is_unassigned: false, values: [3, 2, 4, 1, 0], total: 10 },
+    { id: 'aaaaaaaa-0000-0000-0000-000000000002', name: '이영희', is_unassigned: false, values: [5, 3, 9, 2, 1], total: 20 },
+    { id: 'aaaaaaaa-0000-0000-0000-000000000003', name: '박민준', is_unassigned: false, values: [2, 1, 3, 3, 1], total: 10 },
+    { id: null, name: '미배정', is_unassigned: true, values: [2, 3, 1, 1, 1], total: 8 },
+  ],
+});
+
+// ── 7. Aging VOCs ─────────────────────────────────────────────────────────────
+const DEMO_AGING = AgingVocsResponse.parse({
+  dim: 'all',
+  items: [
+    { voc_id: 'bbbbbbbb-0000-0000-0000-000000000001', issue_code: 'VOC-0421', title: '결제 오류 반복 발생', priority: 'urgent', elapsed_days: 42, system_name: '결제 시스템', menu_name: null },
+    { voc_id: 'bbbbbbbb-0000-0000-0000-000000000002', issue_code: 'VOC-0398', title: '로그인 세션 만료 이슈', priority: 'high',   elapsed_days: 35, system_name: '회원 시스템', menu_name: null },
+    { voc_id: 'bbbbbbbb-0000-0000-0000-000000000003', issue_code: 'VOC-0412', title: '상품 목록 로딩 지연', priority: 'medium', elapsed_days: 28, system_name: '상품 시스템', menu_name: null },
+    { voc_id: 'bbbbbbbb-0000-0000-0000-000000000004', issue_code: 'VOC-0435', title: '환불 처리 미완료', priority: 'high',   elapsed_days: 18, system_name: '결제 시스템', menu_name: null },
+    { voc_id: 'bbbbbbbb-0000-0000-0000-000000000005', issue_code: 'VOC-0441', title: '회원가입 이메일 미발송', priority: 'medium', elapsed_days: 9, system_name: '회원 시스템', menu_name: null },
+  ],
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const dashboardPhaseCHandlers = [
+  http.get('/api/dashboard/distribution', () => HttpResponse.json(DEMO_DISTRIBUTION)),
+  http.get('/api/dashboard/priority-status-matrix', () => HttpResponse.json(DEMO_MATRIX)),
+  http.get('/api/dashboard/heatmap', () => HttpResponse.json(DEMO_HEATMAP)),
+  http.get('/api/dashboard/weekly-trend', () => HttpResponse.json(DEMO_TREND)),
+  http.get('/api/dashboard/processing-speed', () => HttpResponse.json(DEMO_SPEED)),
+  http.get('/api/dashboard/assignee-stats', () => HttpResponse.json(DEMO_ASSIGNEE)),
+  http.get('/api/dashboard/aging-vocs', () => HttpResponse.json(DEMO_AGING)),
+];

--- a/frontend/src/test/mocks/handlers/index.ts
+++ b/frontend/src/test/mocks/handlers/index.ts
@@ -11,6 +11,7 @@ import { adminTrashHandlers } from './admin-trash';
 import { adminUsersHandlers } from './admin-users';
 import { adminMastersHandlers } from './admin-masters';
 import { dashboardHandlers } from './dashboard';
+import { dashboardPhaseCHandlers } from './dashboard-phase-c';
 
 export const handlers = [
   ...healthHandlers,
@@ -26,4 +27,5 @@ export const handlers = [
   ...adminUsersHandlers,
   ...adminMastersHandlers,
   ...dashboardHandlers,
+  ...dashboardPhaseCHandlers,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "react-dom": "^18.3.1",
         "react-grid-layout": "^2.2.3",
         "react-router-dom": "^7.14.2",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.4.1"
@@ -3073,6 +3074,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "dev": true,
@@ -3128,6 +3165,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tabby_ai/hijri-converter": {
       "version": "1.0.5",
@@ -3491,6 +3540,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
@@ -3790,6 +3902,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -5708,6 +5826,127 @@
       "integrity": "sha512-g+Dgy1ZSAKTgWIl2jhpr6K3keFic8aapOFlVh74eoBYPbjGq5lMdEzANG5w6hFX1fzQBsaAzhuTYICRjyt4OcA==",
       "license": "OFL"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "dev": true,
@@ -5770,6 +6009,12 @@
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6190,6 +6435,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "dev": true,
@@ -6540,7 +6795,6 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -7612,6 +7866,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.3.8",
       "dev": true,
@@ -7694,6 +7958,15 @@
       "version": "1.3.8",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -10979,8 +11252,30 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -11159,6 +11454,36 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "dev": true,
@@ -11169,6 +11494,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -11191,6 +11531,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
@@ -12676,6 +13022,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
@@ -13227,6 +13579,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {


### PR DESCRIPTION
## Summary

Wave 2 Phase C frontend implementation: 7 dashboard content widgets, recharts dependency, MSW handlers, and full test coverage.

### Widget → Component → Endpoint bindings

| widgetId | Component | Endpoint |
|---|---|---|
| `dist-matrix` | `DistributionWidget` | `GET /api/dashboard/distribution` |
| `heatmap` | `HeatmapWidget` | `GET /api/dashboard/heatmap` |
| `trend-tag` | `WeeklyTrendWidget` | `GET /api/dashboard/weekly-trend` |
| `sla-aging` | `ProcessingSpeedWidget` | `GET /api/dashboard/processing-speed` |
| `assignee` | `AssigneeStatsWidget` | `GET /api/dashboard/assignee-stats` |
| `aging-top10` | `AgingVocsWidget` | `GET /api/dashboard/aging-vocs` |

Note: `dist-matrix` slot serves `DistributionWidget` only (single widgetId per `defaultLayouts.ts`). `PriorityStatusMatrixWidget` is implemented but not slotted in RGL — will be composed in Phase D if a separate slot is added.

### Changes

**Dependencies:** `recharts@^3.8.1` added to `frontend/` workspace.

**New files (widgets):** `DistributionWidget`, `PriorityStatusMatrixWidget`, `HeatmapWidget`, `WeeklyTrendWidget`, `ProcessingSpeedWidget`, `AssigneeStatsWidget`, `AgingVocsWidget`, `GridTable` (shared intensity-shaded grid used by heatmap/assignee/matrix).

**New files (model):** 7 custom hooks — `useDistribution`, `usePriorityStatusMatrix`, `useHeatmap` (local xAxis state), `useWeeklyTrend` (date range omitted per spec), `useProcessingSpeed`, `useAssigneeStats` (local xAxis state, independent from heatmap), `useAgingVocs` (date range omitted).

**Modified:** `api/queries.ts` (7 new API functions), `api/keys.ts` (7 new query key factories), `DashboardShell.tsx` (Phase C widgets wired by widgetId, no more placeholder for 6 slots).

**MSW:** `dashboard-phase-c.ts` — 7 handlers, fixture data zod-validated against locked contracts. Registered in `handlers/index.ts`.

**Tests:** `GridTable.test.tsx` (intensity interpolation + click behavior), `PhaseC.test.tsx` + `PhaseC-2.test.tsx` (3 smoke tests × 7 widgets), `DashboardShell.test.tsx` updated for Phase C wiring.

### Status

- FE typecheck: 0 errors
- FE lint + token lint: 0 violations
- FE tests: 635 passed (83 test files), +28 new tests
- BE tests: 584 passed (41 suites), unchanged

### Spec deviations / open items

- `PriorityStatusMatrixWidget` is implemented and tested but not in a dedicated RGL slot (defaultLayouts.ts has no `priority-matrix` widgetId). It shares `dist-matrix`. Phase D will clarify if a split is needed — stopping short of adding a new slot without spec confirmation.
- `oklch(63% 0.19 258 / opacity)` literal in `GridTable.tsx` is intentional (spec-literal formula per dashboard.md §3/§4/§8) and suppressed with `// allow-raw-color:` on the same line.
- Recharts renders size warnings in jsdom (zero-width container) — informational stderr only, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)