### PR TITLE
chore(fe): rename useVocFilter hooks + split tag-master into ui/+api/

### DIFF
--- a/frontend/src/features/admin/tag-master/api/tag-master.api.ts
+++ b/frontend/src/features/admin/tag-master/api/tag-master.api.ts
@@ -14,7 +14,7 @@ import {
   TagRuleSuspendInput,
   TagMasterItem,
   type TagMasterListQuery,
-} from '../../../../../shared/contracts/admin/tag';
+} from '@contracts/admin/tag';
 
 const QUERY_KEY = ['admin', 'tags'] as const;
 

--- a/frontend/src/features/admin/tag-master/ui/TagMasterActionButton.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterActionButton.tsx
@@ -2,7 +2,7 @@
  * ActionButton — reusable icon+label button for Tag Master table actions.
  * Disabled state shows "Admin 전용" tooltip.
  */
-export function ActionButton({
+export function TagMasterActionButton({
   icon,
   label,
   enabled,

--- a/frontend/src/features/admin/tag-master/ui/TagMasterCreateModal.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterCreateModal.tsx
@@ -4,8 +4,8 @@
  */
 import { useState } from 'react';
 import { X } from 'lucide-react';
-import { useCreateTag } from './api';
-import type { TagKind } from '../../../../../shared/contracts/admin/tag';
+import { useCreateTag } from '../api/tag-master.api';
+import type { TagKind } from '@contracts/admin/tag';
 
 interface Props {
   onClose: () => void;

--- a/frontend/src/features/admin/tag-master/ui/TagMasterEditModal.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterEditModal.tsx
@@ -3,7 +3,7 @@
  * Only `name` mutable; kind locked per spec.
  */
 import { useState } from 'react';
-import { useRenameTag } from './api';
+import { useRenameTag } from '../api/tag-master.api';
 import {
   ModalOverlay,
   ModalHeader,
@@ -13,7 +13,7 @@ import {
   cancelBtnStyle,
   submitBtnStyle,
 } from './TagMasterCreateModal';
-import type { TagMasterItem } from '../../../../../shared/contracts/admin/tag';
+import type { TagMasterItem } from '@contracts/admin/tag';
 
 interface Props {
   tag: TagMasterItem;

--- a/frontend/src/features/admin/tag-master/ui/TagMasterMergeModal.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterMergeModal.tsx
@@ -4,7 +4,7 @@
  * 409/404/400 shown inline.
  */
 import { useState } from 'react';
-import { useMergeTag } from './api';
+import { useMergeTag } from '../api/tag-master.api';
 import {
   ModalOverlay,
   ModalHeader,
@@ -14,7 +14,7 @@ import {
   cancelBtnStyle,
   submitBtnStyle,
 } from './TagMasterCreateModal';
-import type { TagMasterItem } from '../../../../../shared/contracts/admin/tag';
+import type { TagMasterItem } from '@contracts/admin/tag';
 
 interface Props {
   source: TagMasterItem;

--- a/frontend/src/features/admin/tag-master/ui/TagMasterRow.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterRow.tsx
@@ -3,8 +3,8 @@
  * Extracted to keep TagMasterTable under the 200-line limit.
  */
 import { Lock, Pencil, GitMerge, PauseCircle, Trash2 } from 'lucide-react';
-import { ActionButton } from './ActionButton';
-import type { TagMasterItem } from '../../../../../shared/contracts/admin/tag';
+import { TagMasterActionButton } from './TagMasterActionButton';
+import type { TagMasterItem } from '@contracts/admin/tag';
 
 interface Props {
   tag: TagMasterItem;
@@ -60,14 +60,14 @@ export function TagMasterRow({
       </td>
       <td style={{ padding: '10px 12px' }}>
         <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
-          <ActionButton
+          <TagMasterActionButton
             icon={<Pencil size={13} />}
             label="편집"
             enabled={canMutate}
             onClick={() => onEdit(tag)}
             testId={`btn-edit-${tag.id}`}
           />
-          <ActionButton
+          <TagMasterActionButton
             icon={<GitMerge size={13} />}
             label="병합"
             enabled={isAdmin}
@@ -79,14 +79,14 @@ export function TagMasterRow({
             (Codex P2 — tag.id 를 rule id 자리에 넘기는 오매핑.)
             규칙 선택 UI 가 들어올 때까지 disabled placeholder.
           */}
-          <ActionButton
+          <TagMasterActionButton
             icon={<PauseCircle size={13} />}
             label="일시중지"
             enabled={false}
             onClick={() => onSuspend(tag.id)}
             testId={`btn-suspend-${tag.id}`}
           />
-          <ActionButton
+          <TagMasterActionButton
             icon={<Trash2 size={13} />}
             label="삭제"
             enabled={isAdmin}

--- a/frontend/src/features/admin/tag-master/ui/TagMasterSuspendModal.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterSuspendModal.tsx
@@ -3,7 +3,7 @@
  * suspended_until = null → resume immediately.
  */
 import { useState } from 'react';
-import { useSuspendTagRule } from './api';
+import { useSuspendTagRule } from '../api/tag-master.api';
 import {
   ModalOverlay,
   ModalHeader,

--- a/frontend/src/features/admin/tag-master/ui/TagMasterTable.tsx
+++ b/frontend/src/features/admin/tag-master/ui/TagMasterTable.tsx
@@ -11,13 +11,13 @@
 import { useState } from 'react';
 import { Tag, Plus } from 'lucide-react';
 import { useRole } from '@entities/user/model/useRole';
-import { useAdminTags, useDeleteTag, useToggleExternal } from './api';
+import { useAdminTags, useDeleteTag, useToggleExternal } from '../api/tag-master.api';
 import { TagMasterCreateModal } from './TagMasterCreateModal';
 import { TagMasterEditModal } from './TagMasterEditModal';
 import { TagMasterMergeModal } from './TagMasterMergeModal';
 import { TagMasterSuspendModal } from './TagMasterSuspendModal';
 import { TagMasterRow } from './TagMasterRow';
-import type { TagMasterItem as TagMasterItemT } from '../../../../../shared/contracts/admin/tag';
+import type { TagMasterItem as TagMasterItemT } from '@contracts/admin/tag';
 
 export function TagMasterTable() {
   const { isAdmin, isManager } = useRole();

--- a/frontend/src/features/voc/list/index.ts
+++ b/frontend/src/features/voc/list/index.ts
@@ -1,8 +1,8 @@
 export { VocFilterProvider, VocFilterContext } from './model/VocFilterContext';
 export type { VocFilters, VocFilterContextValue, VocStatus } from './model/VocFilterContext';
-export { useVocFilter } from './model/useVocFilter';
-export { useVocFilters } from './model/useVocFilters';
-export type { VocPageFilters } from './model/useVocFilters';
+export { useVocFilterContext } from './model/useVocFilterContext';
+export { useVocFilterUrlState } from './model/useVocFilterUrlState';
+export type { VocPageFilters } from './model/useVocFilterUrlState';
 export { VocListHeader } from './ui/VocListHeader';
 export { VOC_FIELD_LABELS } from '../constants';
 export { VOC_GRID_COLUMNS, VOC_GRID_PADDING_X } from './ui/vocGridLayout';

--- a/frontend/src/features/voc/list/model/useVocFilterContext.ts
+++ b/frontend/src/features/voc/list/model/useVocFilterContext.ts
@@ -2,8 +2,8 @@ import { useContext } from 'react';
 import { VocFilterContext } from './VocFilterContext';
 import type { VocFilterContextValue } from './VocFilterContext';
 
-export function useVocFilter(): VocFilterContextValue {
+export function useVocFilterContext(): VocFilterContextValue {
   const ctx = useContext(VocFilterContext);
-  if (!ctx) throw new Error('useVocFilter must be used within VOCFilterProvider');
+  if (!ctx) throw new Error('useVocFilterContext must be used within VOCFilterProvider');
   return ctx;
 }

--- a/frontend/src/features/voc/list/model/useVocFilterUrlState.ts
+++ b/frontend/src/features/voc/list/model/useVocFilterUrlState.ts
@@ -22,7 +22,7 @@ export interface VocPageFilters {
 const DEFAULT_PER_PAGE = 20;
 
 /** URL ↔ VocFilter+sort+page sync. Multi-status round-trips via repeated keys. */
-export function useVocFilters(): {
+export function useVocFilterUrlState(): {
   state: VocPageFilters;
   setFilter: (next: VocFilter) => void;
   setSort: (sortBy: VocSortColumnT, sortDir: SortDirT) => void;

--- a/frontend/src/features/voc/model/useVocPageController.ts
+++ b/frontend/src/features/voc/model/useVocPageController.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useVocList } from '@features/voc/model/useVocList';
-import { useVocFilters } from '@features/voc/list/model/useVocFilters';
+import { useVocFilterUrlState } from '@features/voc/list/model/useVocFilterUrlState';
 import { useUpdateVoc, useAddNote, useNotes } from '@features/voc/model/useVocMutation';
 import { useRole } from '@entities/user/model/useRole';
 import { useCreateVoc } from '@features/voc/create/model/useCreateVoc';
@@ -14,7 +14,7 @@ import type { NotificationItem } from '@contracts/notification';
 export function useVocPageController() {
   const role = useRole();
   const qc = useQueryClient();
-  const { state, setFilter, setSort, setPage, vocId, setVocId } = useVocFilters();
+  const { state, setFilter, setSort, setPage, vocId, setVocId } = useVocFilterUrlState();
   const { filter, sortBy, sortDir, page, perPage } = state;
   const list = useVocList(filter, sortBy, sortDir, page, perPage);
   const updateVoc = useUpdateVoc();

--- a/frontend/src/pages/admin/__tests__/AdminTagsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AdminTagsPage.test.tsx
@@ -25,7 +25,7 @@ const listTagsMock = vi.fn();
 const deleteTagMock = vi.fn();
 const toggleExternalMock = vi.fn();
 
-vi.mock('@features/admin/tag-master/api', () => ({
+vi.mock('@features/admin/tag-master/api/tag-master.api', () => ({
   useAdminTags: () => listTagsMock(),
   useCreateTag: () => ({ mutate: vi.fn(), isPending: false }),
   useRenameTag: () => ({ mutate: vi.fn(), isPending: false }),

--- a/frontend/src/pages/admin/tags.tsx
+++ b/frontend/src/pages/admin/tags.tsx
@@ -6,7 +6,7 @@
 import { Navigate } from 'react-router-dom';
 import { StickyHeaderLayout, PageHeader } from '@widgets/app-shell';
 import { useRole } from '@entities/user/model/useRole';
-import { TagMasterTable } from '@features/admin/tag-master/TagMasterTable';
+import { TagMasterTable } from '@features/admin/tag-master/ui/TagMasterTable';
 
 export default function AdminTagsPage() {
   const { isAdmin, isManager, isDev } = useRole();


### PR DESCRIPTION
## Summary
- `useVocFilter.ts` → `useVocFilterContext.ts` (context consumer)
- `useVocFilters.ts` → `useVocFilterUrlState.ts` (URL ↔ state sync)
- `features/admin/tag-master/` flat → `api/+ui/`, `ActionButton` → `TagMasterActionButton`
- normalize tag contract import to `@contracts/admin/tag` alias

Per `naming-conventions.md` §5.2/§5.3. Adversarial review (codex): PROCEED on Cand 2+4.

## Test plan
- [x] FE typecheck green
- [x] FE lint green
- [x] FE 661/661 vitest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)