### PR TITLE
docs(flowline): ADR-0008 + uidesign §16 Flowline Alignment Primitives

### DIFF
--- a/docs/adr/0008-flowline-design-alignment.md
+++ b/docs/adr/0008-flowline-design-alignment.md
@@ -1,0 +1,73 @@
+# 0008 — Flowline 디자인 정합화
+
+## Status
+
+Proposed (2026-05-10). 본 ADR 잠금 후 `uidesign.md §16` 신설 PR 진입.
+
+## Context
+
+`refSystem/Integrated Platform _ Standalone.html` 은 통합 플랫폼 시각 레퍼런스이다. 그 내부 모듈 중 **Flowline** (Linear-flavored 이슈/태스크 모듈, CSS 위치 lines 835–1079) 의 완성도가 가장 높다는 판단으로, vocpage **전체** (VOC 리스트·상세·admin·dashboard·shell) 가 Flowline 과 같은 패밀리로 인식되도록 시각 정합화한다. 픽셀 동일이 아니라 **형제 시스템 인식**이 목표.
+
+`docs/specs/plans/flowline-alignment-cues.md` 가 시그널 7개와 OQ 5건을 정리했고 OQ 전건 해소 완료.
+
+### OQ resolutions (cues §3)
+
+- S2 status glyph: 보완(좌측 prepend), 텍스트 유지.
+- S4 row density: VocRow 가 이미 Flowline 사양과 동일(`7px 24px / 36px / 13px / gap 10px`). 코드 변경 불필요.
+- S6 avatar stack: 하향(VOC 다중 담당자 없음). label-chip 만 유지.
+- S7 활동 피드: 기존 `VocActivityTimeline` 활용. 시각 정합성은 별 wave.
+- 적용 범위: Flowline 시그널 7개 + dashboard primitives. dashboard 는 `uidesign.md §11` 우선.
+
+### 결정 분기
+
+- **A (선택)** — Flowline 시그널 5개 (S1·S2·S3·S5·S6 label-chip) 만 신규 컴포넌트 명세, S4·S7 는 verified-aligned 명시, dashboard 는 §11 그대로.
+- B — 7개 전부 신규 명세 (S4·S7 중복).
+- C — refSystem 시각 참고만, 명세 없음.
+
+## Decision
+
+### A 채택. 다음을 확정:
+
+1. **목표**: vocpage 가 Flowline 과 형제 시스템으로 인식되는 시각 통일감. 픽셀 일치·기능 일치 아님.
+2. **패러다임**: shadcn 유지 + variants. 신규 시그널은 `frontend/src/shared/ui/<name>` React 컴포넌트로 추가. refSystem 의 시맨틱 클래스(`.iid`, `.s-icon` 등)는 **참고용**, 런타임 적용 금지.
+3. **신규 컴포넌트 5종** (사용처 발생 시 컴포넌트화):
+   - `issue-id` (S1) — VOC ID, 사용자 ID, 태그 ID 의 mono 칩.
+   - `status-glyph` (S2) — 14×14 원형 글리프, SolidChip 좌측 prepend 용.
+   - `priority-bars` (S3) — 14×14 3-bar, urgent/high/med/low.
+   - `list-group-header` (S5) — 리스트 그룹 라벨 밴드.
+   - `label-chip` (S6) — 기존 OutlineChip 의 `dot-pill` variant 추가 (신규 컴포넌트 아님, variant 확장).
+4. **변경 없음 명시**:
+   - S4 row density: `VocRow.tsx:35` 가 이미 사양 동일. 검증만.
+   - S7 활동 피드: 기존 `VocActivityTimeline` 유지. 시각 정합성 점검은 별 wave.
+   - 토큰: `globals.css` 변경 없음 (Flowline CSS 의 모든 token reference 가 이미 globals.css 에 존재).
+5. **Dashboard primitives**: `uidesign.md §11` 이 KPI / Heatmap / Donut 을 이미 명세. Flowline `.sparkline` 만 §16 에 추가 (§11 Donut 옆 미니 bar 패턴과 통합 가능).
+6. **사용 게이트**: `uidesign.md §16` 등재 항목만 ad-hoc 컴포넌트화 허용. 기타 Flowline CSS 클래스(`.kanban`, `.tl-grid` 등) 은 본 ADR 범위 외, 차후 사용처 발생 시 별 ADR.
+
+### Rejected — B (7개 전부 신규 명세)
+
+- S4 는 코드 검증 결과 이미 정렬, 명세 추가 = 중복.
+- S7 는 기존 컴포넌트 보유, 시각 점검은 코드 변경 wave 가 더 적합.
+
+### Rejected — C (참고만)
+
+- 시그널 추출까지 한 시점에서 명세 없는 정합화는 spec drift 보장.
+
+## Consequences
+
+- **+** §16 가 Flowline 정합화의 단일 출처. 화면별 wave 가 §16 컴포넌트만 채택.
+- **+** 신규 시그널 5개 모두 작은 atomic 컴포넌트 (각 ~30~50줄). 누적 영향 < 200 LOC.
+- **+** 토큰 변경 0, 기존 컴포넌트 변경 0 (label-chip 은 OutlineChip variant 추가).
+- **+** S4 자동 해결로 행 밀도 변경에 따른 visual-diff 베이스라인 22장 재촬영 회피.
+- **−** 5개 컴포넌트 중 1차 사용처는 VOC 리스트(S1·S2·S3) 정도로 좁음. 나머지(S5·S6 dot-pill)는 사용처 발견까지 spec-only 상태. 완화: §16 표 "구현 상태" 컬럼 의무.
+- **−** Flowline 모듈만 정합 기준이고 refSystem 내 Servey/Analytics 모듈은 미정. 향후 별 시스템(설문 도입 등) 추가 시 분기점 발생. 본 ADR 범위 외.
+
+## Implementation outline
+
+1. (본 PR) ADR-0008 + `uidesign.md §16 — Flowline Alignment Primitives` 신설 (S1·S2·S3·S5 명세, S4 verified, S6 label-chip dot-pill variant, S7 deferred, sparkline 1행).
+2. (별 wave · 가벼움) `shared/ui/issue-id` + `shared/ui/status-glyph` 컴포넌트화 + VOC 리스트·drawer 1차 적용. visual-diff 베이스라인은 변경 페이지만 재촬영.
+3. (별 wave) `priority-bars` + `list-group-header` 도입.
+4. (수요 발생 시) S6 dot-pill variant, S7 활동 피드 시각 점검.
+
+## Open Questions
+
+- 없음 (cues OQ 5건 전건 해소).

--- a/docs/specs/plans/flowline-alignment-cues.md
+++ b/docs/specs/plans/flowline-alignment-cues.md
@@ -1,0 +1,89 @@
+# Flowline Alignment Cues
+
+> **Status:** Draft (2026-05-10). Not a spec — a working queue.
+> **Goal:** vocpage 전체가 refSystem 내 **Flowline** 모듈과 같은 패밀리로 인식될 정도의 디자인 통일감 확보. 픽셀 동일 아님, 기능 차이 허용.
+> **Reference:** `refSystem/Integrated Platform _ Standalone.html` (decoded body 75KB; Flowline CSS = lines 835–1079, `tasks-shell.css — Linear-flavored extras`).
+> **Scope of application:** vocpage 전체 (VOC 리스트·상세·admin·dashboard·shell). 기존 `uidesign.md` 토큰·팔레트·타이포는 이미 95% 동일이므로 **추가 시그널만** 정렬한다.
+
+## 1. Family-resemblance signals (extracted)
+
+Flowline 을 다른 시스템과 구분짓는 시각 시그널을 영향력 순으로 7개 추렸다. 같은 패밀리로 보이려면 1~5번이 가장 비싸고, 6~7은 보너스.
+
+### S1 — Issue ID 칩 (`.iid`)
+- 형태: `font-mono 11.5px / padding 1px 6px / radius 4px / bg var(--bg-elevated) / border var(--border-subtle) / color var(--text-tertiary) / letter-spacing 0.01em`
+- 의미: 도메인 ID(`LIN-204`, `VOC-318`, `SV-22`)를 본문 텍스트와 분리해 시각 앵커로.
+- vocpage 영향: VOC 행 ID, 어드민 사용자/태그 ID, 활동 피드 mention.
+
+### S2 — Status glyph (`.s-icon`)
+- 형태: 14×14 원형 / 1.5px ring / `backlog`(dashed) · `todo`(solid ring) · `progress`(60% conic amber) · `review`(80% conic blue) · `done`(filled emerald + check) · `canceled`(filled muted + ×).
+- 의미: status를 **단어 없이도** 즉시 식별. 칩이 아니라 글리프라는 점이 Linear/Flowline 시그니처.
+- vocpage 영향: 현 VOC `received|reviewing|processing|done|drop` 5상태 → 글리프 5종 매핑. 기존 SolidChip 텍스트 유지하되 좌측에 글리프 prepend.
+
+### S3 — Priority bars (`.p-icon`)
+- 형태: 14×14 / 3 bar (높이 4·7·10px, 너비 2.5px) / `urgent`(red 3) · `high`(orange 3) · `med`(secondary 2) · `low`(secondary 1).
+- 의미: 텍스트 없이 우선순위 레벨 표현. 행 밀도 유지에 핵심.
+- vocpage 영향: VOC 우선순위 컬럼이 현재 텍스트 또는 색칩이라면 글리프로 대체 검토.
+
+### S4 — Tight row density (`.irow`)
+- 형태: `grid-template-columns: 16px 22px 70px 1fr auto / gap 10px / padding 7px 24px / min-height 36px / font-size 13px`.
+- 의미: glyph(s-icon) · iid · 중심 타이틀 · 우측 메타로 고정된 5-슬롯 행. 36px 행 높이가 Flowline 시그니처.
+- vocpage 영향: `features/voc/list/ui/VocRow.tsx` 의 행 높이·컬럼 그리드 점검. 현 VOC 리스트가 더 여유 있으면 `compact` 모드 도입을 옵션으로.
+
+### S5 — Group header band (`.igroup-h`)
+- 형태: `padding 8px 24px / bg var(--bg-panel) / font 12px 600 / count 11px 500 tertiary / cursor pointer`.
+- 의미: 리스트 그룹핑(상태별/담당자별) 라벨이 row와 시각 위계가 분명히 분리된다.
+- vocpage 영향: VOC 리스트 카테고리 분리, admin 테이블 그룹핑.
+
+### S6 — Label chip (`.label-chip`) & avatar stack (`.av-stack`)
+- label-chip: `padding 1px 8px / radius pill / dot 7px / font 11.5px 500 / bg var(--bg-elevated)`.
+- av-stack: `margin-left -6px / 2px solid var(--bg-surface) border` 로 겹침.
+- 의미: 메타 정보가 아이콘+텍스트 일체형 칩으로 응축. 태그·할당자가 **밀도 있는 한 줄 메타**가 됨.
+
+### S7 — Activity feed (`.act`)
+- 형태: `gap 10px / padding 10px 0 / 마지막 외 border-bottom subtle / line 13px secondary line-height 1.55 / time 11px quaternary`.
+- bold (`b`)는 `text-primary`로 객체(이슈 ID, 사용자명) 강조.
+- 의미: VOC 상세 drawer의 활동 탭 = Jira/Linear 풍 피드.
+
+### Bonus — `.kbd` (키보드 힌트), `.proj-pick` (프로젝트 picker), modal radius 12px
+
+## 2. Mapping vs current vocpage
+
+| Signal | 현 vocpage 위치                                          | 갭 평가                                    |
+| ------ | -------------------------------------------------------- | ------------------------------------------ |
+| S1 iid | (없음 — VOC ID는 plain text)                              | **신규** `shared/ui/issue-id` 도입        |
+| S2 s-icon | `shared/ui/badge/SolidChip.tsx` (텍스트 only)         | **신규** `shared/ui/status-glyph`          |
+| S3 p-icon | `shared/ui/badge/` priority semantic wrapper          | **신규** `shared/ui/priority-bars` 또는 기존 우선순위 칩에 glyph variant |
+| S4 row density | `features/voc/list/ui/VocRow.tsx`                | **점검** 현 행 높이·padding 측정 후 결정 |
+| S5 group band | (없음)                                               | **신규** `shared/ui/list-group-header`     |
+| S6 label-chip | `shared/ui/badge/OutlineChip.tsx`, `avatar.tsx`     | **부분** OutlineChip variants에 `dot-pill` 추가 / avatar stack 미존재 |
+| S7 act | (활동 탭 존재 여부 미확인)                                | **확인** VOC drawer 활동 탭 현황 → variant 또는 신규 |
+
+## 3. OQ resolutions (2026-05-10)
+
+- **OQ-1 → 보완(좌측 prepend)**: S2 status glyph는 SolidChip 텍스트 유지 + 좌측에 14×14 글리프 prepend. 한국어 사용자 가독성 유지.
+- **OQ-2 → 자동 해결**: `VocRow.tsx:35` 주석에 이미 `padding 7px 24px / min-height 36px / font-size 13px / gap 10px` 명시. Flowline 사양과 동일. **코드 변경 불필요**.
+- **OQ-3 → S6 stack 하향**: VOC에 다중 담당자 케이스 없음. label-chip만 S6에 유지, avatar stack 본 wave 제외.
+- **OQ-4 → 기존 자산 활용**: `features/voc/review/ui/VocActivityTimeline.tsx` + `ActivityAvatar.tsx` + `VocHistory.tsx` 이미 존재. S7는 시각 정합성 점검만 별 wave.
+- **OQ-5 → dashboard primitives 포함**: kpi / donut / sparkline 까지 Flowline 정합화 범위에 포함. 단 기존 `uidesign.md §11 Dashboard Components` 와 충돌하면 §11 우선.
+
+## 4. Wave proposal (after OQ resolution)
+
+1. **Wave A · 토큰 갭 0건** — 현 globals.css 가 이미 모든 토큰 보유. 추가 토큰 불필요. ✅
+2. **Wave B · ADR + 시그널 5개 명세** — S1~S5 만 우선 ADR + uidesign.md 추가 (S6·S7 보류).
+3. **Wave C · S1·S2 컴포넌트** (가장 가벼움) — `issue-id` + `status-glyph`, VOC 리스트·drawer 1차 적용.
+4. **Wave D · S3·S4·S5** — priority-bars + 행 밀도 조정 + group band. 시각 회귀 영향 큼, visual-diff 베이스라인 재촬영.
+5. **Wave E · S6·S7** — OQ-3·4 결과에 따라.
+
+## 5. Out of scope (본 문서 의도적 제외)
+
+- Kanban (`.kanban` / `.kcard`) — VOC에 board 화면 없음.
+- Roadmap timeline (`.tl-grid`) — VOC에 일정 화면 없음.
+- Dashboard primitives (kpi / donut / sparkline) — `uidesign.md §11` 이 이미 다루므로 별도.
+- refSystem 내 Servey / Analytics / Console 모듈 시각 — Flowline 으로 한정.
+
+## 6. References
+
+- Flowline CSS: `refSystem/Integrated Platform _ Standalone.html` lines 835–1079 (decoded body).
+- 디자인 컨텍스트: `.impeccable.md`.
+- 기존 토큰: `frontend/src/shared/styles/globals.css` (변경 없음).
+- 기존 UI: `frontend/src/shared/ui/badge/`, `frontend/src/features/voc/list/ui/VocRow.tsx`.

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -14,6 +14,7 @@
 | **마이그 023 운영 적용** | PR #312 머지 (2026-05-10) | rogue row 진단 SQL 선행. 적용 후 Dashboard Dialog 'custom' round-trip 통합 검증. |
 | **Admin 미구현 페이지** | [`admin-pages-backlog.md`](./admin-pages-backlog.md) | 시스템/메뉴 / 유형 / 결과 검토 / 태그 규칙. 권장 순서: 태그 규칙(태그 마스터 통합) → 시스템/메뉴 → 유형 → 결과 검토(NextGen). |
 | **ADR 0007 timezone 잠금** | `docs/adr/0007-custom-date-range-timezone.md` (Proposed) | 다중 timezone 운영 진입 전 별 세션. 잠금 전 다중 TZ 진입 금지. |
+| **Flowline Wave C — issue-id + status-glyph 도입** | `uidesign.md §16` · ADR-0008 · `flowline-alignment-cues.md` | 가장 가벼운 Wave. `shared/ui/issue-id` + `shared/ui/status-glyph` 신설 → VOC 리스트 1차 적용 → §16.1 표 상태 갱신. visual-diff 베이스라인 변경 페이지만 재촬영. |
 | **운영/배포 phase** | 본 문서 §운영/배포 | session store · OIDC · Production build · 실 MSSQL · E2E. |
 
 ### Hard-blocks

--- a/docs/specs/requires/uidesign.md
+++ b/docs/specs/requires/uidesign.md
@@ -1468,3 +1468,148 @@ Use these as templates when generating new components. They reference only token
 - ❌ Mixed shadow tokens on one element — raise the surface level instead
 - ✅ Every color comes from `var(--…)`; every spacing from `--sp-*`; every radius from §7 "Border Radius by Element"
 - ✅ Light and dark must both be tested before considering a component done
+
+---
+
+## 16. Flowline Alignment Primitives
+
+> 본 섹션은 ADR-0008 잠금 결과로 신설. `refSystem/Integrated Platform _ Standalone.html` 내 Flowline 모듈 (Linear-flavored, lines 835–1079) 의 시각 시그널 중 vocpage 와 형제 시스템 인식을 위해 도입할 항목을 명세한다. **본 §16 등재 항목만** ad-hoc 컴포넌트화 허용. 기타 Flowline 클래스(kanban / timeline 등) 는 별 ADR 후 진입.
+>
+> 시그널 분석 출처: `docs/specs/plans/flowline-alignment-cues.md`.
+
+### 16.1 Scope summary
+
+| Signal | 항목                  | 본 wave 처리                                  |
+| ------ | --------------------- | --------------------------------------------- |
+| S1     | Issue ID (`.iid`)     | 신규 컴포넌트 `shared/ui/issue-id`            |
+| S2     | Status glyph (`.s-icon`) | 신규 `shared/ui/status-glyph` (SolidChip 보완) |
+| S3     | Priority bars (`.p-icon`) | 신규 `shared/ui/priority-bars`              |
+| S4     | Tight row density     | **검증 완료** — `VocRow.tsx:35` 가 이미 동일 사양 |
+| S5     | Group header band     | 신규 `shared/ui/list-group-header`            |
+| S6     | Label chip            | 기존 `shared/ui/badge/OutlineChip` 에 `dot-pill` variant |
+| S7     | Activity feed         | 기존 `features/voc/review/ui/VocActivityTimeline` 유지, 시각 점검 별 wave |
+| Bonus  | Sparkline             | §11.4 Donut legend 옆 mini bar 패턴 재사용     |
+
+### 16.2 S1 — Issue ID (`shared/ui/issue-id`)
+
+```css
+font-family: var(--font-mono);
+font-size: 11.5px;
+color: var(--text-tertiary);
+background: var(--bg-elevated);
+border: 1px solid var(--border-subtle);
+padding: 1px 6px;
+border-radius: 4px;
+letter-spacing: 0.01em;
+```
+
+- 용도: VOC ID (`VOC-318`), 사용자 ID, 태그 ID 등 도메인 키. 본문 텍스트와 분리되는 시각 앵커.
+- props: `id: string` (필수), `tone?: 'default' | 'subdued'` (subdued 는 `opacity: 0.7`, 하위 행에서 사용).
+
+### 16.3 S2 — Status glyph (`shared/ui/status-glyph`)
+
+14×14 원형 ring. SolidChip 의 좌측 prepend 용. **텍스트 대체 아님**.
+
+| Variant     | 시각                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `backlog`   | dashed ring · `var(--text-quaternary)`                                                   |
+| `todo`      | solid ring · `var(--text-tertiary)`                                                      |
+| `progress`  | solid ring `var(--chart-amber)` + `conic-gradient(var(--chart-amber) 0 60%, transparent 60% 100%)` |
+| `review`    | ring `var(--chart-blue)` + 80% conic                                                     |
+| `done`      | filled `var(--chart-emerald)` + white check (`::after`, 1.5px border-left/bottom, rotate -45deg) |
+| `canceled`  | filled `var(--text-quaternary)` + white `×`                                              |
+
+VOC 상태 매핑: `received → todo`, `reviewing → review`, `processing → progress`, `done → done`, `drop → canceled`. (글리프와 텍스트 라벨이 함께 보이므로 매핑 손실 없음.)
+
+### 16.4 S3 — Priority bars (`shared/ui/priority-bars`)
+
+```css
+.priority-bars { width: 14px; height: 14px; display: inline-flex; align-items: flex-end; justify-content: center; gap: 1.5px; flex: 0 0 auto; }
+.priority-bars i { width: 2.5px; border-radius: 1px; }
+.priority-bars i:nth-child(1) { height: 4px; }
+.priority-bars i:nth-child(2) { height: 7px; }
+.priority-bars i:nth-child(3) { height: 10px; }
+```
+
+| Variant   | bar 색상                                                |
+| --------- | ------------------------------------------------------- |
+| `urgent`  | 3 bar 모두 `var(--status-red)`                          |
+| `high`    | 3 bar 모두 `var(--status-orange)`                       |
+| `med`     | bar 1·2 `var(--text-secondary)`, bar 3 `var(--text-quaternary)` |
+| `low`     | bar 1 `var(--text-secondary)`, bar 2·3 `var(--text-quaternary)` |
+
+`var(--text-quaternary)` 는 비활성 bar 의 디폴트.
+
+### 16.5 S4 — Tight row density (verified)
+
+- `frontend/src/features/voc/list/ui/VocRow.tsx` 가 이미 다음 사양:
+  - `padding: 7px 24px`
+  - `min-height: 36px`
+  - `font-size: 13px`
+  - `gap: 10px`
+- Flowline `.irow` 사양과 동일. **추가 작업 없음**. 본 항목은 회귀 방지 목적 명시.
+
+### 16.6 S5 — Group header band (`shared/ui/list-group-header`)
+
+```css
+display: flex;
+align-items: center;
+gap: 8px;
+padding: 8px 24px;
+background: var(--bg-panel);
+font-size: 12px;
+color: var(--text-secondary);
+font-weight: 600;
+border-bottom: 1px solid var(--border-subtle);
+cursor: pointer;
+```
+
+- 우측 count: `font-size: 11px; color: var(--text-tertiary); font-weight: 500`.
+- 용도: VOC 리스트 상태별 그룹핑, admin 테이블 카테고리 분리.
+
+### 16.7 S6 — Label chip (`OutlineChip` `dot-pill` variant)
+
+기존 `shared/ui/badge/OutlineChip` 에 variant 추가:
+
+```css
+.outline-chip[data-variant='dot-pill'] {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 1px 8px;
+  border-radius: 9999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+.outline-chip[data-variant='dot-pill'] .lc-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+}
+```
+
+props 신호: `variant?: 'dot-pill'`, `dotColor?: string` (token).
+
+### 16.8 S7 — Activity feed (deferred verification)
+
+- 기존: `features/voc/review/ui/VocActivityTimeline.tsx`, `ActivityAvatar.tsx`, `VocHistory.tsx`.
+- 본 wave: 변경 없음. Flowline `.act` 사양 (gap 10px / padding 10px 0 / line 13px secondary 1.55 / time 11px quaternary / `b` text-primary 600) 과 비교 점검은 별 wave.
+
+### 16.9 Sparkline note
+
+- Flowline `.sparkline` 은 6px 너비 막대 시리즈. §11.4 Donut legend 의 mini bar 패턴 (proportional width, `var(--bg-elevated)` track) 과 의도가 동일하므로 별도 컴포넌트 도입 보류. 차후 시계열 sparkline 사용처 발생 시 §11 확장.
+
+### 16.10 Adoption rules
+
+1. 본 §16 등재 컴포넌트만 `shared/ui/` 신설 허용. 기타 Flowline 클래스 적용 금지.
+2. 신규 컴포넌트 첫 사용 PR 에서 §16 표 "구현 상태" 갱신 (`spec-only` → `implemented`).
+3. SolidChip + status-glyph 결합 시 `<status-glyph>` 가 좌측 prepend, 텍스트 라벨 우측. 이중 렌더링 금지(글리프 단독 / 텍스트 단독 케이스 별도 props).
+4. priority-bars 와 텍스트 우선순위 라벨 결합은 선택 — 좁은 컬럼은 글리프만, 넓은 컬럼은 둘 다.
+5. issue-id 는 본문 inline 사용 시 mono 폰트 유지, 줄높이 보정으로 위치 정렬.
+
+### 16.11 Cross-references
+
+- 시그널 분석: `docs/specs/plans/flowline-alignment-cues.md`.
+- ADR: `docs/adr/0008-flowline-design-alignment.md`.
+- 디자인 컨텍스트: `.impeccable.md` (refSystem · Linear UI + Jira UX).
+- 참조 HTML: `refSystem/Integrated Platform _ Standalone.html` lines 835–1079 (수동 편집 금지).
+- 토큰: `frontend/src/shared/styles/globals.css` (변경 없음 — 모든 참조 토큰 기존 보유).


### PR DESCRIPTION
## Summary

- ADR-0008: Flowline 디자인 정합화 결정 — `refSystem/Integrated Platform _ Standalone.html` Flowline 모듈을 형제 시스템으로 인식. 픽셀 동일이 아닌 시각 통일감 목표.
- `uidesign.md §16 Flowline Alignment Primitives` 신설 — S1~S7 + sparkline 시그널 명세. 신규 컴포넌트 5종 (`issue-id` / `status-glyph` / `priority-bars` / `list-group-header`) + OutlineChip `dot-pill` variant.
- `next-session-tasks.md` 에 Wave C 진입 행 등재.

토큰 / globals.css 변경 0. 컴포넌트 신설은 별 wave (Wave C ~ E) 에서 단계 도입.

## Test plan
- [ ] ADR-0008 결정 분기 (A 채택) 와 Rejected B/C 사유 검토
- [ ] §16.1 표 시그널 매핑이 ADR Decision §3 과 정합 확인
- [ ] §16.10 Adoption rules 가 향후 wave 의 컴포넌트 게이트로 명료한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)