### PR TITLE
docs(progress): Flowline Wave C 머지 반영

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,18 +1,22 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점 (2026-05-10 구조/네이밍 정리 1차 머지 완료)
+## 다음 세션 시작점 (2026-05-10 Flowline Wave C 머지 완료)
 
 → **머지 완료 (2026-05-10)**:
    - **PR #310** ADR 0006 (Accepted) + 0007 (Proposed) — `dashboard_settings.default_date_range='custom'` 컬럼 신설 + timezone OQ 별 ADR 분기.
    - **PR #312** Wave 3 Phase A 구현 — 마이그 023 + zod superRefine + BE service + FE CustomDateRangePicker. BE 593 / FE 661 pass.
    - **PR #313** specs 정리 + stub `/tags` nav 제거 + admin-pages-backlog.md.
    - **PR #314** 구조/네이밍 정리 1차 (deepening candidates 2 + 4) — `useVocFilter`/`useVocFilters` → `useVocFilterContext`/`useVocFilterUrlState`, `features/admin/tag-master/` 평면 → `api/+ui/`, `ActionButton` → `TagMasterActionButton`, `@contracts/admin/tag` alias 통일.
+   - **PR #316** ADR-0008 + `uidesign.md §16 Flowline Alignment Primitives` — Flowline 정합화 결정 + 시그널 7종 명세.
+   - **PR #317** Flowline Wave C — `shared/ui/issue-id` + `shared/ui/status-glyph` 신설. `VocStatusBadge` 가 두 모드(아이콘/칩+라벨) 모두 글리프 외부 wrap → VocRow / 드로어 / 디테일 / 그룹헤더 자동 적용. 671 vitest pass. §16.1 S1·S2 = `implemented`.
 
 → **구조/네이밍 정리 진행 상태 (2026-05-10 audit, codex 적대적 리뷰)**:
    - **완료**: Cand 2 (useVocFilter rename) · Cand 4 (tag-master split) — PR #314.
    - **차기 후보 (PROCEED, 단계적)**: Cand 1 entity api/ slice 네이밍 통일 — `entities/{master,user,notification,voc}/api/*` camelCase + `entities/{faq,notice}/api/*` 평면 → 모두 `subject.api.ts` / `subject.query-keys.ts`. ~9 파일 + 다수 caller, 슬라이스 단위 PR 분할 권장 (voc → master → user → notification → faq → notice → auth).
    - **DEFER**: Cand 3 `features/dashboard/widgets/` 와 top-level `widgets/` shadow — 12 컴포넌트 import churn 대비 leverage 약함 / Cand 5 backend repo·service suffix 혼재 (`*.repo.ts` vs `*.ts`) — 다음 BE 작업 시 같이 처리.
    - **REJECT**: Cand 6 backend `controllers/` + `validators/` orphan 의혹 — `backend/src/CLAUDE.md`가 5-layer 명시, ADR-0003 이 validators 보존 결정. 코드 drift 아니라 의도적 layer.
+
+→ **Flowline 정합화 상태**: ADR-0008 + Wave C 머지. 차기 — Wave D 후보 (S3 priority-bars / S5 list-group-header / S6 OutlineChip dot-pill variant) 는 사용처 발생 시 진입. S7 활동 피드 + sparkline deferred.
 
 → **다음 세션 작업 후보**:
    - **구조/네이밍 정리 2차** — Cand 1 voc 슬라이스부터 (`entities/voc/api/vocApi.ts` → `voc.api.ts` + `vocQueryKeys.ts` → `voc.query-keys.ts`).
@@ -21,4 +25,4 @@
    - **운영/배포 phase** — session store · OIDC · Production build · 실 MSSQL · E2E.
    - **ADR 0007 (timezone) 잠금** — 다중 timezone 운영 진입 전 별 세션.
 
-→ **현재 main 상태**: `5336d9c` (PR #314 머지 후).
+→ **현재 main 상태**: `e1b9999` (PR #317 머지 후).

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -14,7 +14,7 @@
 | **마이그 023 운영 적용** | PR #312 머지 (2026-05-10) | rogue row 진단 SQL 선행. 적용 후 Dashboard Dialog 'custom' round-trip 통합 검증. |
 | **Admin 미구현 페이지** | [`admin-pages-backlog.md`](./admin-pages-backlog.md) | 시스템/메뉴 / 유형 / 결과 검토 / 태그 규칙. 권장 순서: 태그 규칙(태그 마스터 통합) → 시스템/메뉴 → 유형 → 결과 검토(NextGen). |
 | **ADR 0007 timezone 잠금** | `docs/adr/0007-custom-date-range-timezone.md` (Proposed) | 다중 timezone 운영 진입 전 별 세션. 잠금 전 다중 TZ 진입 금지. |
-| ~~Flowline Wave C — issue-id + status-glyph 도입~~ | `uidesign.md §16` · ADR-0008 | 진행 중 (`feat/flowline-wave-c`) — `shared/ui/issue-id` + `shared/ui/status-glyph` 신설. VocStatusBadge 가 두 표면(아이콘 / 칩 모드) 모두 글리프로 전환 → VocRow / 드로어 / 디테일 / 그룹헤더 자동 적용. §16.1 구현 상태 `implemented`. visual-diff baseline 재촬영은 PR 머지 직전 별도 단계. |
+| **Flowline Wave D 후보** | `uidesign.md §16` · ADR-0008 | Wave C (S1·S2) 머지 (PR #317). 차기 — S3 priority-bars / S5 list-group-header / S6 OutlineChip dot-pill 은 사용처 발생 시 진입. S7 / sparkline deferred. |
 | **운영/배포 phase** | 본 문서 §운영/배포 | session store · OIDC · Production build · 실 MSSQL · E2E. |
 
 ### Hard-blocks


### PR DESCRIPTION
## Summary

PR #316 (ADR-0008 + uidesign §16) + PR #317 (Wave C — issue-id / status-glyph) 머지 후 진행 문서 동기화.

- `claude-progress.txt` 머지 라인업에 PR #316 / #317 추가, 헤더 (Flowline Wave C 머지 완료) 갱신, main 상태 → `e1b9999`.
- `next-session-tasks.md` Wave C 행 → Wave D 후보 행으로 갱신 (S3 / S5 / S6 은 사용처 발생 시).

## Test plan
- [ ] 진행 헤더 + 머지 라인업 정합 확인
- [ ] Wave D 차기 후보 표기 적정성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)