### PR TITLE
feat(flowline-wave-c-ext): S3+S5+S6 + impeccable critique fixes (sibling 8.3/10)

### DIFF
--- a/docs/specs/requires/uidesign.md
+++ b/docs/specs/requires/uidesign.md
@@ -1483,10 +1483,10 @@ Use these as templates when generating new components. They reference only token
 | ------ | --------------------- | --------------------------------------------- | --------- |
 | S1     | Issue ID (`.iid`)     | 신규 컴포넌트 `shared/ui/issue-id`            | implemented (Wave C) |
 | S2     | Status glyph (`.s-icon`) | 신규 `shared/ui/status-glyph` (SolidChip 보완) | implemented (Wave C) |
-| S3     | Priority bars (`.p-icon`) | 신규 `shared/ui/priority-bars`              | spec-only |
+| S3     | Priority bars (`.p-icon`) | 신규 `shared/ui/priority-bars`              | implemented (Wave C-ext) |
 | S4     | Tight row density     | **검증 완료** — `VocRow.tsx:35` 가 이미 동일 사양 | verified |
-| S5     | Group header band     | 신규 `shared/ui/list-group-header`            | spec-only |
-| S6     | Label chip            | 기존 `shared/ui/badge/OutlineChip` 에 `dot-pill` variant | spec-only |
+| S5     | Group header band     | 신규 `shared/ui/list-group-header`            | implemented (Wave C-ext) |
+| S6     | Label chip            | 기존 `shared/ui/badge/OutlineChip` 에 `dot-pill` variant | implemented (Wave C-ext) |
 | S7     | Activity feed         | 기존 `features/voc/review/ui/VocActivityTimeline` 유지, 시각 점검 별 wave | deferred |
 | Bonus  | Sparkline             | §11.4 Donut legend 옆 mini bar 패턴 재사용     | deferred |
 
@@ -1538,7 +1538,7 @@ VOC 상태 매핑: `received → todo`, `reviewing → review`, `processing → 
 | `med`     | bar 1·2 `var(--text-secondary)`, bar 3 `var(--text-quaternary)` |
 | `low`     | bar 1 `var(--text-secondary)`, bar 2·3 `var(--text-quaternary)` |
 
-`var(--text-quaternary)` 는 비활성 bar 의 디폴트.
+`var(--text-quaternary)` 는 비활성 bar 의 디폴트. status-glyph 와 priority-bars 는 row 그리드에서 column 분리되어 warm 색을 공유해도 시각 충돌이 적다 — Linear convention 을 따라 `urgent`(red) / `high`(orange) 는 색으로, `med` / `low` 는 회색 강도로 위계를 표현한다.
 
 ### 16.5 S4 — Tight row density (verified)
 

--- a/frontend/src/entities/voc/ui/VocAssignee.tsx
+++ b/frontend/src/entities/voc/ui/VocAssignee.tsx
@@ -1,22 +1,5 @@
 import { UserX } from 'lucide-react';
 
-const COLOR_CLASSES = ['steel', 'teal', 'violet'] as const;
-export type AvatarColorClass = (typeof COLOR_CLASSES)[number];
-
-const COLOR_VAR: Record<AvatarColorClass, string> = {
-  steel: 'var(--avatar-steel)',
-  teal: 'var(--avatar-teal)',
-  violet: 'var(--avatar-violet)',
-};
-
-export function hashAssigneeColor(name: string): AvatarColorClass {
-  let h = 0;
-  for (let i = 0; i < name.length; i += 1) {
-    h = (h * 31 + name.charCodeAt(i)) | 0;
-  }
-  return COLOR_CLASSES[Math.abs(h) % COLOR_CLASSES.length] as AvatarColorClass;
-}
-
 const ROW_STYLE: React.CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -25,26 +8,22 @@ const ROW_STYLE: React.CSSProperties = {
   color: 'var(--text-tertiary)',
 };
 
-const CIRCLE_BASE: React.CSSProperties = {
-  width: '22px',
-  height: '22px',
+const CIRCLE_STYLE: React.CSSProperties = {
+  width: '18px',
+  height: '18px',
   borderRadius: '50%',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontSize: '9.5px',
-  fontWeight: 700,
-  color: 'var(--text-on-brand)',
+  fontSize: '9px',
+  fontWeight: 600,
+  color: 'var(--text-secondary)',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border-subtle)',
   flexShrink: 0,
 };
 
-export function VocAssignee({
-  name,
-  colorClass,
-}: {
-  name: string | null;
-  colorClass?: AvatarColorClass;
-}) {
+export function VocAssignee({ name }: { name: string | null }) {
   const trimmed = name?.trim() ?? '';
   if (!trimmed) {
     return (
@@ -59,16 +38,11 @@ export function VocAssignee({
     );
   }
 
-  const bucket = colorClass ?? hashAssigneeColor(trimmed);
   const initial = Array.from(trimmed)[0] ?? '';
 
   return (
-    <span
-      data-testid={`assignee-${bucket}`}
-      aria-label={`담당자 ${trimmed}`}
-      style={ROW_STYLE}
-    >
-      <span aria-hidden="true" style={{ ...CIRCLE_BASE, background: COLOR_VAR[bucket] }}>
+    <span data-testid="assignee-circle" aria-label={`담당자 ${trimmed}`} style={ROW_STYLE}>
+      <span aria-hidden="true" style={CIRCLE_STYLE}>
         {initial}
       </span>
       {trimmed}

--- a/frontend/src/entities/voc/ui/VocPriorityBadge.tsx
+++ b/frontend/src/entities/voc/ui/VocPriorityBadge.tsx
@@ -1,15 +1,33 @@
-import { Flame, ChevronUp, Minus, ChevronDown, type LucideIcon } from 'lucide-react';
+import type { CSSProperties } from 'react';
 import type { VocPriority } from '@contracts/voc';
-import { TextMark } from '@shared/ui/badge';
+import {
+  PriorityBars,
+  type PriorityBarsVariant,
+} from '@shared/ui/priority-bars';
 
 const PRIORITY_CONFIG: Record<
   VocPriority,
-  { label: string; Icon: LucideIcon; color: string; weight: 400 | 500 | 600 | 700 }
+  { label: string; variant: PriorityBarsVariant; weight: 400 | 500 | 600 | 700 }
 > = {
-  urgent: { label: 'Urgent', Icon: Flame, color: 'var(--status-red)', weight: 700 },
-  high: { label: 'High', Icon: ChevronUp, color: 'var(--status-orange)', weight: 400 },
-  medium: { label: 'Medium', Icon: Minus, color: 'var(--text-tertiary)', weight: 400 },
-  low: { label: 'Low', Icon: ChevronDown, color: 'var(--text-quaternary)', weight: 400 },
+  urgent: { label: 'Urgent', variant: 'urgent', weight: 700 },
+  high: { label: 'High', variant: 'high', weight: 400 },
+  medium: { label: 'Medium', variant: 'med', weight: 400 },
+  low: { label: 'Low', variant: 'low', weight: 400 },
+};
+
+const CHIP_BASE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 12,
+  lineHeight: 1,
+  color: 'var(--text-secondary)',
+};
+
+const ICON_ONLY_BASE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 };
 
 export function VocPriorityBadge({
@@ -19,17 +37,34 @@ export function VocPriorityBadge({
   priority: VocPriority;
   iconOnly?: boolean;
 }) {
-  const { label, Icon, color, weight } = PRIORITY_CONFIG[priority];
+  const { label, variant, weight } = PRIORITY_CONFIG[priority];
+  const ariaLabel = `Priority ${label}`;
+  const testId = `priority-badge-${priority}`;
+
+  if (iconOnly) {
+    return (
+      <span
+        data-testid={testId}
+        data-variant={variant}
+        aria-label={ariaLabel}
+        role="img"
+        style={{ ...ICON_ONLY_BASE, fontWeight: weight }}
+      >
+        <PriorityBars variant={variant} />
+      </span>
+    );
+  }
+
   return (
-    <TextMark
-      variant={priority}
-      iconMode={iconOnly ? 'icon-only' : 'icon+text'}
-      icon={Icon}
-      label={label}
-      color={color}
-      weight={weight}
-      extraTestId={`priority-badge-${priority}`}
-      ariaLabelOverride={`Priority ${label}`}
-    />
+    <span
+      data-testid={testId}
+      data-variant={variant}
+      aria-label={ariaLabel}
+      role="img"
+      style={{ ...CHIP_BASE, fontWeight: weight }}
+    >
+      <PriorityBars variant={variant} />
+      <span>{label}</span>
+    </span>
   );
 }

--- a/frontend/src/entities/voc/ui/VocTagPill.tsx
+++ b/frontend/src/entities/voc/ui/VocTagPill.tsx
@@ -1,4 +1,4 @@
-import { TextMark } from '@shared/ui/badge';
+import { OutlineChip } from '@shared/ui/badge';
 
 export interface VocTagPillProps {
   name: string;
@@ -6,18 +6,12 @@ export interface VocTagPillProps {
 
 export function VocTagPill({ name }: VocTagPillProps) {
   return (
-    <span data-testid="voc-tag-pill" data-tag-name={name}>
-      <TextMark
-        variant="tag"
-        iconMode="icon+text"
-        icon="#"
-        label={name}
-        size="xs"
-        weight={500}
-        color="var(--text-quaternary)"
-        extraTestId="text-mark-tag"
-        ariaLabelOverride={`태그 ${name}`}
-      />
+    <span
+      data-testid="voc-tag-pill"
+      data-tag-name={name}
+      aria-label={`태그 ${name}`}
+    >
+      <OutlineChip variant="dot-pill" label={name} />
     </span>
   );
 }

--- a/frontend/src/entities/voc/ui/VocTagPill.tsx
+++ b/frontend/src/entities/voc/ui/VocTagPill.tsx
@@ -4,6 +4,32 @@ export interface VocTagPillProps {
   name: string;
 }
 
+// Cool-tone palette only — avoids collision with status-glyph (amber/red/emerald)
+// and priority-bars (red/orange). Tokens defined in shared/styles/globals.css.
+const TAG_COLOR_PALETTE = [
+  'var(--chart-blue)',
+  'var(--chart-sky)',
+  'var(--chart-teal)',
+  'var(--chart-indigo)',
+] as const;
+
+const FALLBACK_DOT_COLOR = 'var(--text-quaternary)';
+
+/**
+ * Deterministic tag-name → palette index via djb2 hash.
+ * Same name always maps to the same color across renders.
+ */
+export function hashTagColor(name: string): string {
+  if (!name) return FALLBACK_DOT_COLOR;
+  let hash = 5381;
+  for (let i = 0; i < name.length; i++) {
+    // hash * 33 + c
+    hash = ((hash << 5) + hash + name.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % TAG_COLOR_PALETTE.length;
+  return TAG_COLOR_PALETTE[index] ?? FALLBACK_DOT_COLOR;
+}
+
 export function VocTagPill({ name }: VocTagPillProps) {
   return (
     <span
@@ -11,7 +37,7 @@ export function VocTagPill({ name }: VocTagPillProps) {
       data-tag-name={name}
       aria-label={`태그 ${name}`}
     >
-      <OutlineChip variant="dot-pill" label={name} />
+      <OutlineChip variant="dot-pill" label={name} dotColor={hashTagColor(name)} />
     </span>
   );
 }

--- a/frontend/src/entities/voc/ui/VocTypeBadge.tsx
+++ b/frontend/src/entities/voc/ui/VocTypeBadge.tsx
@@ -5,17 +5,16 @@ export interface VocTypeBadgeProps {
   slug: string;
   name: string;
   color?: string;
-  iconOnly?: boolean;
 }
 
-export function VocTypeBadge({ slug, name, iconOnly = false }: VocTypeBadgeProps) {
+export function VocTypeBadge({ slug, name }: VocTypeBadgeProps) {
   const { Icon, color, weight, isUnknown } = getVocTypeIconConfig(slug);
   const variant = isUnknown ? 'unknown' : slug;
 
   return (
     <TextMark
       variant={variant}
-      iconMode={iconOnly ? 'icon-only' : 'icon+text'}
+      iconMode="icon+text"
       icon={Icon}
       label={name}
       color={color}

--- a/frontend/src/entities/voc/ui/__tests__/VocAssignee.test.tsx
+++ b/frontend/src/entities/voc/ui/__tests__/VocAssignee.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { VocAssignee, hashAssigneeColor } from '../VocAssignee';
+import { VocAssignee } from '../VocAssignee';
 
 describe('VocAssignee', () => {
   it('renders unassigned state when name is null', () => {
@@ -24,7 +24,7 @@ describe('VocAssignee', () => {
 
   it('renders assigned state with initial and name', () => {
     render(<VocAssignee name="홍길동" />);
-    const el = screen.getByTestId(/^assignee-(steel|teal|violet)$/);
+    const el = screen.getByTestId('assignee-circle');
     expect(el).toBeInTheDocument();
     expect(el).toHaveTextContent('홍길동');
     expect(el).toHaveAttribute('aria-label', '담당자 홍길동');
@@ -38,47 +38,16 @@ describe('VocAssignee', () => {
     expect(initialNode).toBeInTheDocument();
   });
 
-  it('explicit colorClass prop overrides hash', () => {
-    render(<VocAssignee name="홍길동" colorClass="violet" />);
-    expect(screen.getByTestId('assignee-violet')).toBeInTheDocument();
-  });
-
-  it('hashAssigneeColor is deterministic and total over the 3 buckets', () => {
-    expect(hashAssigneeColor('홍길동')).toBe(hashAssigneeColor('홍길동'));
-    const buckets = new Set<string>();
-    [
-      '홍길동',
-      '김철수',
-      '이영희',
-      '박민수',
-      '최지우',
-      '정아름',
-      'Alice',
-      'Bob',
-      'Carol',
-      'Dave',
-    ].forEach((n) => {
-      buckets.add(hashAssigneeColor(n));
-    });
-    expect(buckets.size).toBe(3);
-  });
-
-  it('hashAssigneeColor locks specific name→bucket pairs (regression guard)', () => {
-    expect(hashAssigneeColor('홍길동')).toBe('violet');
-    expect(hashAssigneeColor('이분석')).toBe('steel');
-    expect(hashAssigneeColor('Alice')).toBe('teal');
-  });
-
   it('rendered output contains no hex literal anywhere (className OR inline style)', () => {
     render(<VocAssignee name="홍길동" />);
-    const el = screen.getByTestId(/^assignee-(steel|teal|violet)$/);
+    const el = screen.getByTestId('assignee-circle');
     expect(el.outerHTML).not.toMatch(/#[0-9a-f]{3,8}\b/i);
   });
 
   it('has data-testid marker for visual-diff (assigned)', () => {
     render(<VocAssignee name="홍길동" />);
-    const el = screen.getByTestId(/^assignee-(steel|teal|violet)$/);
-    expect(el.getAttribute('data-testid')).toMatch(/^assignee-(steel|teal|violet)$/);
+    const el = screen.getByTestId('assignee-circle');
+    expect(el.getAttribute('data-testid')).toBe('assignee-circle');
   });
 
   it('has data-testid marker for visual-diff (unassigned)', () => {

--- a/frontend/src/entities/voc/ui/__tests__/VocPriorityBadge.test.tsx
+++ b/frontend/src/entities/voc/ui/__tests__/VocPriorityBadge.test.tsx
@@ -4,16 +4,17 @@ import type { VocPriority } from '@contracts/voc';
 
 describe('VocPriorityBadge', () => {
   type Case = [VocPriority, string, string, number];
+  // [priority, label, bars-variant, fontWeight]
   const cases: Case[] = [
-    ['urgent', 'Urgent', 'flame', 700],
-    ['high', 'High', 'chevron-up', 400],
-    ['medium', 'Medium', 'minus', 400],
-    ['low', 'Low', 'chevron-down', 400],
+    ['urgent', 'Urgent', 'urgent', 700],
+    ['high', 'High', 'high', 400],
+    ['medium', 'Medium', 'med', 400],
+    ['low', 'Low', 'low', 400],
   ];
 
   it.each(cases)(
-    'renders priority=%s with label %s, icon %s, fontWeight %s',
-    (priority, label, iconClass, fontWeight) => {
+    'renders priority=%s with label %s, bars %s, fontWeight %s',
+    (priority, label, barsVariant, fontWeight) => {
       render(<VocPriorityBadge priority={priority} />);
 
       const el = screen.getByTestId(`priority-badge-${priority}`);
@@ -24,18 +25,27 @@ describe('VocPriorityBadge', () => {
       // font-weight via inline style
       expect(el.style.fontWeight).toBe(String(fontWeight));
 
-      // icon: lucide renders an svg; check aria-hidden child exists
-      const icon = el.querySelector('[aria-hidden="true"]');
-      expect(icon).not.toBeNull();
+      // PriorityBars glyph child rendered with matching variant
+      const bars = el.querySelector(`[data-testid="priority-bars-${barsVariant}"]`);
+      expect(bars).not.toBeNull();
+      expect(bars?.getAttribute('data-variant')).toBe(barsVariant);
 
-      // icon class contains the lucide icon name
-      expect(icon?.getAttribute('class') ?? '').toContain(iconClass);
+      // exactly 3 bar children inside the glyph
+      const segments = bars?.querySelectorAll('i[aria-hidden="true"]');
+      expect(segments?.length).toBe(3);
     },
   );
 
-  it('no hex color in className (lint hard rule)', () => {
+  it('iconOnly mode renders glyph without label text', () => {
+    render(<VocPriorityBadge priority="urgent" iconOnly />);
+    const el = screen.getByTestId('priority-badge-urgent');
+    expect(el.textContent ?? '').not.toContain('Urgent');
+    expect(el.querySelector('[data-testid="priority-bars-urgent"]')).not.toBeNull();
+  });
+
+  it('no hex color literal in markup (lint hard rule)', () => {
     render(<VocPriorityBadge priority="urgent" />);
     const el = screen.getByTestId('priority-badge-urgent');
-    expect(el.className).not.toMatch(/#[0-9a-f]/i);
+    expect(el.outerHTML).not.toMatch(/#[0-9a-f]{3,8}/i);
   });
 });

--- a/frontend/src/entities/voc/ui/__tests__/VocTagPill.test.tsx
+++ b/frontend/src/entities/voc/ui/__tests__/VocTagPill.test.tsx
@@ -7,28 +7,31 @@ describe('VocTagPill', () => {
     expect(screen.getByText('UX')).toBeInTheDocument();
   });
 
-  it('renders # glyph (aria-hidden) preceding the label in document order', () => {
-    render(<VocTagPill name="UX" />);
-    const hash = screen.getByText('#');
-    expect(hash).toHaveAttribute('aria-hidden', 'true');
-    const pill = screen.getByTestId('voc-tag-pill');
-    expect(pill).toHaveTextContent(/^#UX$/);
-  });
-
   it('has stable data-testid="voc-tag-pill" with name in data-tag-name', () => {
     render(<VocTagPill name="UX bug" />);
     const pill = screen.getByTestId('voc-tag-pill');
     expect(pill).toHaveAttribute('data-tag-name', 'UX bug');
   });
 
-  it('delegates to TextMark primitive (not OutlineChip)', () => {
+  it('delegates to OutlineChip in dot-pill variant (no # glyph)', () => {
     render(<VocTagPill name="UX" />);
-    expect(screen.getByTestId('text-mark-tag')).toBeInTheDocument();
-    expect(screen.queryByTestId('outline-chip')).not.toBeInTheDocument();
+    const chip = screen.getByTestId('outline-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute('data-variant', 'dot-pill');
+    // No '#' prefix anymore — the dot replaces the hash glyph.
+    expect(chip.textContent).toBe('UX');
   });
 
-  it('TextMark child has aria-label "태그 {name}" (override)', () => {
+  it('renders a dot child element (aria-hidden) preceding the label', () => {
     render(<VocTagPill name="UX" />);
-    expect(screen.getByTestId('text-mark-tag')).toHaveAttribute('aria-label', '태그 UX');
+    const chip = screen.getByTestId('outline-chip');
+    const dot = chip.querySelector('.lc-dot');
+    expect(dot).not.toBeNull();
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('exposes accessible label "태그 {name}" on the wrapping pill', () => {
+    render(<VocTagPill name="UX" />);
+    expect(screen.getByTestId('voc-tag-pill')).toHaveAttribute('aria-label', '태그 UX');
   });
 });

--- a/frontend/src/entities/voc/ui/__tests__/VocTagPill.test.tsx
+++ b/frontend/src/entities/voc/ui/__tests__/VocTagPill.test.tsx
@@ -1,5 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import { VocTagPill } from '../VocTagPill';
+import { VocTagPill, hashTagColor } from '../VocTagPill';
+
+const PALETTE = [
+  'var(--chart-blue)',
+  'var(--chart-sky)',
+  'var(--chart-teal)',
+  'var(--chart-indigo)',
+];
+
+function dotBackground(container: HTMLElement): string {
+  const dot = container.querySelector('.lc-dot') as HTMLElement | null;
+  return dot?.style.background ?? '';
+}
 
 describe('VocTagPill', () => {
   it('renders with given name', () => {
@@ -33,5 +45,41 @@ describe('VocTagPill', () => {
   it('exposes accessible label "태그 {name}" on the wrapping pill', () => {
     render(<VocTagPill name="UX" />);
     expect(screen.getByTestId('voc-tag-pill')).toHaveAttribute('aria-label', '태그 UX');
+  });
+
+  describe('hashTagColor (deterministic palette)', () => {
+    it('returns one of the cool-tone palette tokens for a non-empty name', () => {
+      const color = hashTagColor('UX');
+      expect(PALETTE).toContain(color);
+    });
+
+    it('is deterministic — same name always maps to the same color', () => {
+      const a = hashTagColor('performance');
+      const b = hashTagColor('performance');
+      expect(a).toBe(b);
+    });
+
+    it('renders the dot with the hashed color (deterministic across renders)', () => {
+      const { unmount } = render(<VocTagPill name="performance" />);
+      const first = dotBackground(screen.getByTestId('outline-chip'));
+      unmount();
+      render(<VocTagPill name="performance" />);
+      const second = dotBackground(screen.getByTestId('outline-chip'));
+      expect(first).toBe(second);
+      expect(PALETTE).toContain(first);
+    });
+
+    it('falls back to var(--text-quaternary) for empty name', () => {
+      expect(hashTagColor('')).toBe('var(--text-quaternary)');
+    });
+
+    it('distributes across multiple palette colors for varied names', () => {
+      const names = ['UX', 'performance', 'bug', 'feature', 'design', 'api', 'auth', 'mobile'];
+      const colors = new Set(names.map(hashTagColor));
+      // Expect at least 2 distinct palette entries — guards against a
+      // degenerate hash that collapses everything to one bucket.
+      expect(colors.size).toBeGreaterThanOrEqual(2);
+      colors.forEach((c) => expect(PALETTE).toContain(c));
+    });
   });
 });

--- a/frontend/src/entities/voc/ui/__tests__/VocTypeBadge.test.tsx
+++ b/frontend/src/entities/voc/ui/__tests__/VocTypeBadge.test.tsx
@@ -40,18 +40,6 @@ describe('VocTypeBadge', () => {
     expect(svg?.getAttribute('class') ?? '').toContain('lucide-tag');
   });
 
-  it('iconOnly: renders icon without text label', () => {
-    render(<VocTypeBadge slug="bug" name="버그" iconOnly />);
-    const el = screen.getByTestId('voc-type-badge-bug');
-    expect(el).toBeInTheDocument();
-    // aria-label preserved for a11y
-    expect(el).toHaveAttribute('aria-label', '유형 버그');
-    // text label is not rendered as visible text content (icon-only mode)
-    expect(el.textContent ?? '').not.toContain('버그');
-    // svg still present
-    expect(el.querySelector('svg')).not.toBeNull();
-  });
-
   it('color prop ignored — rendering is same with or without it', () => {
     const { rerender } = render(<VocTypeBadge slug="bug" name="버그" />);
     const without = screen.getByTestId('voc-type-badge-bug').getAttribute('style');

--- a/frontend/src/features/voc/list/__tests__/VocRow.test.tsx
+++ b/frontend/src/features/voc/list/__tests__/VocRow.test.tsx
@@ -47,10 +47,6 @@ const assigneeMap: Record<string, string> = {
   'user-123': '김담당',
 };
 
-const vocTypeMap: Record<string, { slug: string; name: string }> = {
-  'vtype-001': { slug: 'bug', name: '버그' },
-};
-
 describe('VocRow', () => {
   it('renders role="row" with data-testid="voc-row"', () => {
     render(<VocRow row={row} assigneeMap={assigneeMap} onClick={() => {}} />);
@@ -176,21 +172,8 @@ describe('VocRow', () => {
     expect(screen.queryAllByTestId('voc-tag-pill')).toHaveLength(0);
   });
 
-  it('F-2: renders VocTypeBadge in title cell when vocTypeMap has the row voc_type_id', () => {
-    render(
-      <VocRow row={row} assigneeMap={assigneeMap} vocTypeMap={vocTypeMap} onClick={() => {}} />,
-    );
-    expect(screen.getByTestId('voc-type-badge-bug')).toBeInTheDocument();
-  });
-
-  it('F-2: omits VocTypeBadge when vocTypeMap is absent (backward compatible)', () => {
+  it('Flowline C-extension: title cell does not prepend a VocTypeBadge (type info lives in detail/drawer)', () => {
     render(<VocRow row={row} assigneeMap={assigneeMap} onClick={() => {}} />);
-    expect(screen.queryByTestId('voc-type-badge-bug')).toBeNull();
-    expect(screen.queryByTestId('text-mark-unknown')).toBeNull();
-  });
-
-  it('F-2: omits VocTypeBadge when vocTypeMap is missing the row voc_type_id', () => {
-    render(<VocRow row={row} assigneeMap={assigneeMap} vocTypeMap={{}} onClick={() => {}} />);
     expect(screen.queryByTestId('voc-type-badge-bug')).toBeNull();
     expect(screen.queryByTestId('text-mark-unknown')).toBeNull();
   });

--- a/frontend/src/features/voc/list/ui/VocRow.tsx
+++ b/frontend/src/features/voc/list/ui/VocRow.tsx
@@ -7,21 +7,14 @@ import {
   VocPriorityBadge,
   VocAssignee,
   VocTagPill,
-  VocTypeBadge,
 } from '@entities/voc';
 import { IssueId } from '@shared/ui/issue-id';
 
 type VocRowData = VocListResponse['rows'][number];
 
-export interface VocTypeMapEntry {
-  slug: string;
-  name: string;
-}
-
 export interface VocRowProps {
   row: VocRowData;
   assigneeMap: Record<string, string>;
-  vocTypeMap?: Record<string, VocTypeMapEntry>;
   selected?: boolean;
   onClick: () => void;
   /** Spec §9.2.2: parent rows expose ▶/▼ toggle when subtasks exist. */
@@ -51,7 +44,6 @@ const CONTAINER_STYLE: CSSProperties = {
 export function VocRow({
   row,
   assigneeMap,
-  vocTypeMap,
   selected = false,
   onClick,
   hasChildren = false,
@@ -59,7 +51,6 @@ export function VocRow({
   onToggleExpand,
   indented = false,
 }: VocRowProps) {
-  const vocType = vocTypeMap?.[row.voc_type_id];
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -108,6 +99,8 @@ export function VocRow({
             <ChevronRight
               aria-hidden="true"
               className="voc-row-expand"
+              width={14}
+              height={14}
               style={{
                 transition: 'transform 120ms ease',
                 transform: expanded ? 'rotate(90deg)' : 'none',
@@ -128,7 +121,6 @@ export function VocRow({
       </div>
 
       <div role="gridcell" className="voc-row-title">
-        {vocType && <VocTypeBadge slug={vocType.slug} name={vocType.name} iconOnly />}
         <span className="voc-title-text">{row.title}</span>
         {row.tags.length > 0 && (
           <div className="tag-row">

--- a/frontend/src/features/voc/list/ui/VocStatusGroupHeader.tsx
+++ b/frontend/src/features/voc/list/ui/VocStatusGroupHeader.tsx
@@ -1,7 +1,6 @@
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import type { CSSProperties, KeyboardEvent } from 'react';
 import type { VocStatus } from '@contracts/voc';
 import { VocStatusBadge } from '@entities/voc';
+import { ListGroupHeader } from '@shared/ui/list-group-header';
 
 export interface VocStatusGroupHeaderProps {
   status: VocStatus;
@@ -10,70 +9,33 @@ export interface VocStatusGroupHeaderProps {
   onToggle: () => void;
 }
 
-// Phase 5: Linear-style group header (ref Tasks.html `.igroup-h`).
-// padding 8px 24px, font-size 12px / 600, color text-secondary.
-const HEADER_STYLE: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '8px',
-  width: '100%',
-  paddingTop: '8px',
-  paddingBottom: '8px',
-  paddingLeft: 'var(--sp-5)',
-  paddingRight: 'var(--sp-5)',
-  background: 'var(--bg-panel)',
-  fontSize: '12px',
-  fontWeight: 600,
-  color: 'var(--text-secondary)',
-  letterSpacing: '0.02em',
-  border: 'none',
-  borderTop: '1px solid var(--border-subtle)',
-  borderBottom: '1px solid var(--border-subtle)',
-  cursor: 'pointer',
-  textAlign: 'left' as const,
-};
-
-const COUNT_STYLE: CSSProperties = {
-  fontSize: '11px',
-  color: 'var(--text-tertiary)',
-  fontWeight: 500,
-};
-
-const CHEVRON_STYLE: CSSProperties = {
-  width: 14,
-  height: 14,
-  color: 'var(--text-tertiary)',
-};
-
+// Wave C-extension: domain wrapper around `ListGroupHeader` (uidesign.md §16.6).
+// Visual contract identical to prior inline implementation; legacy `voc-*` testids
+// preserved for back-compat with consumers in `widgets/voc-workspace` integrations.
 export function VocStatusGroupHeader({
   status,
   count,
   collapsed,
   onToggle,
 }: VocStatusGroupHeaderProps) {
-  const Chevron = collapsed ? ChevronRight : ChevronDown;
-  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onToggle();
-    }
-  };
   return (
-    <button
-      type="button"
-      data-testid={`voc-status-group-header-${status}`}
-      data-collapsed={collapsed ? 'true' : 'false'}
-      aria-expanded={!collapsed}
-      onClick={onToggle}
-      onKeyDown={handleKeyDown}
-      style={HEADER_STYLE}
+    <ListGroupHeader
+      collapsed={collapsed}
+      onToggle={onToggle}
+      testId={`voc-status-group-header-${status}`}
     >
-      <Chevron aria-hidden="true" style={CHEVRON_STYLE} data-testid="voc-status-group-chevron" />
       <VocStatusBadge status={status} iconOnly />
       <span>{status}</span>
-      <span style={COUNT_STYLE} data-testid="voc-status-group-count">
+      <span
+        data-testid="voc-status-group-count"
+        style={{
+          fontSize: '11px',
+          color: 'var(--text-tertiary)',
+          fontWeight: 500,
+        }}
+      >
         {count}
       </span>
-    </button>
+    </ListGroupHeader>
   );
 }

--- a/frontend/src/features/voc/list/ui/VocTable.tsx
+++ b/frontend/src/features/voc/list/ui/VocTable.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { VocListHeader } from './VocListHeader';
-import { VocRow, type VocTypeMapEntry } from './VocRow';
+import { VocRow } from './VocRow';
 import { VocStatusGroupHeader } from './VocStatusGroupHeader';
 import type { VocListResponse, VocSortColumn, SortDir, VocStatus } from '@contracts/voc';
 
@@ -16,7 +16,6 @@ interface VocTableProps {
   onSort: (key: VocSortColumn) => void;
   onRowClick: (id: string) => void;
   assigneeMap: Record<string, string>;
-  vocTypeMap?: Record<string, VocTypeMapEntry>;
   selectedId?: string | null;
   groupByStatus?: boolean;
   collapsedStatuses?: ReadonlySet<VocStatus>;
@@ -50,7 +49,6 @@ export function VocTable({
   onSort,
   onRowClick,
   assigneeMap,
-  vocTypeMap,
   selectedId,
   groupByStatus = false,
   collapsedStatuses,
@@ -96,7 +94,6 @@ export function VocTable({
         <VocRow
           row={row}
           assigneeMap={assigneeMap}
-          vocTypeMap={vocTypeMap}
           selected={row.id === selectedId}
           onClick={() => onRowClick(row.id)}
           hasChildren={hasChildren}
@@ -109,7 +106,6 @@ export function VocTable({
               key={child.id}
               row={child}
               assigneeMap={assigneeMap}
-              vocTypeMap={vocTypeMap}
               selected={child.id === selectedId}
               onClick={() => onRowClick(child.id)}
               indented

--- a/frontend/src/shared/ui/badge/OutlineChip.tsx
+++ b/frontend/src/shared/ui/badge/OutlineChip.tsx
@@ -1,17 +1,61 @@
+import type { CSSProperties } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@shared/lib/cn';
 import { badgeVariants } from './Badge';
+
+export type OutlineChipVariant = 'default' | 'dot-pill';
 
 export interface OutlineChipProps {
   label: string;
   icon?: LucideIcon | '#';
   size?: 'sm';
+  variant?: OutlineChipVariant;
+  /** Token reference (e.g. `var(--text-quaternary)`); only used when variant === 'dot-pill'. */
+  dotColor?: string;
 }
 
-export function OutlineChip({ label, icon }: OutlineChipProps) {
+const DOT_PILL_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '5px',
+  padding: '1px 8px',
+  borderRadius: '9999px',
+  border: '1px solid var(--border-subtle)',
+  background: 'var(--bg-elevated)',
+  fontSize: '11.5px',
+  fontWeight: 500,
+  color: 'var(--text-secondary)',
+};
+
+const DOT_STYLE_BASE: CSSProperties = {
+  width: '7px',
+  height: '7px',
+  borderRadius: '50%',
+};
+
+export function OutlineChip({ label, icon, variant = 'default', dotColor }: OutlineChipProps) {
+  if (variant === 'dot-pill') {
+    return (
+      <span
+        data-testid="outline-chip"
+        data-variant="dot-pill"
+        className="outline-chip"
+        style={DOT_PILL_STYLE}
+      >
+        <span
+          className="lc-dot"
+          aria-hidden="true"
+          style={{ ...DOT_STYLE_BASE, background: dotColor ?? 'var(--text-quaternary)' }}
+        />
+        {label}
+      </span>
+    );
+  }
+
   return (
     <span
       data-testid="outline-chip"
+      data-variant="default"
       className={cn(
         badgeVariants({ chipVariant: 'outline' }),
         'text-[length:var(--chip-font-size-sm)]',

--- a/frontend/src/shared/ui/badge/__tests__/OutlineChip.test.tsx
+++ b/frontend/src/shared/ui/badge/__tests__/OutlineChip.test.tsx
@@ -41,4 +41,40 @@ describe('OutlineChip', () => {
     expect(style).not.toMatch(/#[0-9a-fA-F]{3,8}(?![0-9a-fA-F])/);
     expect(style).not.toMatch(/oklch\(/i);
   });
+
+  describe('variant="dot-pill"', () => {
+    it('renders with data-variant="dot-pill" and a .lc-dot child (aria-hidden)', () => {
+      render(<OutlineChip variant="dot-pill" label="UX" />);
+      const el = screen.getByTestId('outline-chip');
+      expect(el).toHaveAttribute('data-variant', 'dot-pill');
+      const dot = el.querySelector('.lc-dot');
+      expect(dot).not.toBeNull();
+      expect(dot).toHaveAttribute('aria-hidden', 'true');
+      expect(el.textContent).toBe('UX');
+    });
+
+    it('default dot color is var(--text-quaternary); custom dotColor is honored', () => {
+      const { rerender } = render(<OutlineChip variant="dot-pill" label="UX" />);
+      let dot = screen.getByTestId('outline-chip').querySelector('.lc-dot') as HTMLElement;
+      expect(dot.getAttribute('style') ?? '').toContain('var(--text-quaternary)');
+
+      rerender(
+        <OutlineChip variant="dot-pill" label="UX" dotColor="var(--accent)" />,
+      );
+      dot = screen.getByTestId('outline-chip').querySelector('.lc-dot') as HTMLElement;
+      expect(dot.getAttribute('style') ?? '').toContain('var(--accent)');
+    });
+
+    it('inline style uses tokens only — no hex/oklch literals', () => {
+      render(<OutlineChip variant="dot-pill" label="UX" />);
+      const el = screen.getByTestId('outline-chip');
+      const style = el.getAttribute('style') ?? '';
+      expect(style).not.toMatch(/#[0-9a-fA-F]{3,8}(?![0-9a-fA-F])/);
+      expect(style).not.toMatch(/oklch\(/i);
+      const dotStyle =
+        (el.querySelector('.lc-dot') as HTMLElement | null)?.getAttribute('style') ?? '';
+      expect(dotStyle).not.toMatch(/#[0-9a-fA-F]{3,8}(?![0-9a-fA-F])/);
+      expect(dotStyle).not.toMatch(/oklch\(/i);
+    });
+  });
 });

--- a/frontend/src/shared/ui/badge/index.ts
+++ b/frontend/src/shared/ui/badge/index.ts
@@ -3,6 +3,6 @@ export type { BadgeVariantProps } from './Badge';
 export { TextMark } from './TextMark';
 export type { TextMarkProps } from './TextMark';
 export { OutlineChip } from './OutlineChip';
-export type { OutlineChipProps } from './OutlineChip';
+export type { OutlineChipProps, OutlineChipVariant } from './OutlineChip';
 export { SolidChip } from './SolidChip';
 export type { SolidChipProps, SolidChipVariant } from './SolidChip';

--- a/frontend/src/shared/ui/list-group-header/ListGroupHeader.tsx
+++ b/frontend/src/shared/ui/list-group-header/ListGroupHeader.tsx
@@ -1,0 +1,83 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
+
+export interface ListGroupHeaderProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  count?: number;
+  children: ReactNode;
+  testId?: string;
+  ariaLabel?: string;
+}
+
+// uidesign.md §16.6 — list group header (Linear-style).
+// padding 8px 24px, font-size 12px / 600, color text-secondary.
+const HEADER_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  width: '100%',
+  paddingTop: '8px',
+  paddingBottom: '8px',
+  paddingLeft: 'var(--sp-5)',
+  paddingRight: 'var(--sp-5)',
+  background: 'var(--bg-panel)',
+  fontSize: '12px',
+  fontWeight: 600,
+  color: 'var(--text-secondary)',
+  letterSpacing: '0.02em',
+  border: 'none',
+  borderTop: '1px solid var(--border-subtle)',
+  borderBottom: '1px solid var(--border-subtle)',
+  cursor: 'pointer',
+  textAlign: 'left' as const,
+};
+
+const COUNT_STYLE: CSSProperties = {
+  fontSize: '11px',
+  color: 'var(--text-tertiary)',
+  fontWeight: 500,
+};
+
+const CHEVRON_STYLE: CSSProperties = {
+  width: 14,
+  height: 14,
+  color: 'var(--text-tertiary)',
+};
+
+export function ListGroupHeader({
+  collapsed,
+  onToggle,
+  count,
+  children,
+  testId,
+  ariaLabel,
+}: ListGroupHeaderProps) {
+  const Chevron = collapsed ? ChevronRight : ChevronDown;
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onToggle();
+    }
+  };
+  return (
+    <button
+      type="button"
+      data-testid={testId ?? 'list-group-header'}
+      data-collapsed={collapsed ? 'true' : 'false'}
+      aria-expanded={!collapsed}
+      aria-label={ariaLabel}
+      onClick={onToggle}
+      onKeyDown={handleKeyDown}
+      style={HEADER_STYLE}
+    >
+      <Chevron aria-hidden="true" style={CHEVRON_STYLE} data-testid="list-group-header-chevron" />
+      {children}
+      {count !== undefined && (
+        <span style={COUNT_STYLE} data-testid="list-group-header-count">
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/shared/ui/list-group-header/__tests__/ListGroupHeader.test.tsx
+++ b/frontend/src/shared/ui/list-group-header/__tests__/ListGroupHeader.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ListGroupHeader } from '../ListGroupHeader';
+
+describe('ListGroupHeader — uidesign.md §16.6', () => {
+  it('renders children as label content', () => {
+    render(
+      <ListGroupHeader collapsed={false} onToggle={() => {}}>
+        <span>Group A</span>
+      </ListGroupHeader>,
+    );
+    expect(screen.getByText('Group A')).toBeInTheDocument();
+  });
+
+  it('renders count when provided and omits when undefined', () => {
+    const { rerender } = render(
+      <ListGroupHeader collapsed={false} onToggle={() => {}} count={7}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    expect(screen.getByTestId('list-group-header-count')).toHaveTextContent('7');
+    rerender(
+      <ListGroupHeader collapsed={false} onToggle={() => {}}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    expect(screen.queryByTestId('list-group-header-count')).toBeNull();
+  });
+
+  it('reflects collapsed state via data-collapsed and aria-expanded', () => {
+    const { rerender } = render(
+      <ListGroupHeader collapsed={false} onToggle={() => {}}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    const btn = screen.getByTestId('list-group-header');
+    expect(btn).toHaveAttribute('data-collapsed', 'false');
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+    rerender(
+      <ListGroupHeader collapsed={true} onToggle={() => {}}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    expect(screen.getByTestId('list-group-header')).toHaveAttribute('data-collapsed', 'true');
+    expect(screen.getByTestId('list-group-header')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('clicking the header invokes onToggle', () => {
+    const onToggle = vi.fn();
+    render(
+      <ListGroupHeader collapsed={false} onToggle={onToggle}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    fireEvent.click(screen.getByTestId('list-group-header'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('keyboard Enter and Space trigger onToggle', () => {
+    const onToggle = vi.fn();
+    render(
+      <ListGroupHeader collapsed={true} onToggle={onToggle}>
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    const btn = screen.getByTestId('list-group-header');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyDown(btn, { key: ' ' });
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors custom testId and ariaLabel', () => {
+    render(
+      <ListGroupHeader
+        collapsed={false}
+        onToggle={() => {}}
+        testId="custom-tid"
+        ariaLabel="custom label"
+      >
+        <span>L</span>
+      </ListGroupHeader>,
+    );
+    const btn = screen.getByTestId('custom-tid');
+    expect(btn).toHaveAttribute('aria-label', 'custom label');
+  });
+});

--- a/frontend/src/shared/ui/list-group-header/index.ts
+++ b/frontend/src/shared/ui/list-group-header/index.ts
@@ -1,0 +1,2 @@
+export { ListGroupHeader } from './ListGroupHeader';
+export type { ListGroupHeaderProps } from './ListGroupHeader';

--- a/frontend/src/shared/ui/priority-bars/PriorityBars.tsx
+++ b/frontend/src/shared/ui/priority-bars/PriorityBars.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties } from 'react';
+
+export type PriorityBarsVariant = 'urgent' | 'high' | 'med' | 'low';
+
+export interface PriorityBarsProps {
+  variant: PriorityBarsVariant;
+  ariaLabel?: string;
+}
+
+const CONTAINER: CSSProperties = {
+  width: 14,
+  height: 14,
+  display: 'inline-flex',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  gap: 1.5,
+  flex: '0 0 auto',
+};
+
+const BAR_BASE: CSSProperties = {
+  width: 2.5,
+  borderRadius: 1,
+  display: 'inline-block',
+};
+
+const BAR_HEIGHTS = [4, 7, 10] as const;
+
+function barColors(variant: PriorityBarsVariant): [string, string, string] {
+  switch (variant) {
+    case 'urgent':
+      return ['var(--status-red)', 'var(--status-red)', 'var(--status-red)'];
+    case 'high':
+      return [
+        'var(--status-orange)',
+        'var(--status-orange)',
+        'var(--status-orange)',
+      ];
+    case 'med':
+      return [
+        'var(--text-secondary)',
+        'var(--text-secondary)',
+        'var(--text-quaternary)',
+      ];
+    case 'low':
+      return [
+        'var(--text-secondary)',
+        'var(--text-quaternary)',
+        'var(--text-quaternary)',
+      ];
+  }
+}
+
+export function PriorityBars({ variant, ariaLabel }: PriorityBarsProps) {
+  const colors = barColors(variant);
+  return (
+    <span
+      role={ariaLabel ? 'img' : 'presentation'}
+      aria-label={ariaLabel}
+      data-testid={`priority-bars-${variant}`}
+      data-variant={variant}
+      style={CONTAINER}
+    >
+      {BAR_HEIGHTS.map((h, i) => (
+        <i
+          key={i}
+          aria-hidden="true"
+          style={{
+            ...BAR_BASE,
+            height: h,
+            background: colors[i],
+          }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/shared/ui/priority-bars/__tests__/PriorityBars.test.tsx
+++ b/frontend/src/shared/ui/priority-bars/__tests__/PriorityBars.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { PriorityBars, type PriorityBarsVariant } from '../PriorityBars';
+
+const VARIANTS: PriorityBarsVariant[] = ['urgent', 'high', 'med', 'low'];
+
+describe('PriorityBars — uidesign.md §16.4', () => {
+  it.each(VARIANTS)('renders 14px container for %s', (variant) => {
+    render(<PriorityBars variant={variant} />);
+    const el = screen.getByTestId(`priority-bars-${variant}`);
+    expect(el).toHaveAttribute('data-variant', variant);
+    expect(el.style.width).toBe('14px');
+    expect(el.style.height).toBe('14px');
+  });
+
+  it.each(VARIANTS)('renders exactly 3 bar children for %s', (variant) => {
+    render(<PriorityBars variant={variant} />);
+    const el = screen.getByTestId(`priority-bars-${variant}`);
+    const bars = el.querySelectorAll('i[aria-hidden="true"]');
+    expect(bars.length).toBe(3);
+  });
+
+  it('exposes aria-label as role=img when provided', () => {
+    render(<PriorityBars variant="urgent" ariaLabel="Priority Urgent" />);
+    const el = screen.getByTestId('priority-bars-urgent');
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).toHaveAttribute('aria-label', 'Priority Urgent');
+  });
+
+  it('uses var() colors only — no hex literal in markup', () => {
+    render(<PriorityBars variant="med" />);
+    const el = screen.getByTestId('priority-bars-med');
+    expect(el.outerHTML).not.toMatch(/#[0-9a-f]{3,8}/i);
+  });
+});

--- a/frontend/src/shared/ui/priority-bars/index.ts
+++ b/frontend/src/shared/ui/priority-bars/index.ts
@@ -1,0 +1,2 @@
+export { PriorityBars } from './PriorityBars';
+export type { PriorityBarsProps, PriorityBarsVariant } from './PriorityBars';

--- a/frontend/src/shared/ui/status-glyph/StatusGlyph.tsx
+++ b/frontend/src/shared/ui/status-glyph/StatusGlyph.tsx
@@ -14,74 +14,110 @@ export interface StatusGlyphProps {
 }
 
 const SIZE = 14;
+const CENTER = SIZE / 2;
+const STROKE = 1.5;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
-const BASE: CSSProperties = {
+const ROOT: CSSProperties = {
   width: SIZE,
   height: SIZE,
-  borderRadius: '50%',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
   flex: '0 0 auto',
-  boxSizing: 'border-box',
+  borderRadius: '50%',
 };
 
-function variantStyle(variant: StatusGlyphVariant): CSSProperties {
+interface RingArcProps {
+  color: string;
+  fraction: number;
+}
+
+function RingArc({ color, fraction }: RingArcProps) {
+  const dash = CIRCUMFERENCE * fraction;
+  return (
+    <>
+      <circle
+        cx={CENTER}
+        cy={CENTER}
+        r={RADIUS}
+        fill="none"
+        stroke={color}
+        strokeWidth={STROKE}
+        opacity={0.35}
+      />
+      <circle
+        cx={CENTER}
+        cy={CENTER}
+        r={RADIUS}
+        fill="none"
+        stroke={color}
+        strokeWidth={STROKE}
+        strokeDasharray={`${dash} ${CIRCUMFERENCE - dash}`}
+        strokeLinecap="butt"
+        transform={`rotate(-90 ${CENTER} ${CENTER})`}
+      />
+    </>
+  );
+}
+
+function variantContent(variant: StatusGlyphVariant) {
   switch (variant) {
     case 'backlog':
-      return { ...BASE, border: '1.5px dashed var(--text-quaternary)' };
+      return (
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke="var(--text-quaternary)"
+          strokeWidth={STROKE}
+          strokeDasharray="2 2"
+        />
+      );
     case 'todo':
-      return { ...BASE, border: '1.5px solid var(--text-tertiary)' };
+      return (
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke="var(--text-tertiary)"
+          strokeWidth={STROKE}
+        />
+      );
     case 'progress':
-      return {
-        ...BASE,
-        border: '1.5px solid var(--chart-amber)',
-        background:
-          'conic-gradient(var(--chart-amber) 0 60%, transparent 60% 100%)',
-      };
+      return <RingArc color="var(--chart-amber)" fraction={0.6} />;
     case 'review':
-      return {
-        ...BASE,
-        border: '1.5px solid var(--chart-blue)',
-        background:
-          'conic-gradient(var(--chart-blue) 0 80%, transparent 80% 100%)',
-      };
+      return <RingArc color="var(--chart-blue)" fraction={0.8} />;
     case 'done':
-      return { ...BASE, background: 'var(--chart-emerald)' };
+      return (
+        <>
+          <circle cx={CENTER} cy={CENTER} r={CENTER} fill="var(--chart-emerald)" />
+          <polyline
+            points="3.5,7.5 6,10 10.5,4.5"
+            fill="none"
+            stroke="var(--text-primary)"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </>
+      );
     case 'canceled':
-      return { ...BASE, background: 'var(--text-quaternary)' };
+      return (
+        <>
+          <circle cx={CENTER} cy={CENTER} r={CENTER} fill="var(--text-quaternary)" />
+          <path
+            d="M4.5 4.5 L9.5 9.5 M9.5 4.5 L4.5 9.5"
+            stroke="var(--text-primary)"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+          />
+        </>
+      );
   }
-}
-
-function CheckMark() {
-  return (
-    <span
-      aria-hidden="true"
-      style={{
-        width: 6,
-        height: 3,
-        borderLeft: '1.5px solid var(--text-primary)',
-        borderBottom: '1.5px solid var(--text-primary)',
-        transform: 'rotate(-45deg) translate(0px, -1px)',
-      }}
-    />
-  );
-}
-
-function CancelMark() {
-  return (
-    <span
-      aria-hidden="true"
-      style={{
-        color: 'var(--text-primary)',
-        fontSize: 10,
-        lineHeight: 1,
-        fontWeight: 600,
-      }}
-    >
-      ×
-    </span>
-  );
 }
 
 export function StatusGlyph({ variant, ariaLabel }: StatusGlyphProps) {
@@ -91,10 +127,17 @@ export function StatusGlyph({ variant, ariaLabel }: StatusGlyphProps) {
       aria-label={ariaLabel}
       data-testid={`status-glyph-${variant}`}
       data-variant={variant}
-      style={variantStyle(variant)}
+      style={ROOT}
     >
-      {variant === 'done' && <CheckMark />}
-      {variant === 'canceled' && <CancelMark />}
+      <svg
+        width={SIZE}
+        height={SIZE}
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        aria-hidden="true"
+        focusable="false"
+      >
+        {variantContent(variant)}
+      </svg>
     </span>
   );
 }

--- a/frontend/src/shared/ui/status-glyph/__tests__/StatusGlyph.test.tsx
+++ b/frontend/src/shared/ui/status-glyph/__tests__/StatusGlyph.test.tsx
@@ -26,10 +26,16 @@ describe('StatusGlyph — uidesign.md §16.3', () => {
     expect(el.querySelector('[aria-hidden="true"]')).not.toBeNull();
   });
 
-  it('canceled variant renders × glyph', () => {
+  it('canceled variant renders an × stroke path', () => {
     render(<StatusGlyph variant="canceled" />);
     const el = screen.getByTestId('status-glyph-canceled');
-    expect(el.textContent).toContain('×');
+    expect(el.querySelector('svg path')).not.toBeNull();
+  });
+
+  it('done variant renders a check polyline', () => {
+    render(<StatusGlyph variant="done" />);
+    const el = screen.getByTestId('status-glyph-done');
+    expect(el.querySelector('svg polyline')).not.toBeNull();
   });
 
   it('exposes aria-label when provided', () => {

--- a/frontend/src/widgets/voc-workspace/VocListPage.tsx
+++ b/frontend/src/widgets/voc-workspace/VocListPage.tsx
@@ -162,7 +162,6 @@ export function VocListPage() {
                     }}
                     selectedId={ctrl.drawer.vocId}
                     assigneeMap={ctrl.masters.assigneeMap}
-                    vocTypeMap={vocTypeMap}
                     groupByStatus
                     collapsedStatuses={collapsedStatuses}
                     onToggleStatus={toggleStatus}

--- a/frontend/src/widgets/voc-workspace/__tests__/VocListPage.integration.test.tsx
+++ b/frontend/src/widgets/voc-workspace/__tests__/VocListPage.integration.test.tsx
@@ -223,17 +223,15 @@ describe('VocListPage — Wave D D5 integration', () => {
     expect(header).toHaveAttribute('data-collapsed', 'true');
   });
 
-  it('vocTypeMap threads VocListPage → VocTable → VocRow → VocTypeBadge (renders type icon for each row)', async () => {
+  it('Flowline C-extension: VocRow title cell does not prepend a type badge (type info moved to detail/drawer)', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByTestId('voc-table')).toBeInTheDocument());
 
-    // All fixture rows reference TYPE_PRIMARY ("기능 요청", slug=feature) — see master.fixtures.ts
     const renderedRows = screen.getAllByTestId('voc-row');
     expect(renderedRows.length).toBeGreaterThan(0);
 
-    // Each rendered row's title cell should contain a VocTypeBadge with aria-label "유형 기능 요청"
-    // (proves vocTypeMap was threaded VocListPage → VocTable → VocRow → VocTypeBadge).
-    const badges = await screen.findAllByLabelText('유형 기능 요청');
-    expect(badges.length).toBe(renderedRows.length);
+    // The VocTypeBadge in the title cell would expose aria-label "유형 ...".
+    // After C-extension, list rows must not render any such badge.
+    expect(screen.queryAllByLabelText(/^유형 /)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

ADR-0008 implementation outline 의 step 3 (priority-bars + list-group-header) 와 step 4 (S6 dot-pill) 묶어 도입 + impeccable:critique 결과 반영. Wave C 가 S1/S2 만으로는 sibling recognition gestalt 미달성 — 부분 변환된 인접 요소들이 Flowline grammar 를 압도하는 안티패턴이었음.

**핵심 메트릭**:
- impeccable:critique 1차: Nielsen 26/40, sibling 6.5/10.
- 4개 fix-skill 순차 적용 (quieter / distill / colorize / polish) 후 재critique: **Nielsen 35/40 'Strong' band, sibling 8.3/10**.

## Changes

### 신규 primitive (5종 중 마지막 3)
- `shared/ui/priority-bars` (S3) — 14×14 ascending 4/7/10 bars. urgent=red / high=orange / med·low=gradient gray.
- `shared/ui/list-group-header` (S5) — collapsible band primitive. VocStatusGroupHeader 가 wrapper 로 축소.
- `shared/ui/badge/OutlineChip` `dot-pill` variant (S6) — 7px dot + rounded pill. dotColor prop.

### Critique-driven fixes
- **P0 — /quieter VocAssignee**: 22px saturated bucket-color → 18px outline neutral. hashAssigneeColor + COLOR_VAR + colorClass prop 제거. focal hierarchy 복원.
- **P1 — /distill VocTypeBadge**: VocRow title cell 의 type-icon prepend 제거. vocTypeMap prop drilling 정리. detail/create surface 무영향. VocTypeBadge.iconOnly prop 제거.
- **P1 — /colorize VocTagPill**: djb2 hash → 4 cool-tone palette (chart-blue/sky/teal/indigo). status warm 과 충돌 회피.
- **P2 — /polish chevron + 색**: VocRow expand chevron 14×14 (ListGroupHeader 일관). StatusGlyph conic-gradient → SVG stroked-arc + polyline check (translate magic-number 제거). priority-bars high orange 유지 (status/priority column 분리로 시각 충돌 적음 — Linear convention 우선).

### Spec
- §16.1 — S3·S5·S6 = `implemented (Wave C-ext)`.
- §16.4 — high 행 + justification note (warm 색 column 분리 근거).

토큰 / globals.css 변경 0. typecheck / 691 vitest / lint 통과.

## Test plan
- [ ] FE typecheck + 691 tests + lint clean (자동 pass)
- [ ] `/voc` 시각 확인 — Linear 사용자가 cold open 시 sibling 인식
- [ ] VocRow title cell 에서 type-icon 사라지고 IssueId + title + tag pill 만
- [ ] VocAssignee 18px outline 으로 차분 — status-glyph 가 행의 유일한 saturated 요소
- [ ] tag dot 4색 (cool 톤만) 다양성 확인
- [ ] priority urgent=red / high=orange / med·low=gray gradient
- [ ] StatusGlyph progress/review = SVG stroked arc, done = filled emerald + clean polyline check

🤖 Generated with [Claude Code](https://claude.com/claude-code)