### PR TITLE
docs(progress): Flowline Wave C-extension 머지 반영 (sibling 8.3/10)

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -1,6 +1,6 @@
 # vocpage — Session Progress
 
-## 다음 세션 시작점 (2026-05-10 Flowline Wave C 머지 완료)
+## 다음 세션 시작점 (2026-05-10 Flowline Wave C-extension 머지 완료, sibling 8.3/10)
 
 → **머지 완료 (2026-05-10)**:
    - **PR #310** ADR 0006 (Accepted) + 0007 (Proposed) — `dashboard_settings.default_date_range='custom'` 컬럼 신설 + timezone OQ 별 ADR 분기.
@@ -9,6 +9,7 @@
    - **PR #314** 구조/네이밍 정리 1차 (deepening candidates 2 + 4) — `useVocFilter`/`useVocFilters` → `useVocFilterContext`/`useVocFilterUrlState`, `features/admin/tag-master/` 평면 → `api/+ui/`, `ActionButton` → `TagMasterActionButton`, `@contracts/admin/tag` alias 통일.
    - **PR #316** ADR-0008 + `uidesign.md §16 Flowline Alignment Primitives` — Flowline 정합화 결정 + 시그널 7종 명세.
    - **PR #317** Flowline Wave C — `shared/ui/issue-id` + `shared/ui/status-glyph` 신설. `VocStatusBadge` 가 두 모드(아이콘/칩+라벨) 모두 글리프 외부 wrap → VocRow / 드로어 / 디테일 / 그룹헤더 자동 적용. 671 vitest pass. §16.1 S1·S2 = `implemented`.
+   - **PR #319** Flowline Wave C-extension — S3 priority-bars + S5 list-group-header + S6 OutlineChip dot-pill 일괄 도입 + impeccable critique 4 fix-skill 순차 적용 (quieter avatar / distill type-icon / colorize tag-dot / polish chevron + arc). 재critique sibling **6.5 → 8.3/10**, Nielsen **26 → 35/40 'Strong'**. 691 vitest pass. §16.1 S3·S5·S6 = `implemented (Wave C-ext)`.
 
 → **구조/네이밍 정리 진행 상태 (2026-05-10 audit, codex 적대적 리뷰)**:
    - **완료**: Cand 2 (useVocFilter rename) · Cand 4 (tag-master split) — PR #314.
@@ -16,7 +17,7 @@
    - **DEFER**: Cand 3 `features/dashboard/widgets/` 와 top-level `widgets/` shadow — 12 컴포넌트 import churn 대비 leverage 약함 / Cand 5 backend repo·service suffix 혼재 (`*.repo.ts` vs `*.ts`) — 다음 BE 작업 시 같이 처리.
    - **REJECT**: Cand 6 backend `controllers/` + `validators/` orphan 의혹 — `backend/src/CLAUDE.md`가 5-layer 명시, ADR-0003 이 validators 보존 결정. 코드 drift 아니라 의도적 layer.
 
-→ **Flowline 정합화 상태**: ADR-0008 + Wave C 머지. 차기 — Wave D 후보 (S3 priority-bars / S5 list-group-header / S6 OutlineChip dot-pill variant) 는 사용처 발생 시 진입. S7 활동 피드 + sparkline deferred.
+→ **Flowline 정합화 상태**: ADR-0008 + Wave C + Wave C-extension 머지. 시그널 7종 중 S1·S2·S3·S5·S6 = implemented (sibling 8.3/10 sign-off via impeccable:critique). S4 = verified. S7 (활동 피드 시각 점검) + sparkline deferred — 사용처 발생 시 별 wave. 잔여 sub-pixel polish: filled-vs-ring radius 0.75px 차, 16px chevron slot 비표시 행, UserX 15px 비대칭.
 
 → **다음 세션 작업 후보**:
    - **구조/네이밍 정리 2차** — Cand 1 voc 슬라이스부터 (`entities/voc/api/vocApi.ts` → `voc.api.ts` + `vocQueryKeys.ts` → `voc.query-keys.ts`).

--- a/docs/specs/plans/next-session-tasks.md
+++ b/docs/specs/plans/next-session-tasks.md
@@ -14,7 +14,7 @@
 | **마이그 023 운영 적용** | PR #312 머지 (2026-05-10) | rogue row 진단 SQL 선행. 적용 후 Dashboard Dialog 'custom' round-trip 통합 검증. |
 | **Admin 미구현 페이지** | [`admin-pages-backlog.md`](./admin-pages-backlog.md) | 시스템/메뉴 / 유형 / 결과 검토 / 태그 규칙. 권장 순서: 태그 규칙(태그 마스터 통합) → 시스템/메뉴 → 유형 → 결과 검토(NextGen). |
 | **ADR 0007 timezone 잠금** | `docs/adr/0007-custom-date-range-timezone.md` (Proposed) | 다중 timezone 운영 진입 전 별 세션. 잠금 전 다중 TZ 진입 금지. |
-| **Flowline Wave D 후보** | `uidesign.md §16` · ADR-0008 | Wave C (S1·S2) 머지 (PR #317). 차기 — S3 priority-bars / S5 list-group-header / S6 OutlineChip dot-pill 은 사용처 발생 시 진입. S7 / sparkline deferred. |
+| **Flowline 정합화 — 잔여** | `uidesign.md §16` · ADR-0008 | Wave C + C-ext 머지 (PR #317 / #319) — S1·S2·S3·S5·S6 implemented (sibling 8.3/10). 잔여: S7 활동 피드 시각 점검 + sparkline (사용처 발생 시 별 wave) + sub-pixel polish (filled-vs-ring radius / 16px chevron slot / UserX 15px 비대칭). |
 | **운영/배포 phase** | 본 문서 §운영/배포 | session store · OIDC · Production build · 실 MSSQL · E2E. |
 
 ### Hard-blocks


### PR DESCRIPTION
## Summary

PR #319 머지 후 진행 문서 동기화.

- `claude-progress.txt`: PR #319 라인업 추가 (sibling 6.5→8.3, Nielsen 26→35), Flowline 정합화 상태 헤더 갱신 (S1·S2·S3·S5·S6 implemented).
- `next-session-tasks.md`: 'Wave D 후보' 행 → '잔여' 행 (S7 / sparkline / sub-pixel polish 만).

## Test plan
- [ ] 헤더 + 머지 라인업 정합 확인
- [ ] 잔여 항목 표기 적정성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)